### PR TITLE
[Feat] #240 - 통계 페이지 기간 별 상위, 하위 항목 표시

### DIFF
--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -53,6 +53,201 @@
       </div>
     </div>
 
+    <!-- 판매/매출 중심 분석 -->
+    <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-6 space-y-5">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 class="text-xl font-bold text-gray-900">판매/매출 핵심 분석</h2>
+          <p class="text-sm text-gray-500 mt-1">기간을 직접 선택하거나 월/년 기준으로 비교할 수 있습니다.</p>
+        </div>
+        <div class="flex items-center gap-2 rounded-lg border border-gray-200 p-1">
+          <button
+            type="button"
+            class="text-xs px-3 py-1.5 rounded-md font-semibold transition-colors"
+            :class="analysisMode === 'month' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-50'"
+            @click="analysisMode = 'month'"
+          >
+            월 비교
+          </button>
+          <button
+            type="button"
+            class="text-xs px-3 py-1.5 rounded-md font-semibold transition-colors"
+            :class="analysisMode === 'year' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-50'"
+            @click="analysisMode = 'year'"
+          >
+            년 비교
+          </button>
+          <button
+            type="button"
+            class="text-xs px-3 py-1.5 rounded-md font-semibold transition-colors"
+            :class="analysisMode === 'custom' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-50'"
+            @click="analysisMode = 'custom'"
+          >
+            직접 선택
+          </button>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2">
+        <template v-if="analysisMode !== 'custom'">
+          <select
+            v-model="selectedYear"
+            class="text-sm px-3 py-2 rounded-lg border border-gray-200 bg-white focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none"
+          >
+            <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}년</option>
+          </select>
+          <select
+            v-if="analysisMode === 'month'"
+            v-model="selectedMonth"
+            class="text-sm px-3 py-2 rounded-lg border border-gray-200 bg-white focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none"
+          >
+            <option v-for="m in monthOptions" :key="m" :value="m">{{ m }}월</option>
+          </select>
+        </template>
+        <template v-else>
+          <input
+            v-model="customStartDate"
+            type="date"
+            class="text-sm px-3 py-2 rounded-lg border border-gray-200 bg-white focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none"
+          />
+          <span class="text-sm text-gray-400">~</span>
+          <input
+            v-model="customEndDate"
+            type="date"
+            class="text-sm px-3 py-2 rounded-lg border border-gray-200 bg-white focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none"
+          />
+        </template>
+      </div>
+
+      <div class="text-xs text-gray-500">
+        기준 기간: <span class="font-semibold text-gray-700">{{ analysisLabel }}</span> /
+        비교 기간: <span class="font-semibold text-gray-700">{{ compareLabel }}</span>
+      </div>
+
+      <div class="rounded-2xl border border-gray-200 p-5 space-y-4">
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex items-center gap-2 rounded-lg border border-gray-200 p-1">
+            <button
+              type="button"
+              class="text-xs px-3 py-1.5 rounded-md font-semibold transition-colors"
+              :class="analysisTab === 'sales' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-50'"
+              @click="analysisTab = 'sales'"
+            >
+              판매 분석
+            </button>
+            <button
+              type="button"
+              class="text-xs px-3 py-1.5 rounded-md font-semibold transition-colors"
+              :class="analysisTab === 'revenue' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-50'"
+              @click="analysisTab = 'revenue'"
+            >
+              매출 분석
+            </button>
+          </div>
+          <p class="text-xs text-gray-400">{{ analysisTab === 'sales' ? '메뉴 판매수량 기준' : '매장 매출금액 기준' }}</p>
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
+          <div class="rounded-xl border border-gray-200 p-4">
+            <p class="text-xs font-semibold text-gray-400 uppercase tracking-[0.12em]">분석 대상 수</p>
+            <p class="text-2xl font-extrabold text-gray-900 mt-2">{{ analysisSummary.totalCount }}</p>
+            <p class="text-xs text-gray-500 mt-2">총 집계 항목</p>
+          </div>
+          <div class="rounded-xl border border-gray-200 p-4">
+            <p class="text-xs font-semibold text-gray-400 uppercase tracking-[0.12em]">상위 1위 값</p>
+            <p class="text-xl font-extrabold text-gray-900 mt-2 break-keep">{{ analysisSummary.topName }}</p>
+            <p class="text-xs text-gray-500 mt-2">{{ analysisSummary.topValue }}</p>
+          </div>
+          <div class="rounded-xl border border-gray-200 p-4">
+            <p class="text-xs font-semibold text-gray-400 uppercase tracking-[0.12em]">중앙 구간 값</p>
+            <p class="text-xl font-extrabold text-gray-900 mt-2">{{ analysisSummary.medianValue }}</p>
+            <p class="text-xs text-gray-500 mt-2">중간 순위 기준</p>
+          </div>
+          <div class="rounded-xl border border-gray-200 p-4">
+            <p class="text-xs font-semibold text-gray-400 uppercase tracking-[0.12em]">상·하위 격차</p>
+            <p class="text-xl font-extrabold text-gray-900 mt-2">{{ analysisSummary.gapValue }}</p>
+            <p class="text-xs text-gray-500 mt-2">상위 1위 - 하위 1위</p>
+          </div>
+        </div>
+
+        <div class="flex items-center justify-end">
+          <button
+            type="button"
+            class="text-[11px] px-2.5 py-1 rounded border border-gray-200 text-gray-600 font-semibold hover:bg-gray-50"
+            @click="openFullListModal"
+          >
+            전체 순위 보기
+          </button>
+        </div>
+
+        <div class="grid grid-cols-1 xl:grid-cols-2 gap-3">
+          <div class="rounded-xl border border-gray-200 p-4">
+            <p class="text-xs font-semibold text-gray-400 uppercase tracking-[0.12em]">상위 5항목</p>
+            <div class="mt-3 space-y-2">
+              <div
+                v-for="(item, idx) in analysisTab === 'sales' ? salesTop5 : revenueTop5"
+                :key="`${analysisTab}-top-${item.name}`"
+                class="flex items-center justify-between rounded-lg border border-gray-100 px-3 py-2"
+              >
+                <p class="text-sm text-gray-900 font-medium">{{ idx + 1 }}. {{ item.name }}</p>
+                <p class="text-xs text-gray-500">{{ item.display }}</p>
+              </div>
+            </div>
+          </div>
+          <div class="rounded-xl border border-gray-200 p-4">
+            <p class="text-xs font-semibold text-gray-400 uppercase tracking-[0.12em]">하위 5항목</p>
+            <div class="mt-3 space-y-2">
+              <div
+                v-for="(item, idx) in analysisTab === 'sales' ? salesBottom5 : revenueBottom5"
+                :key="`${analysisTab}-bottom-${item.name}`"
+                class="flex items-center justify-between rounded-lg border border-rose-200 bg-rose-50/40 px-3 py-2"
+              >
+                <p class="text-sm text-gray-900 font-medium">
+                  <span class="inline-flex items-center justify-center w-5 h-5 mr-1 rounded-full bg-rose-100 text-rose-600 text-[10px] font-bold">▼</span>
+                  {{ (analysisTab === 'sales' ? salesRanking.length : revenueRanking.length) - idx }}. {{ item.name }}
+                </p>
+                <p class="text-xs text-rose-600 font-semibold">{{ item.display }}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 판매/매출 전체 리스트 모달 -->
+    <div v-if="isFullListModalOpen" class="fixed inset-0 z-50 flex items-center justify-center">
+      <div class="absolute inset-0 bg-black/40" @click="closeFullListModal"></div>
+      <div class="relative w-full max-w-3xl bg-white rounded-xl border border-gray-200 shadow-xl">
+        <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <div>
+            <h3 class="font-bold text-gray-900">
+              {{ analysisTab === 'sales' ? '판매 분석' : '매출 분석' }} · 전체 순위
+            </h3>
+            <p class="text-xs text-gray-400 mt-1">{{ analysisLabel }}</p>
+          </div>
+          <button @click="closeFullListModal" class="text-gray-400 hover:text-gray-600">✕</button>
+        </div>
+
+        <div class="p-5 max-h-[65vh] overflow-auto">
+          <div class="space-y-2">
+            <div
+              v-for="(item, idx) in fullListItems"
+              :key="`modal-${item.name}-${idx}`"
+              class="flex items-center justify-between rounded-lg border px-3 py-2"
+              :class="idx >= fullListItems.length - 5 ? 'border-rose-200 bg-rose-50/40' : 'border-gray-100'"
+            >
+              <p class="text-sm text-gray-900 font-medium">
+                {{ idx + 1 }}. {{ item.name }}
+              </p>
+              <p class="text-xs font-semibold" :class="idx >= fullListItems.length - 5 ? 'text-rose-600' : 'text-gray-600'">
+                {{ item.display }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="grid grid-cols-1 xl:grid-cols-3 gap-4">
       <!-- 발주 트렌드 -->
       <div class="xl:col-span-2 bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col min-h-[320px]">
@@ -129,6 +324,17 @@ const productsByCategory = {
   '장비·세척': ['튀김기름 18L', '그릴 클리너', '필터지', '살균세제 4L'],
 }
 
+const stores = [
+  'BBQ 강남역점',
+  'BBQ 홍대입구점',
+  'BBQ 여의도역점',
+  'BBQ 판교테크노밸리점',
+  'BBQ 잠실새내점',
+  'BBQ 부산서면점',
+  'BBQ 대전둔산점',
+  'BBQ 수원광교점',
+]
+
 const periodOptions = [
   { value: 'day', label: '일간' },
   { value: 'week', label: '주간' },
@@ -148,6 +354,8 @@ const categoryWeights = [
   ['장비·세척', 8],
 ]
 const weightTotal = categoryWeights.reduce((s, [, w]) => s + w, 0)
+const storeWeights = [17, 16, 14, 13, 12, 11, 9, 8]
+const storeWeightTotal = storeWeights.reduce((s, w) => s + w, 0)
 
 function pickCategory(rand) {
   let r = rand() * weightTotal
@@ -156,6 +364,15 @@ function pickCategory(rand) {
     r -= w
   }
   return categoryWeights[categoryWeights.length - 1][0]
+}
+
+function pickStore(rand) {
+  let r = rand() * storeWeightTotal
+  for (let i = 0; i < stores.length; i++) {
+    if (r < storeWeights[i]) return stores[i]
+    r -= storeWeights[i]
+  }
+  return stores[stores.length - 1]
 }
 
 function qtyForCategory(cat, rand) {
@@ -198,6 +415,7 @@ function buildRawOrders() {
       const cat = pickCategory(rand)
       const names = productsByCategory[cat]
       const product = names[Math.floor(rand() * names.length)]
+      const store = pickStore(rand)
       let qty = qtyForCategory(cat, rand)
       if (isPeak && (cat === '신선육' || cat === '튀김·배합')) {
         qty += Math.floor(rand() * 18)
@@ -212,7 +430,7 @@ function buildRawOrders() {
       if (isHolidayLike && rand() < 0.15) abnormalProb += 0.04
       const abnormal = rand() < abnormalProb ? 1 : 0
 
-      list.push({ date: dateStr, category: cat, product, amount, qty, abnormal })
+      list.push({ date: dateStr, category: cat, product, store, amount, qty, abnormal })
     }
   }
   return list
@@ -368,6 +586,251 @@ const summaryCards = computed(() => {
       sub: '금액 기준 상위 1개 품목',
     },
   ]
+})
+
+function getYear(dateStr) {
+  return Number(dateStr.slice(0, 4))
+}
+
+function getMonth(dateStr) {
+  return Number(dateStr.slice(5, 7))
+}
+
+const yearOptions = computed(() => {
+  const years = [...new Set(rawOrders.map((o) => getYear(o.date)))].sort((a, b) => b - a)
+  return years
+})
+
+const monthOptions = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+const analysisMode = ref('month')
+const analysisTab = ref('sales')
+const isFullListModalOpen = ref(false)
+const selectedYear = ref(getYear(anchorDate))
+const selectedMonth = ref(getMonth(anchorDate))
+const customStartDate = ref('2026-03-01')
+const customEndDate = ref('2026-04-21')
+
+function getDaysInMonth(year, month) {
+  return new Date(year, month, 0).getDate()
+}
+
+function ymToDateStr(year, month, day = 1) {
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+
+function filterByDateRange(orders, startStr, endStr) {
+  return orders.filter((o) => o.date >= startStr && o.date <= endStr)
+}
+
+const analysisRange = computed(() => {
+  if (analysisMode.value === 'year') {
+    const y = selectedYear.value
+    return {
+      start: ymToDateStr(y, 1, 1),
+      end: ymToDateStr(y, 12, 31),
+      label: `${y}년`,
+    }
+  }
+
+  if (analysisMode.value === 'custom') {
+    const start = customStartDate.value || customEndDate.value
+    const end = customEndDate.value || customStartDate.value
+    const safeStart = start <= end ? start : end
+    const safeEnd = start <= end ? end : start
+    return {
+      start: safeStart,
+      end: safeEnd,
+      label: `${safeStart} ~ ${safeEnd}`,
+    }
+  }
+
+  const y = selectedYear.value
+  const m = Number(selectedMonth.value)
+  return {
+    start: ymToDateStr(y, m, 1),
+    end: ymToDateStr(y, m, getDaysInMonth(y, m)),
+    label: `${y}년 ${m}월`,
+  }
+})
+
+const compareRange = computed(() => {
+  if (analysisMode.value === 'year') {
+    const y = selectedYear.value - 1
+    return {
+      start: ymToDateStr(y, 1, 1),
+      end: ymToDateStr(y, 12, 31),
+      label: `${y}년`,
+    }
+  }
+
+  if (analysisMode.value === 'custom') {
+    const start = new Date(`${analysisRange.value.start}T00:00:00`)
+    const end = new Date(`${analysisRange.value.end}T00:00:00`)
+    const days = Math.max(1, Math.floor((end - start) / 86400000) + 1)
+    const prevEnd = new Date(start)
+    prevEnd.setDate(prevEnd.getDate() - 1)
+    const prevStart = new Date(prevEnd)
+    prevStart.setDate(prevStart.getDate() - (days - 1))
+    const startStr = prevStart.toISOString().slice(0, 10)
+    const endStr = prevEnd.toISOString().slice(0, 10)
+    return {
+      start: startStr,
+      end: endStr,
+      label: `${startStr} ~ ${endStr}`,
+    }
+  }
+
+  let y = selectedYear.value
+  let m = Number(selectedMonth.value) - 1
+  if (m === 0) {
+    y -= 1
+    m = 12
+  }
+  return {
+    start: ymToDateStr(y, m, 1),
+    end: ymToDateStr(y, m, getDaysInMonth(y, m)),
+    label: `${y}년 ${m}월`,
+  }
+})
+
+const analysisOrders = computed(() =>
+  filterByDateRange(rawOrders, analysisRange.value.start, analysisRange.value.end)
+)
+
+const compareOrders = computed(() =>
+  filterByDateRange(rawOrders, compareRange.value.start, compareRange.value.end)
+)
+
+const analysisLabel = computed(() => analysisRange.value.label)
+const compareLabel = computed(() => compareRange.value.label)
+
+function rankTopBy(orders, key, metric = 'qty') {
+  const map = new Map()
+  for (const o of orders) {
+    map.set(o[key], (map.get(o[key]) || 0) + (metric === 'amount' ? o.amount : o.qty))
+  }
+  const rows = [...map.entries()].sort((a, b) => b[1] - a[1])
+  if (!rows.length) return { name: '-', value: 0 }
+  return { name: rows[0][0], value: rows[0][1] }
+}
+
+function rankLowBy(orders, key, metric = 'amount') {
+  const map = new Map()
+  for (const o of orders) {
+    map.set(o[key], (map.get(o[key]) || 0) + (metric === 'amount' ? o.amount : o.qty))
+  }
+  const rows = [...map.entries()].sort((a, b) => a[1] - b[1])
+  if (!rows.length) return { name: '-', value: 0 }
+  return { name: rows[0][0], value: rows[0][1] }
+}
+
+function rankListBy(orders, key, metric = 'amount') {
+  const map = new Map()
+  for (const o of orders) {
+    map.set(o[key], (map.get(o[key]) || 0) + (metric === 'amount' ? o.amount : o.qty))
+  }
+  const rows = [...map.entries()].map(([name, value]) => ({ name, value }))
+  rows.sort((a, b) => b.value - a.value)
+  return rows
+}
+
+const topMenuCurrent = computed(() => {
+  const top = rankTopBy(analysisOrders.value, 'product', 'qty')
+  return {
+    name: top.name,
+    meta: `${analysisLabel.value} · 판매수량 ${Number(top.value).toLocaleString()}개`,
+  }
+})
+
+const topMenuCompare = computed(() => {
+  const top = rankTopBy(compareOrders.value, 'product', 'qty')
+  return {
+    name: top.name,
+    meta: `${compareLabel.value} · 판매수량 ${Number(top.value).toLocaleString()}개`,
+  }
+})
+
+const topStore = computed(() => {
+  const top = rankTopBy(analysisOrders.value, 'store', 'amount')
+  return {
+    name: top.name,
+    meta: `${analysisLabel.value} · 매출 ₩${Number(top.value).toLocaleString()}`,
+  }
+})
+
+const lowStore = computed(() => {
+  const low = rankLowBy(analysisOrders.value, 'store', 'amount')
+  return {
+    name: low.name,
+    meta: `${analysisLabel.value} · 매출 ₩${Number(low.value).toLocaleString()}`,
+  }
+})
+
+const salesRanking = computed(() => rankListBy(analysisOrders.value, 'product', 'qty'))
+const revenueRanking = computed(() => rankListBy(analysisOrders.value, 'store', 'amount'))
+
+function toDisplay(item, metric) {
+  if (!item) return '-'
+  if (metric === 'qty') return `${Number(item.value).toLocaleString()}개`
+  return `₩${Number(item.value).toLocaleString()}`
+}
+
+const salesTop5 = computed(() =>
+  salesRanking.value.slice(0, 5).map((item) => ({ ...item, display: toDisplay(item, 'qty') }))
+)
+const salesBottom5 = computed(() =>
+  [...salesRanking.value]
+    .reverse()
+    .slice(0, 5)
+    .map((item) => ({ ...item, display: toDisplay(item, 'qty') }))
+)
+const revenueTop5 = computed(() =>
+  revenueRanking.value.slice(0, 5).map((item) => ({ ...item, display: toDisplay(item, 'amount') }))
+)
+const revenueBottom5 = computed(() =>
+  [...revenueRanking.value]
+    .reverse()
+    .slice(0, 5)
+    .map((item) => ({ ...item, display: toDisplay(item, 'amount') }))
+)
+
+const fullListItems = computed(() => {
+  const base = analysisTab.value === 'sales' ? salesRanking.value : revenueRanking.value
+  const metric = analysisTab.value === 'sales' ? 'qty' : 'amount'
+  return base.map((item) => ({ ...item, display: toDisplay(item, metric) }))
+})
+
+function openFullListModal() {
+  isFullListModalOpen.value = true
+}
+
+function closeFullListModal() {
+  isFullListModalOpen.value = false
+}
+
+const analysisSummary = computed(() => {
+  const list = analysisTab.value === 'sales' ? salesRanking.value : revenueRanking.value
+  const metric = analysisTab.value === 'sales' ? 'qty' : 'amount'
+  if (!list.length) {
+    return {
+      totalCount: 0,
+      topName: '-',
+      topValue: '-',
+      medianValue: '-',
+      gapValue: '-',
+    }
+  }
+  const top = list[0]
+  const bottom = list[list.length - 1]
+  const median = list[Math.floor((list.length - 1) / 2)]
+  const gap = top.value - bottom.value
+  return {
+    totalCount: list.length,
+    topName: top.name,
+    topValue: toDisplay(top, metric),
+    medianValue: toDisplay(median, metric),
+    gapValue: metric === 'qty' ? `${Number(gap).toLocaleString()}개` : `₩${Number(gap).toLocaleString()}`,
+  }
 })
 
 const categoryShare = computed(() => {


### PR DESCRIPTION
## Summary
기간 별 
- 통계 페이지에 기간 비교(월/년/직접 선택) 기능을 추가하고, 기준 기간/비교 기간을 자동 산출해 판매·매출 분석에 반영했습니다.
- 핵심 분석 박스에 판매/매출 탭을 도입하고, 각 탭에서 상위 5·하위 5와 전체 순위 모달을 제공하도록 개선했습니다.
- 전체 순위 모달과 하위 항목 표기를 정리해 하위 데이터 인지가 쉽도록(하위 강조 색상, 역순 순번) UI를 보완했습니다.


## Test plan
- [ ] 기간 모드 전환(월 비교/년 비교/직접 선택) 시 기준 기간/비교 기간 라벨과 데이터가 함께 갱신되는지 확인
- [ ] 판매/매출 탭 전환 시 상위 5·하위 5 목록, 요약 지표(대상 수/중앙값/격차)가 맞게 변경되는지 확인
- [ ] 하위 5 항목 블록의 순번이 전체 순위 마지막 번호 기준 역순으로 표시되는지 확인
- [ ]  전체 순위 보기 버튼 클릭 시 모달이 열리고, 하위 5는 빨간색 강조(아이콘 없음)로 표시되는지 확인
- [ ] 모달 닫기 버튼과 배경 클릭으로 정상 닫히는지 확인
- [ ] 발주 트렌드/카테고리 비중/이상 발주 차트가 정상 표시되고 필터 변경에 따라 업데이트되는지 확인
- [ ] CSV 다운로드 파일이 생성되고 주요 섹션(요약/버킷/카테고리/이상 발주)이 포함되는지 확인

## Issue
Close #240