### PR TITLE
[Feat] 보고서 페이지 탭 분리 및 뉴스 요약 기능 구현

### DIFF
--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -4,12 +4,27 @@
     <div class="flex items-center justify-between mb-6">
       <div>
         <h1 class="text-xl font-bold text-gray-900">AI 보고서</h1>
-        <p class="text-sm text-gray-500 mt-0.5">챗봇이 생성한 보고서를 조회하고 다운로드할 수 있습니다.</p>
+        <p class="text-sm text-gray-500 mt-0.5">AI가 생성한 보고서와 뉴스 요약을 확인할 수 있습니다.</p>
       </div>
     </div>
 
-    <!-- Table -->
-    <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
+    <!-- Tabs -->
+    <div class="flex gap-1 mb-4 border-b border-gray-200">
+      <button
+        v-for="tab in tabs"
+        :key="tab.value"
+        @click="activeTab = tab.value"
+        class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px"
+        :class="activeTab === tab.value
+          ? 'border-[#F37321] text-[#F37321]'
+          : 'border-transparent text-gray-500 hover:text-gray-700'"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <!-- AI 보고서 탭 -->
+    <div v-if="activeTab === 'report'" class="bg-white rounded-lg border border-gray-200 overflow-hidden">
       <table class="w-full text-sm">
         <thead>
           <tr class="border-b border-gray-100 bg-gray-50/70">
@@ -51,12 +66,27 @@
         </tbody>
       </table>
     </div>
+
+    <!-- 뉴스 요약 탭 -->
+    <div v-if="activeTab === 'news'" class="flex flex-col gap-3">
+      <p class="text-xs text-gray-400">매일 오전 9시 AI가 치킨 업계 관련 뉴스를 수집·요약합니다.</p>
+      <div v-if="newsSummaries.length === 0" class="bg-white rounded-lg border border-gray-200 px-5 py-16 text-center text-gray-400 text-sm">
+        수집된 뉴스가 없습니다.
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
 import { ref } from 'vue'
 import { FileText, Download } from 'lucide-vue-next'
+
+const tabs = [
+  { label: 'AI 보고서', value: 'report' },
+  { label: '뉴스 요약', value: 'news' },
+]
+
+const activeTab = ref('report')
 
 const reports = ref([
   {
@@ -91,8 +121,9 @@ const reports = ref([
   },
 ])
 
+const newsSummaries = ref([])
+
 function handleDownload(report) {
-  // API 연동 후 실제 다운로드로 교체
   alert(`${report.report_title} 다운로드 준비 중입니다.`)
 }
 </script>

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -4,7 +4,6 @@
     <div class="flex items-center justify-between mb-6">
       <div>
         <h1 class="text-xl font-bold text-gray-900">AI 보고서</h1>
-        <p class="text-sm text-gray-500 mt-0.5">AI가 생성한 보고서와 뉴스 요약을 확인할 수 있습니다.</p>
       </div>
     </div>
 
@@ -75,44 +74,77 @@
         수집된 뉴스가 없습니다.
       </div>
 
-      <div
+      <!-- 뉴스 목록 (간략 표시) -->
+      <button
         v-for="news in newsSummaries"
         :key="news.idx"
-        class="bg-white rounded-lg border border-gray-200 p-5 flex flex-col gap-3"
+        @click="selectedNews = news"
+        class="w-full bg-white rounded-lg border border-gray-200 p-4 flex items-start justify-between gap-4 hover:border-[#F37321] hover:bg-orange-50/20 transition-colors text-left"
       >
-        <!-- 제목 + 날짜 -->
-        <div class="flex items-start justify-between gap-4">
-          <div class="flex items-center gap-2">
-            <Newspaper class="w-4 h-4 text-[#F37321] shrink-0 mt-0.5" />
-            <span class="font-semibold text-gray-900 text-sm">{{ news.summary_title }}</span>
+        <div class="flex items-start gap-3 min-w-0">
+          <Newspaper class="w-4 h-4 text-[#F37321] shrink-0 mt-0.5" />
+          <div class="min-w-0">
+            <p class="font-semibold text-gray-900 text-sm">{{ news.summary_title }}</p>
+            <p class="text-xs text-gray-500 mt-1 line-clamp-1">{{ firstLine(news.summary_content) }}</p>
           </div>
-          <span class="text-xs text-gray-400 shrink-0">{{ news.summary_date }}</span>
+        </div>
+        <span class="text-xs text-gray-400 shrink-0">{{ news.summary_date }}</span>
+      </button>
+    </div>
+
+    <!-- 뉴스 상세 모달 -->
+    <div v-if="selectedNews" class="fixed inset-0 z-50 flex items-center justify-center">
+      <div class="absolute inset-0 bg-black/40" @click="selectedNews = null"></div>
+      <div class="relative bg-white rounded-2xl shadow-2xl w-full max-w-2xl mx-4 max-h-[80vh] flex flex-col overflow-hidden">
+
+        <!-- 모달 헤더 -->
+        <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100 shrink-0">
+          <div class="flex items-center gap-2">
+            <Newspaper class="w-4 h-4 text-[#F37321]" />
+            <span class="font-bold text-gray-900 text-sm">{{ selectedNews.summary_title }}</span>
+          </div>
+          <button @click="selectedNews = null" class="text-gray-400 hover:text-gray-700 transition-colors">
+            <X class="w-5 h-5" />
+          </button>
         </div>
 
-        <!-- 요약 내용 -->
-        <div class="text-sm text-gray-700 leading-relaxed bg-gray-50 rounded-md px-4 py-3">
-          {{ news.summary_content }}
-        </div>
+        <!-- 모달 내용 -->
+        <div class="overflow-y-auto px-6 py-5 flex flex-col gap-4">
+          <!-- 날짜 -->
+          <p class="text-xs text-gray-400">{{ selectedNews.summary_date }}</p>
 
-        <!-- 운영 조언 -->
-        <div class="flex gap-2 text-sm bg-orange-50 border border-orange-100 rounded-md px-4 py-3">
-          <Lightbulb class="w-4 h-4 text-[#F37321] shrink-0 mt-0.5" />
-          <p class="text-gray-700 leading-relaxed">{{ news.advice }}</p>
-        </div>
+          <!-- 요약 내용 -->
+          <div class="bg-gray-50 rounded-lg px-4 py-3">
+            <p class="text-xs font-semibold text-gray-500 mb-2 uppercase tracking-wide">요약</p>
+            <p class="text-sm text-gray-700 leading-relaxed whitespace-pre-line">{{ selectedNews.summary_content }}</p>
+          </div>
 
-        <!-- 원문 링크 -->
-        <div class="flex flex-wrap gap-2">
-          <a
-            v-for="(url, i) in news.urls"
-            :key="i"
-            :href="url"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center gap-1 text-xs text-blue-500 hover:underline"
-          >
-            <ExternalLink class="w-3 h-3" />
-            원문 {{ i + 1 }}
-          </a>
+          <!-- 운영 조언 -->
+          <div class="flex gap-2 bg-orange-50 border border-orange-100 rounded-lg px-4 py-3">
+            <Lightbulb class="w-4 h-4 text-[#F37321] shrink-0 mt-0.5" />
+            <div>
+              <p class="text-xs font-semibold text-[#F37321] mb-1">운영 조언</p>
+              <p class="text-sm text-gray-700 leading-relaxed">{{ selectedNews.advice }}</p>
+            </div>
+          </div>
+
+          <!-- 원문 링크 -->
+          <div>
+            <p class="text-xs font-semibold text-gray-500 mb-2">원문 링크</p>
+            <div class="flex flex-wrap gap-2">
+              <a
+                v-for="(url, i) in selectedNews.urls"
+                :key="i"
+                :href="url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1 text-xs text-blue-500 hover:underline"
+              >
+                <ExternalLink class="w-3 h-3" />
+                원문 {{ i + 1 }}
+              </a>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -121,14 +153,15 @@
 
 <script setup>
 import { ref } from 'vue'
-import { FileText, Download, Newspaper, Lightbulb, ExternalLink } from 'lucide-vue-next'
+import { FileText, Download, Newspaper, Lightbulb, ExternalLink, X } from 'lucide-vue-next'
 
 const tabs = [
-  { label: 'AI 보고서', value: 'report' },
+  { label: '보고서', value: 'report' },
   { label: '뉴스 요약', value: 'news' },
 ]
 
 const activeTab = ref('report')
+const selectedNews = ref(null)
 
 const reports = ref([
   {
@@ -189,6 +222,10 @@ const newsSummaries = ref([
     urls: ['https://example.com/news/6', 'https://example.com/news/7', 'https://example.com/news/8'],
   },
 ])
+
+function firstLine(content) {
+  return content.split('\n')[0]
+}
 
 function handleDownload(report) {
   alert(`${report.report_title} 다운로드 준비 중입니다.`)

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -70,8 +70,50 @@
     <!-- 뉴스 요약 탭 -->
     <div v-if="activeTab === 'news'" class="flex flex-col gap-3">
       <p class="text-xs text-gray-400">매일 오전 9시 AI가 치킨 업계 관련 뉴스를 수집·요약합니다.</p>
+
       <div v-if="newsSummaries.length === 0" class="bg-white rounded-lg border border-gray-200 px-5 py-16 text-center text-gray-400 text-sm">
         수집된 뉴스가 없습니다.
+      </div>
+
+      <div
+        v-for="news in newsSummaries"
+        :key="news.idx"
+        class="bg-white rounded-lg border border-gray-200 p-5 flex flex-col gap-3"
+      >
+        <!-- 제목 + 날짜 -->
+        <div class="flex items-start justify-between gap-4">
+          <div class="flex items-center gap-2">
+            <Newspaper class="w-4 h-4 text-[#F37321] shrink-0 mt-0.5" />
+            <span class="font-semibold text-gray-900 text-sm">{{ news.summary_title }}</span>
+          </div>
+          <span class="text-xs text-gray-400 shrink-0">{{ news.summary_date }}</span>
+        </div>
+
+        <!-- 요약 내용 -->
+        <div class="text-sm text-gray-700 leading-relaxed bg-gray-50 rounded-md px-4 py-3">
+          {{ news.summary_content }}
+        </div>
+
+        <!-- 운영 조언 -->
+        <div class="flex gap-2 text-sm bg-orange-50 border border-orange-100 rounded-md px-4 py-3">
+          <Lightbulb class="w-4 h-4 text-[#F37321] shrink-0 mt-0.5" />
+          <p class="text-gray-700 leading-relaxed">{{ news.advice }}</p>
+        </div>
+
+        <!-- 원문 링크 -->
+        <div class="flex flex-wrap gap-2">
+          <a
+            v-for="(url, i) in news.urls"
+            :key="i"
+            :href="url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1 text-xs text-blue-500 hover:underline"
+          >
+            <ExternalLink class="w-3 h-3" />
+            원문 {{ i + 1 }}
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -79,7 +121,7 @@
 
 <script setup>
 import { ref } from 'vue'
-import { FileText, Download } from 'lucide-vue-next'
+import { FileText, Download, Newspaper, Lightbulb, ExternalLink } from 'lucide-vue-next'
 
 const tabs = [
   { label: 'AI 보고서', value: 'report' },
@@ -121,7 +163,32 @@ const reports = ref([
   },
 ])
 
-const newsSummaries = ref([])
+const newsSummaries = ref([
+  {
+    idx: 3,
+    summary_title: '2026-04-21 치킨 업계 주요 이슈 요약',
+    summary_date: '2026-04-21 09:00',
+    summary_content: '1. 국내 생닭 도매가격이 전주 대비 8% 상승하며 3개월 만에 최고치를 기록했습니다. 공급 부족과 여름 성수기 수요 증가가 주요 원인으로 분석됩니다.\n2. 공정거래위원회가 주요 치킨 프랜차이즈 브랜드의 가맹점 원부자재 공급가 실태 점검에 착수했습니다.\n3. 튀김유 원재료인 대두유 국제 선물 가격이 2주 연속 강세를 보이며 국내 식용유 가격 인상 가능성이 제기되고 있습니다.',
+    advice: '생닭 도매가 상승 추세에 따라 단기 재고 확보를 검토하시고, 튀김유 가격 동향을 모니터링하여 구매 시점을 조율하는 것을 권장합니다.',
+    urls: ['https://example.com/news/1', 'https://example.com/news/2', 'https://example.com/news/3'],
+  },
+  {
+    idx: 2,
+    summary_title: '2026-04-20 치킨 업계 주요 이슈 요약',
+    summary_date: '2026-04-20 09:00',
+    summary_content: '1. 치킨 소스류 주요 원재료인 고추 작황 부진으로 핫소스 공급가 상승이 예상됩니다.\n2. 식품의약품안전처가 닭고기 위생 관리 기준을 강화하는 개정안을 예고했습니다. 냉장 유통 온도 기준이 기존 5℃에서 4℃로 조정될 예정입니다.\n3. 배달 플랫폼 수수료 인상 발표로 치킨 프랜차이즈 가맹점주들의 반발이 커지고 있습니다.',
+    advice: '위생 관리 기준 강화에 대비해 냉장 보관 온도 설정을 사전에 점검하시고, 배달 플랫폼 수수료 변동에 따른 정산 계획을 재검토하시기 바랍니다.',
+    urls: ['https://example.com/news/4', 'https://example.com/news/5'],
+  },
+  {
+    idx: 1,
+    summary_title: '2026-04-19 치킨 업계 주요 이슈 요약',
+    summary_date: '2026-04-19 09:00',
+    summary_content: '1. 황금연휴 기간 치킨 주문량이 평일 대비 평균 230% 증가할 것으로 전망됩니다.\n2. 치킨박스·포장재 제조업체들이 원가 상승을 이유로 공급가 인상을 예고했습니다.\n3. 조류독감(AI) 발생 우려가 일부 지역에서 제기되어 당국이 예찰을 강화하고 있습니다.',
+    advice: '연휴 수요 급증에 대비해 생닭·소스·포장재 재고를 충분히 확보하시고, 조류독감 발생 지역 원산지 납품 현황을 확인하시기 바랍니다.',
+    urls: ['https://example.com/news/6', 'https://example.com/news/7', 'https://example.com/news/8'],
+  },
+])
 
 function handleDownload(report) {
   alert(`${report.report_title} 다운로드 준비 중입니다.`)

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -129,7 +129,7 @@
           </div>
 
           <!-- 원문 링크 -->
-          <div>
+          <div v-if="selectedNews.urls?.length">
             <p class="text-xs font-semibold text-gray-500 mb-2">원문 링크</p>
             <div class="flex flex-wrap gap-2">
               <a
@@ -224,7 +224,7 @@ const newsSummaries = ref([
 ])
 
 function firstLine(content) {
-  return content.split('\n')[0]
+  return content?.split('\n')[0] ?? ''
 }
 
 function handleDownload(report) {

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -13,7 +13,7 @@
       <table class="w-full text-sm">
         <thead>
           <tr class="border-b border-gray-100 bg-gray-50/70">
-            <th class="text-left px-5 py-3 font-semibold text-gray-600 w-12">번호</th>
+            <th class="text-left px-5 py-3 font-semibold text-gray-600 w-20">번호</th>
             <th class="text-left px-5 py-3 font-semibold text-gray-600">보고서 제목</th>
             <th class="text-left px-5 py-3 font-semibold text-gray-600 w-40">생성일시</th>
             <th class="text-center px-5 py-3 font-semibold text-gray-600 w-28">다운로드</th>


### PR DESCRIPTION
## Summary
- 보고서 페이지에 탭 UI 추가 (보고서 / 뉴스 요약)
- 뉴스 요약 탭 구현 — 치킨 업계 관련 뉴스 목록 (제목 + 한 줄 요약)
- 뉴스 항목 클릭 시 상세 모달 표시 (전체 요약, 운영 조언, 원문 링크)
- AI 보고서 탭 번호 컬럼 너비 수정 (숫자 가로 표시)
- 페이지 설명 문구 및 탭 라벨 정리

## Test plan
- [ ] 보고서 / 뉴스 요약 탭 전환 정상 동작 확인
- [ ] 뉴스 목록에서 제목 + 첫 줄 요약만 표시되는지 확인
- [ ] 뉴스 항목 클릭 시 상세 모달 열림 확인
- [ ] 모달 내 요약, 운영 조언, 원문 링크 정상 표시 확인
- [ ] 모달 배경 클릭 또는 X 버튼으로 닫힘 확인

## Issue
Closes #248 
