### PR TITLE
[Refactor] 전체 페이지 UI 일관성 개선 (모달·버튼·금액 표시 통일)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -166,8 +166,8 @@ const adminMenus = [
   {
     path: '/inventory/head-office', name: '재고 관리', icon: Box,
     children: [
-      { path: '/inventory/head-office', name: '본사재고현황' },
-      { path: '/inventory/franchise', name: '가맹점재고현황' },
+      { path: '/inventory/head-office', name: '본사 재고 현황' },
+      { path: '/inventory/franchise', name: '가맹점 재고 현황' },
     ],
   },
   { path: '/delivery',   name: '배송 관리', icon: Truck },

--- a/frontend/src/views/AdminAccountCreateView.vue
+++ b/frontend/src/views/AdminAccountCreateView.vue
@@ -44,13 +44,13 @@
               <div class="flex items-center justify-center gap-2">
                 <button
                   @click="openEditModal(account)"
-                  class="px-2.5 py-1.5 rounded border border-gray-200 text-xs font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer"
+                  class="px-2.5 py-1.5 rounded border border-[#F37321] text-xs font-semibold text-[#F37321] hover:bg-orange-50 cursor-pointer"
                 >
                   수정
                 </button>
                 <button
                   @click="openDeleteModal(account)"
-                  class="px-2.5 py-1.5 rounded border border-red-200 text-xs font-semibold text-red-500 hover:bg-red-50 cursor-pointer"
+                  class="px-2.5 py-1.5 rounded border border-red-400 text-xs font-semibold text-red-500 hover:bg-red-50 cursor-pointer"
                 >
                   삭제
                 </button>

--- a/frontend/src/views/AdminAccountCreateView.vue
+++ b/frontend/src/views/AdminAccountCreateView.vue
@@ -3,7 +3,6 @@
     <div class="flex items-center justify-between">
       <div>
         <h1 class="text-xl font-bold text-gray-900 tracking-tight">계정 관리</h1>
-        <p class="text-sm text-gray-500 mt-1">계정 목록을 조회하고, 계정을 생성/수정/삭제할 수 있습니다.</p>
       </div>
       <button
         @click="openCreateModal"

--- a/frontend/src/views/AdminAccountCreateView.vue
+++ b/frontend/src/views/AdminAccountCreateView.vue
@@ -7,7 +7,7 @@
       </div>
       <button
         @click="openCreateModal"
-        class="inline-flex items-center gap-2 px-4 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d]"
+        class="inline-flex items-center gap-2 px-4 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] cursor-pointer"
       >
         + 계정 생성
       </button>
@@ -45,13 +45,13 @@
               <div class="flex items-center justify-center gap-2">
                 <button
                   @click="openEditModal(account)"
-                  class="px-2.5 py-1.5 rounded border border-gray-200 text-xs font-semibold text-gray-600 hover:bg-gray-50"
+                  class="px-2.5 py-1.5 rounded border border-gray-200 text-xs font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer"
                 >
                   수정
                 </button>
                 <button
                   @click="openDeleteModal(account)"
-                  class="px-2.5 py-1.5 rounded border border-red-200 text-xs font-semibold text-red-500 hover:bg-red-50"
+                  class="px-2.5 py-1.5 rounded border border-red-200 text-xs font-semibold text-red-500 hover:bg-red-50 cursor-pointer"
                 >
                   삭제
                 </button>
@@ -70,7 +70,7 @@
       <div class="relative w-full max-w-lg bg-white rounded-lg border border-gray-200 shadow-xl">
         <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
           <h3 class="font-bold text-gray-900">{{ formMode === 'create' ? '계정 생성' : '계정 수정' }}</h3>
-          <button @click="closeFormModal" class="text-gray-400 hover:text-gray-600">✕</button>
+          <button @click="closeFormModal" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
 
         <form class="p-6 space-y-4" @submit.prevent="submitForm">
@@ -137,13 +137,13 @@
             <button
               type="button"
               @click="closeFormModal"
-              class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50"
+              class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer"
             >
               취소
             </button>
             <button
               type="submit"
-              class="flex-1 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d]"
+              class="flex-1 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] cursor-pointer"
             >
               {{ formMode === 'create' ? '생성' : '수정 저장' }}
             </button>
@@ -164,14 +164,14 @@
           <button
             type="button"
             @click="closeDeleteModal"
-            class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50"
+            class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer"
           >
             취소
           </button>
           <button
             type="button"
             @click="confirmDelete"
-            class="flex-1 py-2.5 rounded bg-red-500 text-white text-sm font-bold hover:bg-red-600"
+            class="flex-1 py-2.5 rounded bg-red-500 text-white text-sm font-bold hover:bg-red-600 cursor-pointer"
           >
             삭제
           </button>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -5,7 +5,7 @@
         <h1 class="text-[22px] font-bold text-gray-900 tracking-tight">운영 현황</h1>
       </div>
       <div class="flex items-center gap-2">
-        <button v-for="tab in periodTabs" :key="tab" class="text-xs px-3 py-1.5 rounded-md border transition-colors"
+        <button v-for="tab in periodTabs" :key="tab" class="text-xs px-3 py-1.5 rounded-md border transition-colors cursor-pointer"
           :class="activePeriod === tab ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-500 border-gray-200 hover:bg-gray-50'"
           @click="activePeriod = tab">
           {{ tab }}

--- a/frontend/src/views/DeliveryView.vue
+++ b/frontend/src/views/DeliveryView.vue
@@ -23,7 +23,7 @@
     <div class="flex gap-2 flex-wrap">
       <button v-for="f in statusFilters" :key="f.value"
               @click="filterStatus = f.value"
-              class="px-3.5 py-1.5 text-sm font-semibold border rounded-md transition-colors"
+              class="px-3.5 py-1.5 text-sm font-semibold border rounded-md transition-colors cursor-pointer"
               :class="filterStatus === f.value
           ? 'bg-[#F37321] text-white border-[#F37321]'
           : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'">
@@ -103,7 +103,7 @@
             <span class="w-2 h-2 rounded-full bg-red-500"></span>
             배송 지연 사유 입력
           </h3>
-          <button @click="closeModal" class="text-gray-400 hover:text-gray-600 transition-colors">
+          <button @click="closeModal" class="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
           </button>
         </div>
@@ -131,10 +131,10 @@
         </div>
 
         <div class="px-6 py-4 bg-gray-50 flex justify-end gap-2 border-t border-gray-100">
-          <button @click="closeModal" class="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 text-sm font-semibold transition-colors">
+          <button @click="closeModal" class="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 text-sm font-semibold transition-colors cursor-pointer">
             취소
           </button>
-          <button @click="saveDelayReason" class="px-5 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 text-sm font-semibold transition-colors shadow-sm">
+          <button @click="saveDelayReason" class="px-5 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 text-sm font-semibold transition-colors shadow-sm cursor-pointer">
             사유 저장
           </button>
         </div>

--- a/frontend/src/views/InventoryHeadOfficeView.vue
+++ b/frontend/src/views/InventoryHeadOfficeView.vue
@@ -91,7 +91,7 @@
               </p>
             </div>
             <button type="button"
-              class="shrink-0 p-1.5 rounded border border-gray-200 text-gray-500 hover:bg-white hover:text-gray-800 cursor-pointer"
+              class="text-gray-400 hover:text-gray-600 cursor-pointer"
               aria-label="닫기"
               @click="closeDetail">
               ✕

--- a/frontend/src/views/InventoryHeadOfficeView.vue
+++ b/frontend/src/views/InventoryHeadOfficeView.vue
@@ -15,7 +15,7 @@
 
     <div class="flex gap-3 items-center flex-wrap">
       <select v-model="filterWarehouse"
-        class="px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none bg-white">
+        class="px-3 py-2 rounded-lg border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none bg-white">
         <option value="">전체 창고</option>
         <option>본사 창고</option>
       </select>
@@ -23,7 +23,7 @@
         <button v-for="f in statusFilters" :key="f.value"
           type="button"
           @click="filterStatus = f.value"
-          class="px-3 py-2 text-sm font-semibold border transition-colors cursor-pointer"
+          class="px-3 py-1.5 text-sm font-semibold border rounded-lg transition-colors cursor-pointer"
           :class="filterStatus === f.value
             ? 'bg-[#F37321] text-white border-[#F37321]'
             : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'">

--- a/frontend/src/views/InventoryHeadOfficeView.vue
+++ b/frontend/src/views/InventoryHeadOfficeView.vue
@@ -81,10 +81,10 @@
         aria-modal="true"
         :aria-labelledby="detailTitleId"
         @click.self="closeDetail">
-        <div class="bg-white rounded-lg shadow-xl max-w-lg w-full max-h-[85vh] overflow-hidden flex flex-col border border-gray-200">
-          <div class="flex items-start justify-between gap-3 px-5 py-4 border-b border-gray-200 bg-gray-50">
+        <div class="relative bg-white rounded-xl shadow-xl max-w-lg w-full max-h-[85vh] overflow-hidden flex flex-col border border-gray-200">
+          <div class="flex items-start justify-between gap-3 px-6 py-4 border-b border-gray-200">
             <div class="min-w-0">
-              <p :id="detailTitleId" class="text-lg font-bold text-gray-900 truncate">{{ detailItem.name }}</p>
+              <p :id="detailTitleId" class="font-bold text-gray-900 truncate">{{ detailItem.name }}</p>
               <p class="text-xs font-mono text-gray-500 mt-0.5">{{ detailItem.code }} · {{ detailItem.warehouse }}</p>
               <p class="text-xs text-gray-500 mt-2">
                 합계 <span class="font-semibold text-gray-800">{{ totalStock(detailItem).toLocaleString() }}</span>
@@ -97,7 +97,7 @@
               ✕
             </button>
           </div>
-          <div class="overflow-y-auto">
+          <div class="overflow-y-auto flex-1">
             <table class="w-full text-sm text-left">
               <thead>
                 <tr class="border-b border-gray-100 bg-white sticky top-0">
@@ -117,6 +117,10 @@
                 </tr>
               </tbody>
             </table>
+          </div>
+          <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
+            <button type="button" @click="closeDetail"
+              class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">닫기</button>
           </div>
         </div>
       </div>

--- a/frontend/src/views/InventoryHeadOfficeView.vue
+++ b/frontend/src/views/InventoryHeadOfficeView.vue
@@ -9,7 +9,7 @@
           class="px-4 py-2 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 flex items-center gap-2">
           <History class="w-4 h-4" /> 입출고 이력
         </RouterLink>
-        <button class="px-4 py-2 border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50">재고 동기화</button>
+        <button class="px-4 py-2 border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer">재고 동기화</button>
       </div>
     </div>
 
@@ -23,7 +23,7 @@
         <button v-for="f in statusFilters" :key="f.value"
           type="button"
           @click="filterStatus = f.value"
-          class="px-3 py-2 text-sm font-semibold border transition-colors"
+          class="px-3 py-2 text-sm font-semibold border transition-colors cursor-pointer"
           :class="filterStatus === f.value
             ? 'bg-[#F37321] text-white border-[#F37321]'
             : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'">
@@ -91,7 +91,7 @@
               </p>
             </div>
             <button type="button"
-              class="shrink-0 p-1.5 rounded border border-gray-200 text-gray-500 hover:bg-white hover:text-gray-800"
+              class="shrink-0 p-1.5 rounded border border-gray-200 text-gray-500 hover:bg-white hover:text-gray-800 cursor-pointer"
               aria-label="닫기"
               @click="closeDetail">
               ✕

--- a/frontend/src/views/InventoryView.vue
+++ b/frontend/src/views/InventoryView.vue
@@ -9,7 +9,7 @@
           class="px-4 py-2 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 flex items-center gap-2">
           <History class="w-4 h-4" /> 입출고 이력
         </RouterLink>
-        <button class="px-4 py-2 border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50">재고 동기화</button>
+        <button class="px-4 py-2 border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer">재고 동기화</button>
       </div>
     </div>
 
@@ -33,7 +33,7 @@
         <button v-for="f in statusFilters" :key="f.value"
           type="button"
           @click="filterStatus = f.value"
-          class="px-3 py-2 text-sm font-semibold border transition-colors"
+          class="px-3 py-2 text-sm font-semibold border transition-colors cursor-pointer"
           :class="filterStatus === f.value
             ? 'bg-[#F37321] text-white border-[#F37321]'
             : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'">
@@ -101,7 +101,7 @@
               </p>
             </div>
             <button type="button"
-              class="shrink-0 p-1.5 rounded border border-gray-200 text-gray-500 hover:bg-white hover:text-gray-800"
+              class="shrink-0 p-1.5 rounded border border-gray-200 text-gray-500 hover:bg-white hover:text-gray-800 cursor-pointer"
               aria-label="닫기"
               @click="closeDetail">
               ✕

--- a/frontend/src/views/InventoryView.vue
+++ b/frontend/src/views/InventoryView.vue
@@ -91,10 +91,10 @@
         aria-modal="true"
         :aria-labelledby="detailTitleId"
         @click.self="closeDetail">
-        <div class="bg-white rounded-lg shadow-xl max-w-lg w-full max-h-[85vh] overflow-hidden flex flex-col border border-gray-200">
-          <div class="flex items-start justify-between gap-3 px-5 py-4 border-b border-gray-200 bg-gray-50">
+        <div class="relative bg-white rounded-xl shadow-xl max-w-lg w-full max-h-[85vh] overflow-hidden flex flex-col border border-gray-200">
+          <div class="flex items-start justify-between gap-3 px-6 py-4 border-b border-gray-200">
             <div class="min-w-0">
-              <p :id="detailTitleId" class="text-lg font-bold text-gray-900 truncate">{{ detailItem.name }}</p>
+              <p :id="detailTitleId" class="font-bold text-gray-900 truncate">{{ detailItem.name }}</p>
               <p class="text-xs font-mono text-gray-500 mt-0.5">{{ detailItem.code }} · {{ detailItem.store }}</p>
               <p class="text-xs text-gray-500 mt-2">
                 합계 <span class="font-semibold text-gray-800">{{ totalStock(detailItem).toLocaleString() }}</span>
@@ -107,7 +107,7 @@
               ✕
             </button>
           </div>
-          <div class="overflow-y-auto">
+          <div class="overflow-y-auto flex-1">
             <table class="w-full text-sm text-left">
               <thead>
                 <tr class="border-b border-gray-100 bg-white sticky top-0">
@@ -127,6 +127,10 @@
                 </tr>
               </tbody>
             </table>
+          </div>
+          <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
+            <button type="button" @click="closeDetail"
+              class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">닫기</button>
           </div>
         </div>
       </div>

--- a/frontend/src/views/InventoryView.vue
+++ b/frontend/src/views/InventoryView.vue
@@ -15,14 +15,14 @@
 
     <div class="flex gap-3 items-center flex-wrap">
       <select v-model="filterRegion"
-        class="px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none bg-white">
+        class="px-3 py-2 rounded-lg border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none bg-white">
         <option value="">전체 지역</option>
         <option value="서울">서울</option>
         <option value="경기">경기</option>
         <option value="부산">부산</option>
       </select>
       <select v-model="filterStore"
-        class="px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none bg-white">
+        class="px-3 py-2 rounded-lg border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none bg-white">
         <option value="">전체 가맹점</option>
         <option>한화빌딩점</option>
         <option>여의도역점</option>
@@ -33,7 +33,7 @@
         <button v-for="f in statusFilters" :key="f.value"
           type="button"
           @click="filterStatus = f.value"
-          class="px-3 py-2 text-sm font-semibold border transition-colors cursor-pointer"
+          class="px-3 py-1.5 text-sm font-semibold border rounded-lg transition-colors cursor-pointer"
           :class="filterStatus === f.value
             ? 'bg-[#F37321] text-white border-[#F37321]'
             : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'">

--- a/frontend/src/views/InventoryView.vue
+++ b/frontend/src/views/InventoryView.vue
@@ -101,7 +101,7 @@
               </p>
             </div>
             <button type="button"
-              class="shrink-0 p-1.5 rounded border border-gray-200 text-gray-500 hover:bg-white hover:text-gray-800 cursor-pointer"
+              class="text-gray-400 hover:text-gray-600 cursor-pointer"
               aria-label="닫기"
               @click="closeDetail">
               ✕

--- a/frontend/src/views/OrderManageView.vue
+++ b/frontend/src/views/OrderManageView.vue
@@ -498,7 +498,7 @@ const productPrices = {
 }
 
 function formatPrice(n) {
-  return n.toLocaleString('ko-KR') + '원'
+  return '₩ ' + n.toLocaleString('ko-KR')
 }
 
 const abnormalCount = computed(() => abnormalOrders.value.filter(o => !o.processed).length)

--- a/frontend/src/views/OrderManageView.vue
+++ b/frontend/src/views/OrderManageView.vue
@@ -7,11 +7,11 @@
       </div>
       <div class="flex gap-2">
         <button @click="showSettings = true"
-          class="px-4 py-2 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 flex items-center gap-2">
+          class="px-4 py-2 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 flex items-center gap-2 cursor-pointer">
           <Settings class="w-4 h-4" /> 이상 발주 기준 설정
         </button>
         <button @click="showManualForm = true"
-          class="bg-[#F37321] text-white px-4 py-2 text-sm font-semibold rounded hover:bg-[#e0661d] transition-colors flex items-center gap-2">
+          class="bg-[#F37321] text-white px-4 py-2 text-sm font-semibold rounded hover:bg-[#e0661d] transition-colors flex items-center gap-2 cursor-pointer">
           <Plus class="w-4 h-4" /> 수동 발주 생성
         </button>
       </div>
@@ -21,7 +21,7 @@
     <div class="flex border-b border-gray-200">
       <button v-for="tab in tabs" :key="tab.id"
         @click="setOrderViewTab(tab.id)"
-        class="px-5 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors"
+        class="px-5 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors cursor-pointer"
         :class="activeTab === tab.id
           ? 'border-[#F37321] text-[#F37321]'
           : 'border-transparent text-gray-500 hover:text-gray-700'">
@@ -154,9 +154,9 @@
               <td class="px-5 py-3.5">
                 <div v-if="!o.processed" class="flex justify-center gap-1.5">
                   <button @click.stop="approveAbnormal(o)"
-                    class="px-2.5 py-1 bg-[#F37321] text-white text-xs font-semibold hover:bg-[#e0661d] rounded">승인</button>
+                    class="px-2.5 py-1 bg-[#F37321] text-white text-xs font-semibold hover:bg-[#e0661d] rounded cursor-pointer">승인</button>
                   <button @click.stop="rejectAbnormal(o)"
-                    class="px-2.5 py-1 border border-gray-200 text-gray-600 text-xs font-medium hover:bg-gray-50 rounded">반려</button>
+                    class="px-2.5 py-1 border border-gray-200 text-gray-600 text-xs font-medium hover:bg-gray-50 rounded cursor-pointer">반려</button>
                 </div>
                 <span v-else class="text-xs text-gray-400 block text-center">—</span>
               </td>
@@ -191,7 +191,7 @@
           <div class="flex gap-2 items-center">
             <input v-model="historySearch" type="search" placeholder="발주번호·가맹점·품목"
               class="flex-1 px-3 py-2 rounded border border-gray-200 text-sm outline-none focus:border-[#F37321]" />
-            <button type="button" class="text-xs font-semibold text-gray-500 border border-gray-200 px-4 py-2 rounded hover:bg-gray-50 shrink-0"
+            <button type="button" class="text-xs font-semibold text-gray-500 border border-gray-200 px-4 py-2 rounded hover:bg-gray-50 shrink-0 cursor-pointer"
               @click="historyFilterType = ''; historyDateFrom = ''; historyDateTo = ''; historySearch = ''">
               초기화
             </button>
@@ -241,7 +241,7 @@
       <div class="relative bg-white rounded-xl w-full max-w-lg border border-gray-200 shadow-xl">
         <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
           <h3 class="font-bold text-gray-900">수동 발주 생성</h3>
-          <button @click="showManualForm = false" class="text-gray-400 hover:text-gray-600">✕</button>
+          <button @click="showManualForm = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
         <div class="p-6 space-y-4">
           <div class="space-y-1.5">
@@ -258,7 +258,7 @@
           <div class="space-y-2">
             <div class="flex justify-between items-center">
               <label class="text-xs font-bold text-gray-500 uppercase tracking-wider">발주 품목</label>
-              <button @click="addManualItem" class="text-xs text-[#F37321] font-semibold hover:underline flex items-center gap-1">
+              <button @click="addManualItem" class="text-xs text-[#F37321] font-semibold hover:underline flex items-center gap-1 cursor-pointer">
                 <Plus class="w-3 h-3" /> 품목 추가
               </button>
             </div>
@@ -301,9 +301,9 @@
         </div>
         <div class="px-6 py-4 border-t border-gray-100 flex gap-3">
           <button @click="showManualForm = false"
-            class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50">취소</button>
+            class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer">취소</button>
           <button @click="submitManualOrder"
-            class="flex-1 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d]">발주 생성</button>
+            class="flex-1 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] cursor-pointer">발주 생성</button>
         </div>
       </div>
     </div>
@@ -317,7 +317,7 @@
             <h3 class="font-bold text-gray-900">발주 상세</h3>
             <p class="text-xs text-gray-400 font-mono mt-0.5">{{ selectedOrder?.id }}</p>
           </div>
-          <button @click="showDetail = false" class="text-gray-400 hover:text-gray-600">✕</button>
+          <button @click="showDetail = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
         <div v-if="selectedOrder" class="p-6 space-y-4">
           <div class="grid grid-cols-2 gap-4 text-sm">
@@ -412,7 +412,7 @@
         </div>
         <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
           <button @click="showDetail = false"
-            class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50">닫기</button>
+            class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">닫기</button>
         </div>
       </div>
     </div>
@@ -423,7 +423,7 @@
       <div class="relative bg-white rounded-lg w-full max-w-sm border border-gray-200 shadow-xl">
         <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
           <h3 class="font-bold text-gray-900">이상 발주 기준 설정</h3>
-          <button @click="showSettings = false" class="text-gray-400 hover:text-gray-600">✕</button>
+          <button @click="showSettings = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
         <div class="p-6 space-y-5">
           <div class="space-y-3">
@@ -453,9 +453,9 @@
           </div>
           <div class="flex gap-3 pt-1">
             <button @click="showSettings = false"
-              class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50">취소</button>
+              class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer">취소</button>
             <button @click="showSettings = false"
-              class="flex-1 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d]">저장</button>
+              class="flex-1 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] cursor-pointer">저장</button>
           </div>
         </div>
       </div>

--- a/frontend/src/views/ProductView.vue
+++ b/frontend/src/views/ProductView.vue
@@ -72,7 +72,7 @@
           <td class="px-5 py-3.5 text-gray-600">{{ p.unit }}</td>
           <td class="px-5 py-3.5 font-medium text-gray-900">{{ p.baseStock.toLocaleString() }}</td>
           <td class="px-5 py-3.5 font-semibold text-[#F37321]">{{ p.minStock.toLocaleString() }}</td>
-          <td class="px-5 py-3.5 font-medium text-gray-900">₩{{ p.price.toLocaleString() }}</td>
+          <td class="px-5 py-3.5 font-medium text-gray-900">₩ {{ p.price.toLocaleString() }}</td>
           <td class="px-5 py-3.5 text-xs font-mono"
               :class="p.expiryDays ? 'text-amber-600 font-semibold' : 'text-gray-400'">
             {{ p.expiryDays ? `D-${p.expiryDays}` : '-' }}

--- a/frontend/src/views/ProductView.vue
+++ b/frontend/src/views/ProductView.vue
@@ -7,11 +7,11 @@
       </div>
       <div class="flex gap-2">
         <button @click="showCategoryModal = true"
-                class="px-4 py-2 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 flex items-center gap-2">
+                class="px-4 py-2 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 flex items-center gap-2 cursor-pointer">
           <Tag class="w-4 h-4" /> 카테고리 관리
         </button>
         <button @click="openModal(null)"
-                class="bg-[#F37321] text-white px-4 py-2 text-sm font-semibold rounded hover:bg-[#e0661d] transition-colors flex items-center gap-2">
+                class="bg-[#F37321] text-white px-4 py-2 text-sm font-semibold rounded hover:bg-[#e0661d] transition-colors flex items-center gap-2 cursor-pointer">
           <Plus class="w-4 h-4" /> 제품 등록
         </button>
       </div>
@@ -37,7 +37,7 @@
           :key="cat"
           @click="selectedCategory = cat"
           class="px-3 py-1.5 text-sm font-semibold border rounded-lg
-                transition-colors shadow-sm"
+                transition-colors shadow-sm cursor-pointer"
           :class="selectedCategory === cat
             ? 'bg-[#F37321] text-white border-[#F37321]'
             : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'">
@@ -79,10 +79,10 @@
           </td>
           <td class="px-5 py-3.5">
             <div class="flex justify-center gap-3">
-              <button @click="openModal(p)" class="text-gray-300 hover:text-[#F37321] transition-colors">
+              <button @click="openModal(p)" class="text-gray-300 hover:text-[#F37321] transition-colors cursor-pointer">
                 <Pencil class="w-4 h-4" />
               </button>
-              <button @click="deleteProduct(p.code)" class="text-gray-300 hover:text-red-500 transition-colors">
+              <button @click="deleteProduct(p.code)" class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer">
                 <Trash2 class="w-4 h-4" />
               </button>
             </div>
@@ -101,7 +101,7 @@
       <div class="relative bg-white rounded-lg w-full max-w-lg border border-gray-200 shadow-xl">
         <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
           <h3 class="font-bold text-gray-900">{{ editTarget ? '제품 정보 수정' : '신규 제품 등록' }}</h3>
-          <button @click="showModal = false" class="text-gray-400 hover:text-gray-600">✕</button>
+          <button @click="showModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
         <form @submit.prevent="saveProduct" class="p-6 space-y-4">
           <div class="grid grid-cols-2 gap-4">
@@ -149,9 +149,9 @@
           </div>
           <div class="flex gap-3 pt-2">
             <button type="button" @click="showModal = false"
-                    class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50">취소</button>
+                    class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer">취소</button>
             <button type="submit"
-                    class="flex-1 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d]">저장</button>
+                    class="flex-1 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] cursor-pointer">저장</button>
           </div>
         </form>
       </div>
@@ -163,7 +163,7 @@
       <div class="relative bg-white rounded-lg w-full max-w-md border border-gray-200 shadow-xl">
         <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
           <h3 class="font-bold text-gray-900">카테고리 관리</h3>
-          <button @click="showCategoryModal = false" class="text-gray-400 hover:text-gray-600">✕</button>
+          <button @click="showCategoryModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
         <div class="p-6 space-y-4">
           <!-- 등록 폼 -->
@@ -172,7 +172,7 @@
                    @keyup.enter="addCategory"
                    class="flex-1 px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none" />
             <button @click="addCategory"
-                    class="px-4 py-2 bg-[#F37321] text-white text-sm font-semibold rounded hover:bg-[#e0661d]">
+                    class="px-4 py-2 bg-[#F37321] text-white text-sm font-semibold rounded hover:bg-[#e0661d] cursor-pointer">
               추가
             </button>
           </div>
@@ -186,7 +186,7 @@
                    class="flex items-center justify-between px-4 py-2.5 hover:bg-gray-50">
                 <span class="text-sm font-medium text-gray-700">{{ cat }}</span>
                 <button @click="deleteCategory(cat)"
-                        class="text-gray-300 hover:text-red-500 transition-colors">
+                        class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer">
                   <Trash2 class="w-3.5 h-3.5" />
                 </button>
               </div>
@@ -197,7 +197,7 @@
             </div>
           </div>
           <button @click="showCategoryModal = false"
-                  class="w-full py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50">
+                  class="w-full py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer">
             닫기
           </button>
         </div>

--- a/frontend/src/views/ProductView.vue
+++ b/frontend/src/views/ProductView.vue
@@ -78,12 +78,12 @@
             {{ p.expiryDays ? `D-${p.expiryDays}` : '-' }}
           </td>
           <td class="px-5 py-3.5">
-            <div class="flex justify-center gap-3">
-              <button @click="openModal(p)" class="text-gray-300 hover:text-[#F37321] transition-colors cursor-pointer">
-                <Pencil class="w-4 h-4" />
+            <div class="flex justify-center gap-2">
+              <button @click="openModal(p)" class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer">
+                수정
               </button>
-              <button @click="deleteProduct(p.code)" class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer">
-                <Trash2 class="w-4 h-4" />
+              <button @click="deleteProduct(p.code)" class="px-3 py-1.5 text-xs font-semibold text-red-500 border border-red-400 rounded hover:bg-red-50 transition-colors cursor-pointer">
+                삭제
               </button>
             </div>
           </td>
@@ -208,7 +208,7 @@
 
 <script setup>
 import { ref, computed } from 'vue'
-import { Plus, Pencil, Trash2, Search, Tag } from 'lucide-vue-next'
+import { Plus, Trash2, Search, Tag } from 'lucide-vue-next'
 
 const categories = ref(['육류', '소스', '채소', '가공식품', '음료'])
 const selectedCategory = ref('전체')

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="p-6 space-y-4 font-sans text-gray-900">
+  <div class="p-5 space-y-4">
 
     <!-- ── 페이지 헤더 ── -->
     <div class="flex items-center justify-between">
       <div>
-        <h1 class="text-xl font-black text-gray-900">메뉴 관리</h1>
+        <h1 class="text-xl font-bold text-gray-900 tracking-tight">메뉴 관리</h1>
 
       </div>
       <button @click="openNewMenuModal"
@@ -46,14 +46,11 @@
     </div>
 
     <!-- ── 검색 ── -->
-    <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-5">
-
-
-      <!-- ── 메뉴 테이블 ── -->
+    <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
       <div class="overflow-x-auto">
         <table class="w-full text-sm text-left">
           <thead>
-          <tr class="border-b border-gray-100 bg-gray-50/60">
+          <tr class="border-b border-gray-200 bg-gray-50">
             <th class="px-4 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">메뉴번호</th>
             <th class="px-4 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">메뉴명</th>
             <th class="px-4 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">가격</th>
@@ -61,19 +58,19 @@
             <th class="px-4 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">관리</th>
           </tr>
           </thead>
-          <tbody class="divide-y divide-gray-50">
+          <tbody class="divide-y divide-gray-100">
           <tr v-for="menu in filteredMenus" :key="menu.id"
               @click="openIngredientModal(menu)"
-              class="hover:bg-gray-50/80 transition-colors cursor-pointer group">
-            <td class="px-4 py-4 font-mono text-xs text-gray-400">{{ menu.id }}</td>
-            <td class="px-4 py-4 font-bold text-gray-900 group-hover:text-[#F97316] transition-colors">{{ menu.name }}</td>
-            <td class="px-4 py-4 text-gray-700 font-semibold">{{ formatPrice(menu.price) }}</td>
-            <td class="px-4 py-4 text-center">
+              class="hover:bg-gray-50/50 transition-colors cursor-pointer group">
+            <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ menu.id }}</td>
+            <td class="px-5 py-3.5 font-bold text-gray-900 group-hover:text-[#F97316] transition-colors">{{ menu.name }}</td>
+            <td class="px-5 py-3.5 text-gray-700 font-semibold">{{ formatPrice(menu.price) }}</td>
+            <td class="px-5 py-3.5 text-center">
                 <span class="text-xs font-bold px-2 py-0.5 rounded-full bg-orange-50 text-orange-600">
                   {{ menu.ingredients.length }}종
                 </span>
             </td>
-            <td class="px-4 py-4" @click.stop>
+            <td class="px-5 py-3.5" @click.stop>
               <div class="flex justify-center gap-2">
                 <button @click="openEditMenuModal(menu)"
                         class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer">
@@ -87,7 +84,7 @@
             </td>
           </tr>
           <tr v-if="filteredMenus.length === 0">
-            <td colspan="5" class="px-4 py-12 text-center text-gray-300 text-sm">검색 결과가 없습니다</td>
+            <td colspan="5" class="px-5 py-12 text-center text-gray-400 text-sm">검색 결과가 없습니다.</td>
           </tr>
           </tbody>
         </table>

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -76,12 +76,12 @@
             <td class="px-4 py-4" @click.stop>
               <div class="flex justify-center gap-2">
                 <button @click="openEditMenuModal(menu)"
-                        class="text-gray-300 hover:text-[#F97316] transition-colors cursor-pointer" title="수정">
-                  <Pencil class="w-4 h-4" />
+                        class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer">
+                  수정
                 </button>
                 <button @click="openDeleteConfirm(menu)"
-                        class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer" title="삭제">
-                  <Trash2 class="w-4 h-4" />
+                        class="px-3 py-1.5 text-xs font-semibold text-red-500 border border-red-400 rounded hover:bg-red-50 transition-colors cursor-pointer">
+                  삭제
                 </button>
               </div>
             </td>
@@ -314,7 +314,7 @@
 
 <script setup>
 import { ref, computed } from 'vue'
-import { Plus, Pencil, Trash2, Search, Image as ImageIcon, ChevronDown } from 'lucide-vue-next'
+import { Plus, Trash2, Search, Image as ImageIcon, ChevronDown } from 'lucide-vue-next'
 
 // ─────────────────────────────────────────────
 //  상품 목록 (제품 관리에서 연동 가정)

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -246,7 +246,6 @@
               <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품명</th>
               <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-right">소요량</th>
               <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</th>
-              <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">관리</th>
             </tr>
             </thead>
             <tbody class="divide-y divide-gray-50">
@@ -256,25 +255,14 @@
               <td class="px-3 py-3 font-semibold text-gray-800">{{ getProductName(item.productId) }}</td>
               <td class="px-3 py-3 text-right text-gray-700 font-mono">{{ item.amount }}</td>
               <td class="px-3 py-3 text-gray-500">{{ item.unit }}</td>
-              <td class="px-3 py-3">
-                <div class="flex justify-center gap-2">
-                  <button @click="deleteIngredient(idx)"
-                          class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer" title="삭제">
-                    <Trash2 class="w-4 h-4" />
-                  </button>
-                </div>
-              </td>
             </tr>
             <tr v-if="!selectedMenu?.ingredients?.length">
-              <td colspan="5" class="px-3 py-8 text-center text-gray-300 text-sm">등록된 재료가 없습니다</td>
+              <td colspan="4" class="px-3 py-8 text-center text-gray-400 text-sm">등록된 재료가 없습니다.</td>
             </tr>
             </tbody>
           </table>
 
-          <div class="mt-5 flex justify-end gap-2"> <button @click="editIngredient"
-                                                            class="flex items-center gap-1 px-3 py-1.5 bg-[#F97316] text-white text-xs font-bold rounded-lg hover:bg-[#EA6700] transition-colors shadow-sm cursor-pointer">
-            <Plus class="w-3 h-3" /> 재료 추가
-          </button>
+          <div class="mt-5 flex justify-end">
             <button @click="showIngredientModal = false"
                     class="px-5 py-2.5 rounded-lg bg-gray-100 text-gray-600 text-sm font-bold hover:bg-gray-200 transition-colors cursor-pointer">
               닫기

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -8,7 +8,7 @@
 
       </div>
       <button @click="openNewMenuModal"
-              class="flex items-center gap-2 px-4 py-2 bg-[#F97316] text-white text-sm font-bold rounded-lg hover:bg-[#EA6700] transition-colors shadow-sm">
+              class="flex items-center gap-2 px-4 py-2 bg-[#F97316] text-white text-sm font-bold rounded-lg hover:bg-[#EA6700] transition-colors shadow-sm cursor-pointer">
         <Plus class="w-4 h-4" /> 신규 메뉴 등록
       </button>
     </div>
@@ -76,11 +76,11 @@
             <td class="px-4 py-4" @click.stop>
               <div class="flex justify-center gap-2">
                 <button @click="openEditMenuModal(menu)"
-                        class="text-gray-300 hover:text-[#F97316] transition-colors" title="수정">
+                        class="text-gray-300 hover:text-[#F97316] transition-colors cursor-pointer" title="수정">
                   <Pencil class="w-4 h-4" />
                 </button>
                 <button @click="openDeleteConfirm(menu)"
-                        class="text-gray-300 hover:text-red-500 transition-colors" title="삭제">
+                        class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer" title="삭제">
                   <Trash2 class="w-4 h-4" />
                 </button>
               </div>
@@ -104,7 +104,7 @@
         <!-- 모달 헤더 -->
         <div class="px-7 py-5 border-b border-gray-100 flex justify-between items-center bg-gray-50">
           <h3 class="font-bold text-gray-900 text-lg">{{ editTarget ? '메뉴 수정' : '신규 메뉴 등록' }}</h3>
-          <button @click="showMenuModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl">✕</button>
+          <button @click="showMenuModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl cursor-pointer">✕</button>
         </div>
 
         <form @submit.prevent="saveMenu" class="p-7 space-y-5">
@@ -137,7 +137,7 @@
                       :class="menuForm.category === cat
                         ? 'bg-[#F97316] text-white border-[#F97316]'
                         : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300 hover:bg-gray-50'"
-                      class="px-3 py-1.5 rounded-lg border text-xs font-semibold transition-all">
+                      class="px-3 py-1.5 rounded-lg border text-xs font-semibold transition-all cursor-pointer">
                 {{ cat }}
               </button>
             </div>
@@ -160,7 +160,7 @@
             <div class="flex items-center justify-between mb-3">
               <span class="text-sm font-bold text-gray-700">재료 등록</span>
               <button type="button" @click="addIngredientRow"
-                      class="flex items-center gap-1 text-xs font-bold text-[#F97316] hover:text-[#EA6700] transition-colors">
+                      class="flex items-center gap-1 text-xs font-bold text-[#F97316] hover:text-[#EA6700] transition-colors cursor-pointer">
                 <Plus class="w-3.5 h-3.5" /> 재료 추가
               </button>
             </div>
@@ -197,7 +197,7 @@
                   <option>묶음</option>
                 </select>
                 <button type="button" @click="removeIngredientRow(idx)"
-                        class="w-8 h-8 flex items-center justify-center rounded-lg bg-red-50 text-red-400 hover:bg-red-100 hover:text-red-600 transition-colors text-sm font-bold">
+                        class="w-8 h-8 flex items-center justify-center rounded-lg bg-red-50 text-red-400 hover:bg-red-100 hover:text-red-600 transition-colors text-sm font-bold cursor-pointer">
                   ✕
                 </button>
               </div>
@@ -210,11 +210,11 @@
           <!-- 버튼 -->
           <div class="flex gap-3 pt-2">
             <button type="button" @click="showMenuModal = false"
-                    class="flex-1 py-3 rounded-lg border border-gray-200 text-sm font-bold text-gray-500 hover:bg-gray-50 transition-colors">
+                    class="flex-1 py-3 rounded-lg border border-gray-200 text-sm font-bold text-gray-500 hover:bg-gray-50 transition-colors cursor-pointer">
               취소
             </button>
             <button type="submit"
-                    class="flex-1 py-3 rounded-lg bg-[#F97316] text-white text-sm font-bold hover:bg-[#EA6700] transition-colors shadow-sm">
+                    class="flex-1 py-3 rounded-lg bg-[#F97316] text-white text-sm font-bold hover:bg-[#EA6700] transition-colors shadow-sm cursor-pointer">
               {{ editTarget ? '수정 저장' : '등록하기' }}
             </button>
           </div>
@@ -237,7 +237,7 @@
           <div class="flex items-center gap-4">
             <!-- 추가 요청 사항: 재료 추가 버튼 -->
 
-            <button @click="showIngredientModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl">✕</button>
+            <button @click="showIngredientModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl cursor-pointer">✕</button>
           </div>
         </div>
 
@@ -262,7 +262,7 @@
               <td class="px-3 py-3">
                 <div class="flex justify-center gap-2">
                   <button @click="deleteIngredient(idx)"
-                          class="text-gray-300 hover:text-red-500 transition-colors" title="삭제">
+                          class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer" title="삭제">
                     <Trash2 class="w-4 h-4" />
                   </button>
                 </div>
@@ -275,11 +275,11 @@
           </table>
 
           <div class="mt-5 flex justify-end gap-2"> <button @click="editIngredient"
-                                                            class="flex items-center gap-1 px-3 py-1.5 bg-[#F97316] text-white text-xs font-bold rounded-lg hover:bg-[#EA6700] transition-colors shadow-sm">
+                                                            class="flex items-center gap-1 px-3 py-1.5 bg-[#F97316] text-white text-xs font-bold rounded-lg hover:bg-[#EA6700] transition-colors shadow-sm cursor-pointer">
             <Plus class="w-3 h-3" /> 재료 추가
           </button>
             <button @click="showIngredientModal = false"
-                    class="px-5 py-2.5 rounded-lg bg-gray-100 text-gray-600 text-sm font-bold hover:bg-gray-200 transition-colors">
+                    class="px-5 py-2.5 rounded-lg bg-gray-100 text-gray-600 text-sm font-bold hover:bg-gray-200 transition-colors cursor-pointer">
               닫기
             </button>
           </div>
@@ -298,11 +298,11 @@
         <p class="text-xs text-gray-400 mb-6">이 작업은 되돌릴 수 없습니다.</p>
         <div class="flex gap-3">
           <button @click="showDeleteConfirm = false"
-                  class="flex-1 py-2.5 rounded-lg border border-gray-200 text-sm font-bold text-gray-500 hover:bg-gray-50 transition-colors">
+                  class="flex-1 py-2.5 rounded-lg border border-gray-200 text-sm font-bold text-gray-500 hover:bg-gray-50 transition-colors cursor-pointer">
             취소
           </button>
           <button @click="confirmDelete"
-                  class="flex-1 py-2.5 rounded-lg bg-red-500 text-white text-sm font-bold hover:bg-red-600 transition-colors">
+                  class="flex-1 py-2.5 rounded-lg bg-red-500 text-white text-sm font-bold hover:bg-red-600 transition-colors cursor-pointer">
             삭제
           </button>
         </div>

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -224,7 +224,7 @@
     ══════════════════════════════════════════ -->
     <div v-if="showIngredientModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div class="absolute inset-0 bg-black/40 " @click="showIngredientModal = false"></div>
-      <div class="relative bg-white rounded-xl w-full max-w-lg border border-gray-200 shadow-xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
+      <div class="relative bg-white rounded-xl w-full max-w-lg border border-gray-200 shadow-xl overflow-hidden max-h-[85vh] flex flex-col animate-in fade-in slide-in-from-bottom-4 duration-200">
 
         <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
           <div>
@@ -234,7 +234,7 @@
           <button @click="showIngredientModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
 
-        <div class="p-6">
+        <div class="p-6 overflow-y-auto flex-1">
           <table class="w-full text-sm text-left">
             <thead>
             <tr class="border-b border-gray-200 bg-gray-50">

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -226,48 +226,43 @@
       <div class="absolute inset-0 bg-black/40 " @click="showIngredientModal = false"></div>
       <div class="relative bg-white rounded-xl w-full max-w-lg border border-gray-200 shadow-xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
 
-        <div class="px-7 py-5 border-b border-gray-100 flex justify-between items-center bg-gray-50">
+        <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
           <div>
-            <h3 class="font-bold text-gray-900 text-lg">{{ selectedMenu?.name }}</h3>
-            <p class="text-xs text-gray-400 mt-0.5">{{selectedMenu?.id}}</p>
+            <h3 class="font-bold text-gray-900">{{ selectedMenu?.name }}</h3>
+            <p class="text-xs text-gray-400 font-mono mt-0.5">{{ selectedMenu?.id }}</p>
           </div>
-          <div class="flex items-center gap-4">
-            <!-- 추가 요청 사항: 재료 추가 버튼 -->
-
-            <button @click="showIngredientModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl cursor-pointer">✕</button>
-          </div>
+          <button @click="showIngredientModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
 
-        <div class="p-7">
+        <div class="p-6">
           <table class="w-full text-sm text-left">
             <thead>
-            <tr class="border-b border-gray-100 bg-gray-50/60">
-              <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">재료번호</th>
-              <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품명</th>
-              <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-right">소요량</th>
-              <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</th>
+            <tr class="border-b border-gray-200 bg-gray-50">
+              <th class="px-4 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">재료번호</th>
+              <th class="px-4 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품명</th>
+              <th class="px-4 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-right">소요량</th>
+              <th class="px-4 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</th>
             </tr>
             </thead>
-            <tbody class="divide-y divide-gray-50">
+            <tbody class="divide-y divide-gray-100">
             <tr v-for="(item, idx) in selectedMenu?.ingredients" :key="idx"
-                class="hover:bg-gray-50/80 transition-colors">
-              <td class="px-3 py-3 font-mono text-xs text-gray-400">R-{{ String(idx + 1).padStart(3, '0') }}</td>
-              <td class="px-3 py-3 font-semibold text-gray-800">{{ getProductName(item.productId) }}</td>
-              <td class="px-3 py-3 text-right text-gray-700 font-mono">{{ item.amount }}</td>
-              <td class="px-3 py-3 text-gray-500">{{ item.unit }}</td>
+                class="hover:bg-gray-50/50 transition-colors">
+              <td class="px-4 py-3 font-mono text-xs text-gray-400">R-{{ String(idx + 1).padStart(3, '0') }}</td>
+              <td class="px-4 py-3 font-semibold text-gray-800">{{ getProductName(item.productId) }}</td>
+              <td class="px-4 py-3 text-right text-gray-700 font-mono">{{ item.amount }}</td>
+              <td class="px-4 py-3 text-gray-500">{{ item.unit }}</td>
             </tr>
             <tr v-if="!selectedMenu?.ingredients?.length">
-              <td colspan="4" class="px-3 py-8 text-center text-gray-400 text-sm">등록된 재료가 없습니다.</td>
+              <td colspan="4" class="px-4 py-8 text-center text-gray-400 text-sm">등록된 재료가 없습니다.</td>
             </tr>
             </tbody>
           </table>
-
-          <div class="mt-5 flex justify-end">
-            <button @click="showIngredientModal = false"
-                    class="px-5 py-2.5 rounded-lg bg-gray-100 text-gray-600 text-sm font-bold hover:bg-gray-200 transition-colors cursor-pointer">
-              닫기
-            </button>
-          </div>
+        </div>
+        <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
+          <button @click="showIngredientModal = false"
+                  class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">
+            닫기
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/views/SettlementView.vue
+++ b/frontend/src/views/SettlementView.vue
@@ -81,14 +81,14 @@
       <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
         <div class="p-5">
           <p class="text-xs font-bold text-gray-400 uppercase tracking-wider">가맹점 청구 합계</p>
-          <p class="text-2xl font-black text-gray-900 mt-2">₩{{ totalStore.toLocaleString() }}</p>
+          <p class="text-2xl font-black text-gray-900 mt-2">₩ {{ totalStore.toLocaleString() }}</p>
           <p class="text-xs text-gray-400 mt-2 pt-2 border-t border-gray-100">{{ selectedMonth }}</p>
         </div>
       </div>
       <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
         <div class="p-5">
           <p class="text-xs font-bold text-gray-400 uppercase tracking-wider">순이익 (차액)</p>
-          <p class="text-2xl font-black text-green-600 mt-2">₩{{ (totalStore - totalSupplier).toLocaleString() }}</p>
+          <p class="text-2xl font-black text-green-600 mt-2">₩ {{ (totalStore - totalSupplier).toLocaleString() }}</p>
           <p class="text-xs text-gray-400 mt-2 pt-2 border-t border-gray-100">{{ selectedMonth }}</p>
         </div>
       </div>
@@ -128,7 +128,7 @@
           <td class="px-5 py-3.5 font-semibold text-gray-900">{{ s.name }}</td>
           <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ s.period }}</td>
           <td class="px-5 py-3.5 text-gray-600">{{ s.count }}건</td>
-          <td class="px-5 py-3.5 font-bold text-gray-900">₩{{ s.amount.toLocaleString() }}</td>
+          <td class="px-5 py-3.5 font-bold text-gray-900">₩ {{ s.amount.toLocaleString() }}</td>
           <td class="px-5 py-3.5">
               <span
                 class="text-xs font-bold px-2 py-0.5 rounded"

--- a/frontend/src/views/SettlementView.vue
+++ b/frontend/src/views/SettlementView.vue
@@ -19,7 +19,7 @@
             v-for="p in periodGranularityOptions"
             :key="p"
             type="button"
-            class="text-xs px-2.5 py-1.5 rounded-md font-semibold transition-colors"
+            class="text-xs px-2.5 py-1.5 rounded-md font-semibold transition-colors cursor-pointer"
             :class="periodGranularity === p ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
             @click="periodGranularity = p"
           >
@@ -37,7 +37,7 @@
           <option>2026-02</option>
         </select>
 
-        <button class="inline-flex items-center gap-2 px-4 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d]">
+        <button class="inline-flex items-center gap-2 px-4 py-2.5 rounded bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] cursor-pointer">
           월별 마감 실행
         </button>
       </div>
@@ -100,7 +100,7 @@
         v-for="tab in ['가맹점 정산']"
         :key="tab"
         @click="activeTab = tab"
-        class="px-5 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors"
+        class="px-5 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors cursor-pointer"
         :class="activeTab === tab
           ? 'border-[#F37321] text-[#F37321]'
           : 'border-transparent text-gray-500 hover:text-gray-700'"
@@ -142,7 +142,7 @@
           <td class="px-5 py-3.5 text-center">
             <button
               type="button"
-              class="text-gray-300 hover:text-[#F37321] transition-colors"
+              class="text-gray-300 hover:text-[#F37321] transition-colors cursor-pointer"
               @click="downloadStatement(s)"
             >
               <Download class="w-4 h-4 mx-auto" />

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -13,7 +13,7 @@
             v-for="p in periodOptions"
             :key="p.value"
             type="button"
-            class="text-xs px-3 py-1.5 rounded-md font-semibold transition-colors"
+            class="text-xs px-3 py-1.5 rounded-md font-semibold transition-colors cursor-pointer"
             :class="period === p.value ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-50'"
             @click="period = p.value"
           >
@@ -29,7 +29,7 @@
         </select>
         <button
           type="button"
-          class="text-xs px-3 py-2 rounded-lg border border-gray-200 bg-white font-semibold text-gray-600 hover:bg-gray-50"
+          class="text-xs px-3 py-2 rounded-lg border border-gray-200 bg-white font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer"
           @click="downloadCsv"
         >
           CSV 다운로드

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -3,9 +3,6 @@
     <div class="flex flex-wrap items-start justify-between gap-4">
       <div>
         <h1 class="text-[22px] font-bold text-gray-900 tracking-tight">발주 통계</h1>
-        <p class="text-sm text-gray-500 mt-1">
-          치킨 프랜차이즈 본사·가맹 발주 기준 데모입니다. 기간·카테고리에 따라 트렌드·비중·이상 발주를 확인할 수 있습니다.
-        </p>
       </div>
       <div class="flex flex-wrap items-center gap-2">
         <div class="flex rounded-lg border border-gray-200 bg-white p-0.5">

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -43,7 +43,7 @@
       >
         <p class="text-[11px] font-semibold text-gray-400 uppercase tracking-[0.12em]">{{ card.title }}</p>
         <div class="flex items-end gap-1 mt-2.5">
-          <p class="text-[26px] leading-none font-extrabold text-gray-900 tracking-tight">{{ card.value }}</p>
+          <p class="text-[26px] leading-none font-extrabold tracking-tight" :class="card.colorClass ?? 'text-gray-900'">{{ card.value }}</p>
           <span v-if="card.unit" class="text-sm text-gray-400 mb-0.5">{{ card.unit }}</span>
         </div>
         <p class="text-xs text-gray-500 mt-3">{{ card.sub }}</p>
@@ -205,8 +205,8 @@ const summaryCards = computed(() => {
   const { totalAmount, momPct, abnormalCount, topProduct } = summary.value
   const periodLabel = periodOptions.find((p) => p.value === period.value)?.label ?? ''
   return [
-    { title: '총 발주 금액', value: `₩${Math.round(totalAmount).toLocaleString()}`, unit: '', sub: `${periodLabel} · 선택 구간 합계` },
-    { title: '전 기간 대비', value: `${momPct >= 0 ? '+' : ''}${momPct.toFixed(1)}`, unit: '%', sub: '직전 동일 길이 구간 대비 변동률' },
+    { title: '총 발주 금액', value: `₩ ${Math.round(totalAmount).toLocaleString()}`, unit: '', sub: `${periodLabel} · 선택 구간 합계` },
+    { title: '전 기간 대비', value: `${momPct >= 0 ? '+' : ''}${momPct.toFixed(1)}`, unit: '%', sub: '직전 동일 길이 구간 대비 변동률', colorClass: momPct >= 0 ? 'text-green-600' : 'text-red-500' },
     { title: '이상 발주 건수', value: String(abnormalCount), unit: '건', sub: '선택 구간 내 이상 플래그 합계' },
     { title: '최다 발주 품목', value: topProduct, unit: '', sub: '금액 기준 상위 1개 품목' },
   ]

--- a/frontend/src/views/StoreView.vue
+++ b/frontend/src/views/StoreView.vue
@@ -7,7 +7,7 @@
 
       </div>
       <button @click="openModal(null)"
-              class="bg-[#F37321] text-white px-4 py-2 text-sm font-semibold rounded-lg hover:bg-[#e0661d] transition-colors flex items-center gap-2 shadow-sm">
+              class="bg-[#F37321] text-white px-4 py-2 text-sm font-semibold rounded-lg hover:bg-[#e0661d] transition-colors flex items-center gap-2 shadow-sm cursor-pointer">
         <Plus class="w-4 h-4" /> 신규 가맹점 등록
       </button>
     </div>
@@ -45,7 +45,7 @@
           />
         </div>
         <button @click="handleSearch"
-                class="px-4 py-2 bg-white border border-gray-300 text-gray-600 text-sm font-bold rounded-lg hover:bg-gray-50 hover:border-gray-400 transition-colors shadow-sm whitespace-nowrap">
+                class="px-4 py-2 bg-white border border-gray-300 text-gray-600 text-sm font-bold rounded-lg hover:bg-gray-50 hover:border-gray-400 transition-colors shadow-sm whitespace-nowrap cursor-pointer">
           검색
         </button>
       </div>
@@ -53,13 +53,13 @@
       <div class="flex items-center gap-3">
         <div class="relative">
           <button @click="toggleDropdown('region')"
-                  class="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm font-bold text-gray-700 hover:border-gray-300 transition-all shadow-sm min-w-[120px] justify-between">
+                  class="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm font-bold text-gray-700 hover:border-gray-300 transition-all shadow-sm min-w-[120px] justify-between cursor-pointer">
             <span>지역: {{ filterRegion }}</span>
             <ChevronDown class="w-4 h-4 text-gray-400 transition-transform" :class="{ 'rotate-180': activeDropdown === 'region' }" />
           </button>
           <div v-if="activeDropdown === 'region'" class="absolute right-0 mt-1 w-40 bg-white border border-gray-200 rounded-lg shadow-lg z-20 py-1 animate-in fade-in zoom-in-95 duration-100">
             <button v-for="r in regionChips" :key="r" @click="selectFilter('region', r)"
-                    class="w-full text-left px-4 py-2 text-sm hover:bg-gray-50 transition-colors"
+                    class="w-full text-left px-4 py-2 text-sm hover:bg-gray-50 transition-colors cursor-pointer"
                     :class="filterRegion === r ? 'text-[#F37321] font-bold' : 'text-gray-600'">
               {{ r }}
             </button>
@@ -68,13 +68,13 @@
 
         <div class="relative">
           <button @click="toggleDropdown('status')"
-                  class="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm font-bold text-gray-700 hover:border-gray-300 transition-all shadow-sm min-w-[120px] justify-between">
+                  class="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm font-bold text-gray-700 hover:border-gray-300 transition-all shadow-sm min-w-[120px] justify-between cursor-pointer">
             <span>상태: {{ filterStatus }}</span>
             <ChevronDown class="w-4 h-4 text-gray-400 transition-transform" :class="{ 'rotate-180': activeDropdown === 'status' }" />
           </button>
           <div v-if="activeDropdown === 'status'" class="absolute right-0 mt-1 w-40 bg-white border border-gray-200 rounded-lg shadow-lg z-20 py-1 animate-in fade-in zoom-in-95 duration-100">
             <button v-for="s in statusOptions" :key="s" @click="selectFilter('status', s)"
-                    class="w-full text-left px-4 py-2 text-sm hover:bg-gray-50 transition-colors"
+                    class="w-full text-left px-4 py-2 text-sm hover:bg-gray-50 transition-colors cursor-pointer"
                     :class="filterStatus === s ? 'text-[#F37321] font-bold' : 'text-gray-600'">
               {{ s }}
             </button>
@@ -126,7 +126,7 @@
           <td class="px-5 py-4">
             <div class="flex justify-center">
               <button @click.stop="openModal(store)"
-                      class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors">
+                      class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer">
                 수정
               </button>
             </div>
@@ -142,7 +142,7 @@
       <div class="relative bg-white rounded-lg w-full max-w-lg border border-gray-200 shadow-xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
         <div class="px-8 py-5 border-b border-gray-100 flex justify-between items-center bg-gray-50">
           <h3 class="font-bold text-gray-900 text-lg">가맹점 상세 정보</h3>
-          <button @click="showDetailModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl">✕</button>
+          <button @click="showDetailModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl cursor-pointer">✕</button>
         </div>
 
         <div class="p-8 space-y-5">
@@ -208,12 +208,12 @@
 
           <div class="pt-4 space-y-3">
             <button @click="downloadPdf"
-                    class="w-full flex items-center justify-center gap-2 py-3 rounded-lg bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] transition-colors shadow-sm">
+                    class="w-full flex items-center justify-center gap-2 py-3 rounded-lg bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] transition-colors shadow-sm cursor-pointer">
               <FileText class="w-4 h-4 text-white" />
               사업자 PDF 다운로드
             </button>
             <button @click="showDetailModal = false"
-                    class="w-full py-3 rounded-lg bg-gray-100 text-gray-600 text-sm font-bold hover:bg-gray-200 transition-colors">
+                    class="w-full py-3 rounded-lg bg-gray-100 text-gray-600 text-sm font-bold hover:bg-gray-200 transition-colors cursor-pointer">
               닫기
             </button>
           </div>
@@ -227,7 +227,7 @@
       <div class="relative bg-white rounded-lg w-full max-w-lg border border-gray-200 shadow-xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
         <div class="px-8 py-5 border-b border-gray-100 flex justify-between items-center bg-gray-50">
           <h3 class="font-bold text-gray-900 text-lg">{{ editTarget ? '가맹점 정보 수정' : '신규 가맹점 등록' }}</h3>
-          <button @click="showModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl">✕</button>
+          <button @click="showModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl cursor-pointer">✕</button>
         </div>
 
         <form @submit.prevent="saveStore" class="p-8 space-y-5">
@@ -306,9 +306,9 @@
           </div>
           <div class="flex gap-3 pt-4">
             <button type="button" @click="showModal = false"
-                    class="flex-1 py-3 rounded-lg border border-gray-200 text-sm font-bold text-gray-500 hover:bg-gray-50 transition-colors">취소</button>
+                    class="flex-1 py-3 rounded-lg border border-gray-200 text-sm font-bold text-gray-500 hover:bg-gray-50 transition-colors cursor-pointer">취소</button>
             <button type="submit"
-                    class="flex-1 py-3 rounded-lg bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] transition-colors shadow-sm">저장</button>
+                    class="flex-1 py-3 rounded-lg bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] transition-colors shadow-sm cursor-pointer">저장</button>
           </div>
         </form>
       </div>

--- a/frontend/src/views/StoreView.vue
+++ b/frontend/src/views/StoreView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-5 space-y-4 font-sans text-gray-900">
+  <div class="p-5 space-y-4">
     <!-- Header -->
     <div class="flex justify-between items-center">
       <div>
@@ -88,7 +88,7 @@
     <div class="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">
       <table class="w-full text-sm text-left">
         <thead>
-        <tr class="border-b border-gray-100 bg-gray-50/50">
+        <tr class="border-b border-gray-200 bg-gray-50">
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider w-16 text-center">IDX</th>
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">지점명</th>
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">점주명</th>
@@ -99,23 +99,23 @@
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">관리</th>
         </tr>
         </thead>
-        <tbody class="divide-y divide-gray-50">
+        <tbody class="divide-y divide-gray-100">
         <tr v-for="(store, index) in filteredStores" :key="store.id"
             @click="openDetail(store)"
-            class="hover:bg-gray-50/80 transition-colors cursor-pointer group"
+            class="hover:bg-gray-50/50 transition-colors cursor-pointer group"
             :class="{ 'bg-gray-50/40 opacity-70': store.closeDate }">
-          <td class="px-5 py-4 text-gray-400 text-xs font-mono text-center">{{ index + 1 }}</td>
-          <td class="px-5 py-4 font-bold text-gray-900 group-hover:text-[#F37321] transition-colors">
+          <td class="px-5 py-3.5 text-gray-400 text-xs font-mono text-center">{{ index + 1 }}</td>
+          <td class="px-5 py-3.5 font-bold text-gray-900 group-hover:text-[#F37321] transition-colors">
             <div class="flex items-center gap-2">
               {{ store.name }}
               <span v-if="store.closeDate" class="text-[9px] font-normal text-red-400 border border-red-200 px-1 rounded-lg italic">CLOSED</span>
             </div>
           </td>
-          <td class="px-5 py-4 text-gray-600">{{ store.owner }}</td>
-          <td class="px-5 py-4 text-gray-500 text-xs truncate max-w-[150px]">{{ store.email }}</td>
-          <td class="px-5 py-4 text-gray-500 text-xs">{{ store.region }}</td>
-          <td class="px-5 py-4 font-mono text-xs text-gray-400">{{ store.bizNumber }}</td>
-          <td class="px-5 py-4 text-center">
+          <td class="px-5 py-3.5 text-gray-600">{{ store.owner }}</td>
+          <td class="px-5 py-3.5 text-gray-500 text-xs truncate max-w-[150px]">{{ store.email }}</td>
+          <td class="px-5 py-3.5 text-gray-500 text-xs">{{ store.region }}</td>
+          <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ store.bizNumber }}</td>
+          <td class="px-5 py-3.5 text-center">
               <span class="text-[11px] font-bold px-2 py-0.5 rounded-lg"
                     :class="!store.closeDate
                   ? 'bg-green-100 text-green-700'
@@ -123,7 +123,7 @@
                 {{ store.closeDate ? '폐업' : '정상' }}
               </span>
           </td>
-          <td class="px-5 py-4">
+          <td class="px-5 py-3.5">
             <div class="flex justify-center">
               <button @click.stop="openModal(store)"
                       class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer">

--- a/frontend/src/views/StoreView.vue
+++ b/frontend/src/views/StoreView.vue
@@ -139,13 +139,13 @@
     <!-- 가맹점 상세 페이지 모달 -->
     <div v-if="showDetailModal" class="fixed inset-0 z-[60] flex items-center justify-center p-4">
       <div class="absolute inset-0 bg-black/40 " @click="showDetailModal = false"></div>
-      <div class="relative bg-white rounded-lg w-full max-w-lg border border-gray-200 shadow-xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
-        <div class="px-8 py-5 border-b border-gray-100 flex justify-between items-center bg-gray-50">
-          <h3 class="font-bold text-gray-900 text-lg">가맹점 상세 정보</h3>
-          <button @click="showDetailModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl cursor-pointer">✕</button>
+      <div class="relative bg-white rounded-xl w-full max-w-lg border border-gray-200 shadow-xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
+        <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+          <h3 class="font-bold text-gray-900">가맹점 상세 정보</h3>
+          <button @click="showDetailModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
 
-        <div class="p-8 space-y-5">
+        <div class="p-6 space-y-4">
           <div class="space-y-1.5">
             <label class="text-[11px] font-bold text-gray-400 uppercase tracking-widest">지점명</label>
             <div class="w-full px-4 py-2 bg-gray-50 border border-gray-100 rounded-lg text-sm font-bold text-gray-900">
@@ -206,17 +206,17 @@
             </div>
           </div>
 
-          <div class="pt-4 space-y-3">
+          <div class="pt-2">
             <button @click="downloadPdf"
                     class="w-full flex items-center justify-center gap-2 py-3 rounded-lg bg-[#F37321] text-white text-sm font-bold hover:bg-[#e0661d] transition-colors shadow-sm cursor-pointer">
               <FileText class="w-4 h-4 text-white" />
               사업자 PDF 다운로드
             </button>
-            <button @click="showDetailModal = false"
-                    class="w-full py-3 rounded-lg bg-gray-100 text-gray-600 text-sm font-bold hover:bg-gray-200 transition-colors cursor-pointer">
-              닫기
-            </button>
           </div>
+        </div>
+        <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
+          <button @click="showDetailModal = false"
+                  class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">닫기</button>
         </div>
       </div>
     </div>

--- a/frontend/src/views/StoreView.vue
+++ b/frontend/src/views/StoreView.vue
@@ -126,9 +126,8 @@
           <td class="px-5 py-4">
             <div class="flex justify-center">
               <button @click.stop="openModal(store)"
-                      class="text-gray-300 hover:text-[#F37321] transition-colors"
-                      title="수정">
-                <Pencil class="w-4 h-4" />
+                      class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors">
+                수정
               </button>
             </div>
           </td>
@@ -319,7 +318,7 @@
 
 <script setup>
 import { ref, computed } from 'vue'
-import { Plus, Pencil, Search, FileText, ChevronDown } from 'lucide-vue-next'
+import { Plus, Search, FileText, ChevronDown } from 'lucide-vue-next'
 
 const searchQuery = ref('')
 const filterRegion = ref('전체')

--- a/frontend/src/views/StoreView.vue
+++ b/frontend/src/views/StoreView.vue
@@ -89,7 +89,6 @@
       <table class="w-full text-sm text-left">
         <thead>
         <tr class="border-b border-gray-200 bg-gray-50">
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider w-16 text-center">IDX</th>
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">지점명</th>
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">점주명</th>
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">이메일</th>
@@ -104,7 +103,6 @@
             @click="openDetail(store)"
             class="hover:bg-gray-50/50 transition-colors cursor-pointer group"
             :class="{ 'bg-gray-50/40 opacity-70': store.closeDate }">
-          <td class="px-5 py-3.5 text-gray-400 text-xs font-mono text-center">{{ index + 1 }}</td>
           <td class="px-5 py-3.5 font-bold text-gray-900 group-hover:text-[#F37321] transition-colors">
             <div class="flex items-center gap-2">
               {{ store.name }}

--- a/frontend/src/views/hq/EsgDashboardView.vue
+++ b/frontend/src/views/hq/EsgDashboardView.vue
@@ -13,7 +13,7 @@
         :key="tab.value"
         type="button"
         @click="activeTab = tab.value"
-        class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px"
+        class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px cursor-pointer"
         :class="activeTab === tab.value
           ? 'border-[#F37321] text-[#F37321]'
           : 'border-transparent text-gray-500 hover:text-gray-700'"

--- a/frontend/src/views/hq/EsgDashboardView.vue
+++ b/frontend/src/views/hq/EsgDashboardView.vue
@@ -3,7 +3,6 @@
     <!-- Header -->
     <div>
       <h1 class="text-[22px] font-bold text-gray-900 tracking-tight">ESG 대시보드</h1>
-      <p class="text-sm text-gray-500 mt-1">폐기 최소화 및 재고 효율 지표를 확인합니다.</p>
     </div>
 
     <!-- 탭 -->

--- a/frontend/src/views/hq/HqNotificationView.vue
+++ b/frontend/src/views/hq/HqNotificationView.vue
@@ -39,9 +39,9 @@
           : 'bg-orange-50/40 border-orange-100 hover:bg-orange-50/70'"
       >
         <!-- Type badge -->
-        <div class="shrink-0 pt-0.5">
+        <div class="shrink-0 pt-0.5 w-18 flex items-start justify-center">
           <span
-            class="inline-block text-[11px] font-semibold px-2 py-0.5 rounded-full border"
+            class="text-[10px] font-bold px-2 py-0.5 rounded border whitespace-nowrap"
             :class="[typeConfig(n.type).color, typeConfig(n.type).bg, typeConfig(n.type).border]"
           >
             {{ typeConfig(n.type).label }}

--- a/frontend/src/views/hq/HqNotificationView.vue
+++ b/frontend/src/views/hq/HqNotificationView.vue
@@ -6,7 +6,7 @@
       <button
         v-if="unreadCount > 0"
         @click="store.markAllRead('ADMIN')"
-        class="text-sm text-[#F37321] hover:underline font-medium"
+        class="text-sm text-[#F37321] hover:underline font-medium cursor-pointer"
       >
         전체 읽음 처리
       </button>
@@ -18,7 +18,7 @@
         v-for="tab in tabs"
         :key="tab.value"
         @click="activeTab = tab.value"
-        class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px"
+        class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px cursor-pointer"
         :class="activeTab === tab.value
           ? 'border-[#F37321] text-[#F37321]'
           : 'border-transparent text-gray-500 hover:text-gray-700'"

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -13,7 +13,7 @@
         v-for="tab in tabs"
         :key="tab.value"
         @click="activeTab = tab.value"
-        class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px"
+        class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px cursor-pointer"
         :class="activeTab === tab.value
           ? 'border-[#F37321] text-[#F37321]'
           : 'border-transparent text-gray-500 hover:text-gray-700'"
@@ -55,7 +55,7 @@
             <td class="px-5 py-3.5 text-center">
               <button
                 @click="handleDownload(report)"
-                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer"
               >
                 <Download class="w-3.5 h-3.5" />
                 PDF
@@ -79,7 +79,7 @@
         v-for="news in newsSummaries"
         :key="news.idx"
         @click="selectedNews = news"
-        class="w-full bg-white rounded-lg border border-gray-200 p-4 flex items-start justify-between gap-4 hover:border-[#F37321] hover:bg-orange-50/20 transition-colors text-left"
+        class="w-full bg-white rounded-lg border border-gray-200 p-4 flex items-start justify-between gap-4 hover:border-[#F37321] hover:bg-orange-50/20 transition-colors text-left cursor-pointer"
       >
         <div class="flex items-start gap-3 min-w-0">
           <Newspaper class="w-4 h-4 text-[#F37321] shrink-0 mt-0.5" />
@@ -103,7 +103,7 @@
             <Newspaper class="w-4 h-4 text-[#F37321]" />
             <span class="font-bold text-gray-900 text-sm">{{ selectedNews.summary_title }}</span>
           </div>
-          <button @click="selectedNews = null" class="text-gray-400 hover:text-gray-700 transition-colors">
+          <button @click="selectedNews = null" class="text-gray-400 hover:text-gray-700 transition-colors cursor-pointer">
             <X class="w-5 h-5" />
           </button>
         </div>

--- a/frontend/src/views/hq/SalesStatisticsView.vue
+++ b/frontend/src/views/hq/SalesStatisticsView.vue
@@ -49,7 +49,7 @@
             :key="mode.value"
             type="button"
             @click="analysisMode = mode.value"
-            class="text-xs px-3 py-1.5 rounded-md font-semibold transition-colors"
+            class="text-xs px-3 py-1.5 rounded-md font-semibold transition-colors cursor-pointer"
             :class="analysisMode === mode.value ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
           >
             {{ mode.label }}
@@ -58,7 +58,7 @@
         <button
           type="button"
           @click="showFullList = true"
-          class="text-xs px-3 py-1.5 rounded-lg border border-gray-200 font-semibold text-gray-600 hover:bg-gray-50 transition-colors"
+          class="text-xs px-3 py-1.5 rounded-lg border border-gray-200 font-semibold text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
         >
           전체 목록 보기
         </button>
@@ -135,7 +135,7 @@
         <div class="relative bg-white rounded-2xl shadow-2xl w-full max-w-2xl mx-4 max-h-[80vh] flex flex-col overflow-hidden">
           <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100 shrink-0">
             <span class="font-bold text-gray-900 text-sm">{{ currentModeLabel }} 전체 매출 순위</span>
-            <button @click="showFullList = false" class="text-gray-400 hover:text-gray-700 transition-colors">
+            <button @click="showFullList = false" class="text-gray-400 hover:text-gray-700 transition-colors cursor-pointer">
               <X class="w-5 h-5" />
             </button>
           </div>

--- a/frontend/src/views/hq/SalesStatisticsView.vue
+++ b/frontend/src/views/hq/SalesStatisticsView.vue
@@ -129,12 +129,12 @@
     <Teleport to="body">
       <div v-if="showFullList" class="fixed inset-0 z-50 flex items-center justify-center">
         <div class="absolute inset-0 bg-black/40" @click="showFullList = false"></div>
-        <div class="relative bg-white rounded-xl shadow-xl w-full max-w-2xl mx-4 border border-gray-200">
-          <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+        <div class="relative bg-white rounded-xl shadow-xl w-full max-w-2xl mx-4 max-h-[85vh] flex flex-col overflow-hidden border border-gray-200">
+          <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
             <span class="font-bold text-gray-900">{{ currentModeLabel }} 전체 매출 순위</span>
             <button @click="showFullList = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
           </div>
-          <div>
+          <div class="overflow-y-auto flex-1">
             <table class="w-full text-sm">
               <thead class="sticky top-0 bg-gray-50 border-b border-gray-200">
                 <tr>
@@ -161,7 +161,7 @@
               </tbody>
             </table>
           </div>
-          <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
+          <div class="px-6 py-4 border-t border-gray-100 flex justify-end shrink-0">
             <button @click="showFullList = false"
               class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">닫기</button>
           </div>

--- a/frontend/src/views/hq/SalesStatisticsView.vue
+++ b/frontend/src/views/hq/SalesStatisticsView.vue
@@ -129,39 +129,41 @@
     <Teleport to="body">
       <div v-if="showFullList" class="fixed inset-0 z-50 flex items-center justify-center">
         <div class="absolute inset-0 bg-black/40" @click="showFullList = false"></div>
-        <div class="relative bg-white rounded-2xl shadow-2xl w-full max-w-2xl mx-4 max-h-[80vh] flex flex-col overflow-hidden">
-          <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100 shrink-0">
-            <span class="font-bold text-gray-900 text-sm">{{ currentModeLabel }} 전체 매출 순위</span>
-            <button @click="showFullList = false" class="text-gray-400 hover:text-gray-700 transition-colors cursor-pointer">
-              <X class="w-5 h-5" />
-            </button>
+        <div class="relative bg-white rounded-xl shadow-xl w-full max-w-2xl mx-4 border border-gray-200">
+          <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+            <span class="font-bold text-gray-900">{{ currentModeLabel }} 전체 매출 순위</span>
+            <button @click="showFullList = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
           </div>
-          <div class="overflow-y-auto flex-1">
+          <div>
             <table class="w-full text-sm">
-              <thead class="sticky top-0 bg-white border-b border-gray-100">
+              <thead class="sticky top-0 bg-gray-50 border-b border-gray-200">
                 <tr>
-                  <th class="text-left px-5 py-3 font-semibold text-gray-500 w-12">순위</th>
-                  <th class="text-left px-5 py-3 font-semibold text-gray-500">{{ currentModeLabel }}</th>
-                  <th class="text-right px-5 py-3 font-semibold text-gray-500">매출액</th>
-                  <th class="text-right px-5 py-3 font-semibold text-gray-500 w-20">비중</th>
+                  <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center whitespace-nowrap">순위</th>
+                  <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">{{ currentModeLabel }}</th>
+                  <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">매출액</th>
+                  <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">비중</th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-gray-50">
+              <tbody class="divide-y divide-gray-100">
                 <tr
                   v-for="(item, i) in rankingData"
                   :key="item.label"
                   class="hover:bg-gray-50/50 transition-colors"
                 >
-                  <td class="px-5 py-3 text-gray-400">{{ i + 1 }}</td>
-                  <td class="px-5 py-3 font-medium text-gray-800">{{ item.label }}</td>
-                  <td class="px-5 py-3 text-right text-gray-800">₩{{ item.amount.toLocaleString() }}</td>
-                  <td class="px-5 py-3 text-right text-gray-500">{{ item.pct.toFixed(1) }}%</td>
+                  <td class="px-5 py-3.5 text-center text-gray-400">{{ i + 1 }}</td>
+                  <td class="px-5 py-3.5 text-center font-semibold text-gray-900">{{ item.label }}</td>
+                  <td class="px-5 py-3.5 text-center font-semibold text-gray-700">₩ {{ item.amount.toLocaleString() }}</td>
+                  <td class="px-5 py-3.5 text-center text-gray-500">{{ item.pct.toFixed(1) }}%</td>
                 </tr>
                 <tr v-if="rankingData.length === 0">
                   <td colspan="4" class="px-5 py-12 text-center text-gray-400">데이터 없음</td>
                 </tr>
               </tbody>
             </table>
+          </div>
+          <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
+            <button @click="showFullList = false"
+              class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">닫기</button>
           </div>
         </div>
       </div>
@@ -171,7 +173,6 @@
 
 <script setup>
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
-import { X } from 'lucide-vue-next'
 import { Chart } from 'chart.js/auto'
 import { rawOrders } from '@/utils/orderData'
 

--- a/frontend/src/views/hq/SalesStatisticsView.vue
+++ b/frontend/src/views/hq/SalesStatisticsView.vue
@@ -3,9 +3,6 @@
     <div class="flex flex-wrap items-start justify-between gap-4">
       <div>
         <h1 class="text-[22px] font-bold text-gray-900 tracking-tight">판매/매출 분석</h1>
-        <p class="text-sm text-gray-500 mt-1">
-          가맹점·제품·카테고리 기준 매출 현황을 분석합니다.
-        </p>
       </div>
       <div class="flex flex-wrap items-center gap-2">
         <select


### PR DESCRIPTION
## Summary
- 상세 모달창 디자인을 발주 관리 기준으로 통일 (rounded-xl, 헤더/푸터 구조, X 버튼, 닫기 버튼)
- 금액 표시 형식을 ₩ + 공백 형태로 전체 통일 (발주 관리, 정산 관리, 판매/매출 분석)
- 수정/삭제 버튼 스타일 타 페이지와 통일 (계정 관리, 가맹점 관리)
- 재고 관리 필터 버튼 및 드롭다운 rounded-lg 적용
- 알림 페이지 뱃지 스타일 개선 및 정렬 통일
- 가맹점 관리 IDX 컬럼 제거, 사이드바 메뉴명 띄어쓰기 수정
- 각 페이지 상단 설명 텍스트 제거 (계정 관리, 발주 통계, 판매/매출 분석, ESG 대시보드)
- 발주 통계 전 기간 대비 수치 색상 적용 (증가 초록, 감소 빨강)

## Test plan
- [ ] 모든 상세 모달창 열고 닫기 확인 (닫기 버튼, X 버튼, 배경 클릭)
- [ ] 재고 관리 본사/가맹점 페이지 필터 버튼 및 드롭다운 스타일 확인
- [ ] 발주 관리, 정산 관리, 판매/매출 분석 금액 표시 확인
- [ ] 알림 페이지 뱃지 정렬 확인
- [ ] 판매/매출 분석 전체 목록 보기 모달 확인

## Issue
Closes #266
