### PR TITLE
[Feat] AI 보고서 챗봇 및 보고서 목록 페이지 구현 (관리자)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -132,7 +132,7 @@ import {
   Calculator, Box, ClipboardList,
   PackageSearch, Truck,
   Warehouse, Receipt, Tablet,
-  ChevronDown, User, LogOut, UserPlus, BarChart3, Bell,
+  ChevronDown, User, LogOut, UserPlus, BarChart3, Bell, FileText,
 } from 'lucide-vue-next'
 import { useAuthStore } from '@/stores/auth'
 import NotificationBell from '@/components/NotificationBell.vue'
@@ -170,6 +170,7 @@ const adminMenus = [
   { path: '/settlement', name: '정산 관리', icon: Calculator },
   { path: '/admin-account', name: '계정 관리', icon: UserPlus },
   { path: '/statistics', name: '통계', icon: BarChart3 },
+  { path: '/report', name: '보고서', icon: FileText },
   { path: '/notification', name: '알림', icon: Bell },
 ]
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -121,6 +121,9 @@
         <RouterView />
       </div>
     </main>
+
+    <!-- AI 챗봇 (관리자 전용) -->
+    <AiChatbot v-if="auth.isAdmin" />
   </div>
 </template>
 
@@ -136,6 +139,7 @@ import {
 } from 'lucide-vue-next'
 import { useAuthStore } from '@/stores/auth'
 import NotificationBell from '@/components/NotificationBell.vue'
+import AiChatbot from '@/components/AiChatbot.vue'
 import nexusLogo from '@/assets/nexus-logo.png'
 
 const route  = useRoute()

--- a/frontend/src/components/AiChatbot.vue
+++ b/frontend/src/components/AiChatbot.vue
@@ -1,0 +1,149 @@
+<template>
+  <!-- Floating button -->
+  <div class="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3">
+
+    <!-- Chat panel -->
+    <transition
+      enter-active-class="transition ease-out duration-200"
+      enter-from-class="opacity-0 translate-y-4"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="transition ease-in duration-150"
+      leave-from-class="opacity-100 translate-y-0"
+      leave-to-class="opacity-0 translate-y-4"
+    >
+      <div
+        v-if="isOpen"
+        class="w-[360px] h-[480px] bg-white rounded-2xl shadow-2xl border border-gray-200 flex flex-col overflow-hidden"
+      >
+        <!-- Header -->
+        <div class="flex items-center justify-between px-4 py-3 bg-[#F37321] shrink-0">
+          <div class="flex items-center gap-2">
+            <Bot class="w-5 h-5 text-white" />
+            <span class="text-sm font-bold text-white">Nexus AI 어시스턴트</span>
+          </div>
+          <button @click="isOpen = false" class="text-white/80 hover:text-white transition-colors">
+            <X class="w-4 h-4" />
+          </button>
+        </div>
+
+        <!-- Messages -->
+        <div ref="messageContainer" class="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-3">
+          <div
+            v-for="msg in messages"
+            :key="msg.id"
+            class="flex"
+            :class="msg.role === 'user' ? 'justify-end' : 'justify-start'"
+          >
+            <!-- AI avatar -->
+            <div v-if="msg.role === 'ai'" class="flex items-end gap-2">
+              <div class="w-7 h-7 rounded-full bg-[#F37321] flex items-center justify-center shrink-0">
+                <Bot class="w-4 h-4 text-white" />
+              </div>
+              <div class="max-w-[240px] px-3 py-2 rounded-2xl rounded-bl-sm bg-gray-100 text-sm text-gray-800 leading-relaxed">
+                {{ msg.text }}
+              </div>
+            </div>
+
+            <!-- User message -->
+            <div v-else class="max-w-[240px] px-3 py-2 rounded-2xl rounded-br-sm bg-[#F37321] text-sm text-white leading-relaxed">
+              {{ msg.text }}
+            </div>
+          </div>
+
+          <!-- Loading indicator -->
+          <div v-if="isLoading" class="flex items-end gap-2">
+            <div class="w-7 h-7 rounded-full bg-[#F37321] flex items-center justify-center shrink-0">
+              <Bot class="w-4 h-4 text-white" />
+            </div>
+            <div class="px-3 py-2 rounded-2xl rounded-bl-sm bg-gray-100">
+              <div class="flex gap-1 items-center h-4">
+                <span class="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0ms]"></span>
+                <span class="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:150ms]"></span>
+                <span class="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:300ms]"></span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Input -->
+        <div class="px-3 py-3 border-t border-gray-100 shrink-0">
+          <div class="flex items-end gap-2">
+            <textarea
+              v-model="input"
+              @keydown.enter.exact.prevent="sendMessage"
+              placeholder="보고서 생성을 요청해보세요..."
+              rows="1"
+              class="flex-1 resize-none text-sm px-3 py-2 rounded-xl border border-gray-200 focus:outline-none focus:border-[#F37321] transition-colors leading-relaxed"
+              :disabled="isLoading"
+            />
+            <button
+              @click="sendMessage"
+              :disabled="!input.trim() || isLoading"
+              class="w-9 h-9 rounded-xl flex items-center justify-center transition-colors shrink-0"
+              :class="input.trim() && !isLoading ? 'bg-[#F37321] hover:bg-orange-500 text-white' : 'bg-gray-100 text-gray-300'"
+            >
+              <Send class="w-4 h-4" />
+            </button>
+          </div>
+          <p class="text-[11px] text-gray-400 mt-1.5 px-1">Enter로 전송 · Shift+Enter로 줄바꿈</p>
+        </div>
+      </div>
+    </transition>
+
+    <!-- Floating button -->
+    <button
+      @click="isOpen = !isOpen"
+      class="w-14 h-14 rounded-full bg-[#F37321] hover:bg-orange-500 text-white shadow-lg flex items-center justify-center transition-all hover:scale-105"
+    >
+      <Bot v-if="!isOpen" class="w-6 h-6" />
+      <X v-else class="w-6 h-6" />
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref, nextTick } from 'vue'
+import { Bot, X, Send } from 'lucide-vue-next'
+
+const isOpen = ref(false)
+const isLoading = ref(false)
+const input = ref('')
+const messageContainer = ref(null)
+
+const messages = ref([
+  {
+    id: 1,
+    role: 'ai',
+    text: '안녕하세요! Nexus AI 어시스턴트입니다. 보고서 생성을 요청해보세요. 예) "저번달 총 매출과 이번달 비교 보고서 만들어줘"',
+  },
+])
+
+let nextId = 2
+
+async function sendMessage() {
+  const text = input.value.trim()
+  if (!text || isLoading.value) return
+
+  messages.value.push({ id: nextId++, role: 'user', text })
+  input.value = ''
+  isLoading.value = true
+  await scrollToBottom()
+
+  // AI 응답 (API 연동 전 더미 응답)
+  await new Promise(r => setTimeout(r, 1500))
+  messages.value.push({
+    id: nextId++,
+    role: 'ai',
+    text: '보고서를 생성 중입니다. 완료되면 보고서 목록 페이지에서 확인하고 다운로드할 수 있습니다.',
+  })
+  isLoading.value = false
+  await scrollToBottom()
+}
+
+async function scrollToBottom() {
+  await nextTick()
+  if (messageContainer.value) {
+    messageContainer.value.scrollTop = messageContainer.value.scrollHeight
+  }
+}
+</script>

--- a/frontend/src/components/AiChatbot.vue
+++ b/frontend/src/components/AiChatbot.vue
@@ -69,11 +69,13 @@
         <div class="px-3 py-3 border-t border-gray-100 shrink-0">
           <div class="flex items-end gap-2">
             <textarea
+              ref="textareaRef"
               v-model="input"
               @keydown.enter.exact.prevent="sendMessage"
+              @input="autoResize"
               placeholder="보고서 생성을 요청해보세요..."
               rows="1"
-              class="flex-1 resize-none text-sm px-3 py-2 rounded-xl border border-gray-200 focus:outline-none focus:border-[#F37321] transition-colors leading-relaxed"
+              class="flex-1 resize-none text-sm px-3 py-2 rounded-xl border border-gray-200 focus:outline-none focus:border-[#F37321] transition-colors leading-relaxed max-h-28 overflow-y-auto"
               :disabled="isLoading"
             />
             <button
@@ -109,6 +111,14 @@ const isOpen = ref(false)
 const isLoading = ref(false)
 const input = ref('')
 const messageContainer = ref(null)
+const textareaRef = ref(null)
+
+function autoResize() {
+  const el = textareaRef.value
+  if (!el) return
+  el.style.height = 'auto'
+  el.style.height = el.scrollHeight + 'px'
+}
 
 const messages = ref([
   {
@@ -126,6 +136,8 @@ async function sendMessage() {
 
   messages.value.push({ id: nextId++, role: 'user', text })
   input.value = ''
+  await nextTick()
+  if (textareaRef.value) textareaRef.value.style.height = 'auto'
   isLoading.value = true
   await scrollToBottom()
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -135,6 +135,12 @@ const router = createRouter({
       meta: { role: 'ADMIN' },
     },
     {
+      path: '/report',
+      name: 'report',
+      component: () => import('@/views/hq/ReportView.vue'),
+      meta: { role: 'ADMIN' },
+    },
+    {
       path: '/store-notification',
       name: 'storeNotification',
       component: () => import('@/views/store/StoreNotificationView.vue'),

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="p-6">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-xl font-bold text-gray-900">AI 보고서</h1>
+        <p class="text-sm text-gray-500 mt-0.5">챗봇이 생성한 보고서를 조회하고 다운로드할 수 있습니다.</p>
+      </div>
+    </div>
+
+    <!-- Table -->
+    <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-gray-100 bg-gray-50/70">
+            <th class="text-left px-5 py-3 font-semibold text-gray-600 w-12">번호</th>
+            <th class="text-left px-5 py-3 font-semibold text-gray-600">보고서 제목</th>
+            <th class="text-left px-5 py-3 font-semibold text-gray-600 w-40">생성일시</th>
+            <th class="text-center px-5 py-3 font-semibold text-gray-600 w-28">다운로드</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-50">
+          <tr v-if="reports.length === 0">
+            <td colspan="4" class="px-5 py-16 text-center text-gray-400 text-sm">
+              생성된 보고서가 없습니다.
+            </td>
+          </tr>
+          <tr
+            v-for="report in reports"
+            :key="report.idx"
+            class="hover:bg-gray-50/50 transition-colors"
+          >
+            <td class="px-5 py-3.5 text-gray-400">{{ report.idx }}</td>
+            <td class="px-5 py-3.5">
+              <div class="flex items-center gap-2">
+                <FileText class="w-4 h-4 text-[#F37321] shrink-0" />
+                <span class="font-medium text-gray-800">{{ report.report_title }}</span>
+              </div>
+            </td>
+            <td class="px-5 py-3.5 text-gray-500">{{ report.created_at }}</td>
+            <td class="px-5 py-3.5 text-center">
+              <button
+                @click="handleDownload(report)"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors"
+              >
+                <Download class="w-3.5 h-3.5" />
+                PDF
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FileText, Download } from 'lucide-vue-next'
+
+const reports = ref([
+  {
+    idx: 5,
+    report_title: '2026년 4월 가맹점별 매출 비교 보고서',
+    created_at: '2026-04-20 14:32',
+    file_path: '/reports/report_5.pdf',
+  },
+  {
+    idx: 4,
+    report_title: '3월 vs 4월 총 매출 비교 보고서',
+    created_at: '2026-04-18 09:15',
+    file_path: '/reports/report_4.pdf',
+  },
+  {
+    idx: 3,
+    report_title: '2026년 1분기 발주 품목 통계 보고서',
+    created_at: '2026-04-10 16:48',
+    file_path: '/reports/report_3.pdf',
+  },
+  {
+    idx: 2,
+    report_title: '판교테크노밸리점 월별 정산 분석 보고서',
+    created_at: '2026-04-05 11:20',
+    file_path: '/reports/report_2.pdf',
+  },
+  {
+    idx: 1,
+    report_title: '2026년 3월 전체 가맹점 재고 현황 보고서',
+    created_at: '2026-04-01 10:00',
+    file_path: '/reports/report_1.pdf',
+  },
+])
+
+function handleDownload(report) {
+  // API 연동 후 실제 다운로드로 교체
+  alert(`${report.report_title} 다운로드 준비 중입니다.`)
+}
+</script>


### PR DESCRIPTION
## Summary
- 본사 사이드바에 보고서 메뉴 항목 추가
- 보고서 목록 페이지 구현 (ReportView) — 게시판 형태, PDF 다운로드
- AI 챗봇 플로팅 컴포넌트 구현 (AiChatbot) — 우측 하단 고정, 채팅창 UI
- 관리자 페이지에 챗봇 컴포넌트 연결 (관리자 전용 노출)
- n8n API 연동 전 더미 응답으로 동작, 추후 실제 연동 예정

## Test plan
- [x] 관리자 로그인 후 사이드바에 보고서 메뉴가 보이는지 확인
- [x] 보고서 목록 페이지 진입 및 PDF 다운로드 버튼 동작 확인
- [x] 우측 하단 챗봇 버튼 클릭 시 채팅창 열림/닫힘 확인
- [x] 메시지 입력 후 Enter 전송 및 AI 더미 응답 확인
- [x] 점주 로그인 시 챗봇이 노출되지 않는지 확인

## Issue
Closes #246 
