### PR TITLE
[Feat] 본사 알림 페이지 구현 및 네비게이션 연결

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -132,7 +132,7 @@ import {
   Calculator, Box, ClipboardList,
   PackageSearch, Truck,
   Warehouse, Receipt, Tablet,
-  ChevronDown, User, LogOut, UserPlus, BarChart3,
+  ChevronDown, User, LogOut, UserPlus, BarChart3, Bell,
 } from 'lucide-vue-next'
 import { useAuthStore } from '@/stores/auth'
 import NotificationBell from '@/components/NotificationBell.vue'
@@ -170,6 +170,7 @@ const adminMenus = [
   { path: '/settlement', name: '정산 관리', icon: Calculator },
   { path: '/admin-account', name: '계정 관리', icon: UserPlus },
   { path: '/statistics', name: '통계', icon: BarChart3 },
+  { path: '/notification', name: '알림', icon: Bell },
 ]
 
 const storeMenus = [
@@ -179,6 +180,7 @@ const storeMenus = [
   { path: '/store-inventory', name: '매장 재고',  icon: Warehouse },
   { path: '/store-delivery',  name: '배송 현황',  icon: Truck },
   { path: '/store-settlement',name: '정산 내역',  icon: Receipt },
+  { path: '/store-notification', name: '알림', icon: Bell },
 ]
 
 const currentMenus = computed(() => {

--- a/frontend/src/components/NotificationBell.vue
+++ b/frontend/src/components/NotificationBell.vue
@@ -48,7 +48,7 @@
           </div>
 
           <div v-for="n in items" :key="n.id"
-            @click="notifStore.markRead(n.id)"
+            @click="handleNotifClick(n)"
             class="flex gap-3 px-4 py-3.5 cursor-pointer transition-colors"
             :class="n.read ? 'bg-white hover:bg-gray-50/50' : unreadRowClass">
 
@@ -95,10 +95,12 @@ import { ref, computed } from 'vue'
 import { Bell } from 'lucide-vue-next'
 import { useNotificationStore } from '@/stores/notification'
 import { useAuthStore } from '@/stores/auth'
+import { useRouter } from 'vue-router'
 
 const open = ref(false)
 const notifStore = useNotificationStore()
 const auth = useAuthStore()
+const router = useRouter()
 
 const role = computed(() => {
   if (auth.isAdmin) return 'ADMIN'
@@ -115,6 +117,13 @@ const unreadRowClass = computed(() => isStoreOwnerRole.value ? 'bg-blue-50/30 ho
 
 function markAll() {
   if (role.value) notifStore.markAllRead(role.value)
+}
+
+function handleNotifClick(n) {
+  notifStore.markRead(n.id)
+  open.value = false
+  const path = auth.isAdmin ? '/notification' : '/store-notification'
+  router.push(path)
 }
 
 function typeColor(type) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -134,12 +134,6 @@ const router = createRouter({
       component: () => import('@/views/hq/HqNotificationView.vue'),
       meta: { role: 'ADMIN' },
     },
-    {
-      path: '/store-notification',
-      name: 'storeNotification',
-      component: () => import('@/views/store/StoreNotificationView.vue'),
-      meta: { role: 'STORE_OWNER' },
-    },
 
     // ── COMMON ─────────────────────────────────────────
     {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -128,6 +128,19 @@ const router = createRouter({
       meta: { role: 'STORE_OWNER' },
     },
 
+    {
+      path: '/notification',
+      name: 'notification',
+      component: () => import('@/views/hq/HqNotificationView.vue'),
+      meta: { role: 'ADMIN' },
+    },
+    {
+      path: '/store-notification',
+      name: 'storeNotification',
+      component: () => import('@/views/store/StoreNotificationView.vue'),
+      meta: { role: 'STORE_OWNER' },
+    },
+
     // ── COMMON ─────────────────────────────────────────
     {
       path: '/profile',

--- a/frontend/src/views/hq/HqNotificationView.vue
+++ b/frontend/src/views/hq/HqNotificationView.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="p-6 max-w-3xl mx-auto">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-5">
+      <h1 class="text-xl font-bold text-gray-900">알림</h1>
+      <button
+        v-if="unreadCount > 0"
+        @click="store.markAllRead('ADMIN')"
+        class="text-sm text-[#F37321] hover:underline font-medium"
+      >
+        전체 읽음 처리
+      </button>
+    </div>
+
+    <!-- Filter tabs -->
+    <div class="flex gap-1 mb-4 border-b border-gray-200">
+      <button
+        v-for="tab in tabs"
+        :key="tab.value"
+        @click="activeTab = tab.value"
+        class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px"
+        :class="activeTab === tab.value
+          ? 'border-[#F37321] text-[#F37321]'
+          : 'border-transparent text-gray-500 hover:text-gray-700'"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <!-- List -->
+    <div v-if="filtered.length > 0" class="flex flex-col gap-2">
+      <div
+        v-for="n in filtered"
+        :key="n.id"
+        @click="store.markRead(n.id)"
+        class="flex gap-3 p-4 rounded-lg border cursor-pointer transition-colors"
+        :class="n.read
+          ? 'bg-white border-gray-100 hover:bg-gray-50'
+          : 'bg-orange-50/40 border-orange-100 hover:bg-orange-50/70'"
+      >
+        <!-- Type badge -->
+        <div class="shrink-0 pt-0.5">
+          <span
+            class="inline-block text-[11px] font-semibold px-2 py-0.5 rounded-full border"
+            :class="[typeConfig(n.type).color, typeConfig(n.type).bg, typeConfig(n.type).border]"
+          >
+            {{ typeConfig(n.type).label }}
+          </span>
+        </div>
+
+        <!-- Content -->
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 mb-0.5">
+            <span class="text-sm font-semibold text-gray-900">{{ n.title }}</span>
+            <span v-if="!n.read" class="w-1.5 h-1.5 rounded-full bg-[#F37321] shrink-0"></span>
+          </div>
+          <p class="text-sm text-gray-600 leading-snug">{{ n.body }}</p>
+          <p class="text-xs text-gray-400 mt-1">{{ store.relativeTime(n.time) }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Empty -->
+    <div v-else class="flex flex-col items-center justify-center py-20 text-gray-400">
+      <Bell class="w-10 h-10 mb-3 opacity-30" />
+      <p class="text-sm">알림이 없습니다.</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { Bell } from 'lucide-vue-next'
+import { useNotificationStore } from '@/stores/notification'
+
+const store = useNotificationStore()
+
+const tabs = [
+  { label: '전체',      value: 'all' },
+  { label: '발주',      value: 'order' },
+  { label: '재고',      value: 'stock' },
+  { label: '비정상 감지', value: 'abnormal' },
+  { label: '정산',      value: 'settlement' },
+]
+
+const activeTab = ref('all')
+
+const adminNotifications = computed(() => store.forRole('ADMIN'))
+const unreadCount = computed(() => store.unreadCount('ADMIN'))
+
+const tabTypeMap = {
+  order:      ['order_new', 'order_approved', 'order_rejected', 'auto_order'],
+  stock:      ['low_stock'],
+  abnormal:   ['abnormal_order'],
+  settlement: ['settlement'],
+}
+
+const filtered = computed(() => {
+  if (activeTab.value === 'all') return adminNotifications.value
+  const types = tabTypeMap[activeTab.value] ?? []
+  return adminNotifications.value.filter(n => types.includes(n.type))
+})
+
+function typeConfig(type) {
+  return store.typeConfig[type] ?? { label: type, color: 'text-gray-600', bg: 'bg-gray-50', border: 'border-gray-200' }
+}
+</script>

--- a/frontend/src/views/hq/HqNotificationView.vue
+++ b/frontend/src/views/hq/HqNotificationView.vue
@@ -89,7 +89,7 @@ const adminNotifications = computed(() => store.forRole('ADMIN'))
 const unreadCount = computed(() => store.unreadCount('ADMIN'))
 
 const tabTypeMap = {
-  order:      ['order_new', 'order_approved', 'order_rejected', 'auto_order'],
+  order:      ['order_new', 'auto_order'],
   stock:      ['low_stock'],
   abnormal:   ['abnormal_order'],
   settlement: ['settlement'],

--- a/frontend/src/views/hq/HqNotificationView.vue
+++ b/frontend/src/views/hq/HqNotificationView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-6 max-w-3xl mx-auto">
+  <div class="p-6">
     <!-- Header -->
     <div class="flex items-center justify-between mb-5">
       <h1 class="text-xl font-bold text-gray-900">알림</h1>


### PR DESCRIPTION
## Summary
- 본사 사이드바에 알림 메뉴 항목 추가
- 본사 알림 페이지 구현 (HqNotificationView) — 필터 탭(전체/발주/재고/비정상감지/정산), 읽음 처리, 전체 읽음 버튼
- 상단 알림 벨 드롭다운 항목 클릭 시 알림 페이지로 이동 연결

## Test plan
- [ ] 본사 로그인 후 사이드바에 알림 메뉴가 보이는지 확인
- [ ] 알림 페이지 진입 후 필터 탭 전환 정상 동작 확인
- [ ] 알림 항목 클릭 시 읽음 처리되는지 확인
- [ ] 전체 읽음 버튼 동작 확인
- [ ] 상단 벨 아이콘 드롭다운에서 항목 클릭 시 알림 페이지로 이동하는지 확인

## Issue
Closes #236 
