### PR TITLE
[Refactor] 점주 페이지 UI 개선 및 본사 페이지와 디자인 통일

### DIFF
--- a/frontend/src/views/hq/HqNotificationView.vue
+++ b/frontend/src/views/hq/HqNotificationView.vue
@@ -29,19 +29,19 @@
 
     <!-- List -->
     <div v-if="filtered.length > 0" class="flex flex-col gap-2">
-      <div
+      <button
         v-for="n in filtered"
         :key="n.id"
         @click="store.markRead(n.id)"
-        class="flex gap-3 p-4 rounded-lg border cursor-pointer transition-colors"
+        class="w-full flex gap-3 p-4 rounded-lg border transition-colors text-left"
         :class="n.read
           ? 'bg-white border-gray-100 hover:bg-gray-50'
           : 'bg-orange-50/40 border-orange-100 hover:bg-orange-50/70'"
       >
         <!-- Type badge -->
-        <div class="shrink-0 pt-0.5 w-18 flex items-start justify-center">
+        <div class="shrink-0 pt-0.5">
           <span
-            class="text-[10px] font-bold px-2 py-0.5 rounded border whitespace-nowrap"
+            class="inline-block text-[11px] font-semibold px-2 py-0.5 rounded-full border"
             :class="[typeConfig(n.type).color, typeConfig(n.type).bg, typeConfig(n.type).border]"
           >
             {{ typeConfig(n.type).label }}
@@ -57,7 +57,7 @@
           <p class="text-sm text-gray-600 leading-snug">{{ n.body }}</p>
           <p class="text-xs text-gray-400 mt-1">{{ store.relativeTime(n.time) }}</p>
         </div>
-      </div>
+      </button>
     </div>
 
     <!-- Empty -->

--- a/frontend/src/views/store/PosView.vue
+++ b/frontend/src/views/store/PosView.vue
@@ -313,12 +313,10 @@
     <!-- ── 결제 모달 ──────────────────────────────────── -->
     <div v-if="showPaymentModal"
       class="fixed inset-0 bg-gray-900/40 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-md border border-gray-100">
-        <div class="border-b border-gray-100 p-5 flex justify-between items-center bg-gray-50 rounded-t-2xl">
+      <div class="bg-white rounded-xl border border-gray-200 shadow-xl w-full max-w-md">
+        <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
           <h2 class="text-lg font-bold text-gray-800">결제 수단 선택</h2>
-          <button @click="showPaymentModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">
-            <X class="w-5 h-5" />
-          </button>
+          <button @click="showPaymentModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
         <div class="p-8">
           <div class="text-center mb-8">
@@ -344,7 +342,7 @@
     <!-- ── 마감 확인 모달 ─────────────────────────────── -->
     <div v-if="showCloseModal"
       class="fixed inset-0 bg-gray-900/40 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-sm border border-gray-100 text-center p-8">
+      <div class="bg-white rounded-xl border border-gray-200 shadow-xl w-full max-w-sm text-center p-8">
         <div class="w-16 h-16 bg-red-50 rounded-full flex items-center justify-center mx-auto mb-5">
           <AlertCircle class="w-8 h-8 text-red-500" />
         </div>

--- a/frontend/src/views/store/PosView.vue
+++ b/frontend/src/views/store/PosView.vue
@@ -8,13 +8,13 @@
         <div class="flex border border-gray-200">
           <button
             @click="activeTab = 'order'"
-            :class="['px-4 py-2 text-sm font-semibold transition-all flex items-center gap-2',
+            :class="['px-4 py-2 text-sm font-semibold transition-all flex items-center gap-2 cursor-pointer',
               activeTab === 'order' ? 'bg-gray-900 text-white' : 'bg-white text-gray-500 hover:bg-gray-50']">
             <ShoppingCart class="w-4 h-4" /> 주문 및 결제
           </button>
           <button
             @click="activeTab = 'settlement'"
-            :class="['px-4 py-2 text-sm font-semibold transition-all flex items-center gap-2 border-l border-gray-200',
+            :class="['px-4 py-2 text-sm font-semibold transition-all flex items-center gap-2 border-l border-gray-200 cursor-pointer',
               activeTab === 'settlement' ? 'bg-gray-900 text-white' : 'bg-white text-gray-500 hover:bg-gray-50']">
             <TrendingUp class="w-4 h-4" /> 일일 마감 (정산)
           </button>
@@ -55,7 +55,7 @@
               v-model="searchQuery"
               placeholder="상품명 검색..."
               class="bg-transparent border-none outline-none text-sm w-full text-gray-700" />
-            <button v-if="searchQuery" @click="searchQuery = ''" class="text-gray-400 hover:text-gray-600 ml-1">
+            <button v-if="searchQuery" @click="searchQuery = ''" class="text-gray-400 hover:text-gray-600 ml-1 cursor-pointer">
               <XCircle class="w-4 h-4" />
             </button>
           </div>
@@ -64,7 +64,7 @@
           <div class="flex gap-2 overflow-x-auto pb-1">
             <button v-for="cat in categories" :key="cat"
               @click="selectedCategory = cat"
-              :class="['px-5 py-2 rounded-full text-sm font-semibold whitespace-nowrap transition-all border shrink-0',
+              :class="['px-5 py-2 rounded-full text-sm font-semibold whitespace-nowrap transition-all border shrink-0 cursor-pointer',
                 selectedCategory === cat
                   ? 'bg-gray-800 text-white border-gray-800 shadow-sm'
                   : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50']">
@@ -114,7 +114,7 @@
             <ShoppingCart class="w-4 h-4 text-gray-500" /> 현재 주문 내역
           </h2>
           <button @click="clearCart"
-            class="text-xs text-gray-500 hover:text-red-500 border border-gray-200 px-3 py-1.5 rounded-md hover:bg-red-50 hover:border-red-100 transition-colors">
+            class="text-xs text-gray-500 hover:text-red-500 border border-gray-200 px-3 py-1.5 rounded-md hover:bg-red-50 hover:border-red-100 transition-colors cursor-pointer">
             전체 삭제
           </button>
         </div>
@@ -133,7 +133,7 @@
             class="bg-white border border-gray-200 p-4">
             <div class="flex justify-between items-start mb-3">
               <span class="font-semibold text-gray-900 text-sm leading-tight">{{ item.name }}</span>
-              <button @click="removeFromCart(item.id)" class="text-gray-300 hover:text-red-500 transition-colors ml-2 shrink-0">
+              <button @click="removeFromCart(item.id)" class="text-gray-300 hover:text-red-500 transition-colors ml-2 shrink-0 cursor-pointer">
                 <X class="w-4 h-4" />
               </button>
             </div>
@@ -142,12 +142,12 @@
               <!-- 수량 조절 -->
               <div class="flex items-center border border-gray-200 rounded-lg overflow-hidden">
                 <button @click="decreaseQty(item)"
-                  class="w-8 h-7 flex items-center justify-center bg-gray-50 text-gray-600 hover:bg-gray-100 hover:text-blue-500 transition-colors">
+                  class="w-8 h-7 flex items-center justify-center bg-gray-50 text-gray-600 hover:bg-gray-100 hover:text-blue-500 transition-colors cursor-pointer">
                   <Minus class="w-3 h-3" />
                 </button>
                 <span class="w-9 h-7 flex items-center justify-center text-xs font-bold text-gray-800 border-x border-gray-200">{{ item.quantity }}</span>
                 <button @click="increaseQty(item)"
-                  class="w-8 h-7 flex items-center justify-center bg-gray-50 text-gray-600 hover:bg-gray-100 hover:text-blue-500 transition-colors">
+                  class="w-8 h-7 flex items-center justify-center bg-gray-50 text-gray-600 hover:bg-gray-100 hover:text-blue-500 transition-colors cursor-pointer">
                   <Plus class="w-3 h-3" />
                 </button>
               </div>
@@ -169,7 +169,7 @@
           <button @click="openPaymentModal"
             :disabled="cart.length === 0 || salesData.isClosed"
             :class="['w-full py-3.5 rounded-xl font-bold text-sm flex items-center justify-center gap-2 transition-all text-white shadow-sm',
-              (cart.length === 0 || salesData.isClosed) ? 'bg-gray-200 text-gray-400 cursor-not-allowed shadow-none' : 'bg-blue-500 hover:bg-blue-600 active:scale-[0.98]']">
+              (cart.length === 0 || salesData.isClosed) ? 'bg-gray-200 text-gray-400 cursor-not-allowed shadow-none' : 'bg-blue-500 hover:bg-blue-600 active:scale-[0.98] cursor-pointer']">
             {{ salesData.isClosed ? '마감됨 — 주문 불가' : '결제 진행하기' }}
           </button>
         </div>
@@ -186,7 +186,7 @@
 
         <!-- 마감 / 영업 시작 버튼 -->
         <button @click="toggleStoreStatus"
-          :class="['text-sm px-6 py-2.5 rounded-lg font-bold transition-all shadow-sm text-white',
+          :class="['text-sm px-6 py-2.5 rounded-lg font-bold transition-all shadow-sm text-white cursor-pointer',
             salesData.isClosed ? 'bg-blue-500 hover:bg-blue-600 ring-4 ring-blue-100' : 'bg-gray-800 hover:bg-gray-700']">
           {{ salesData.isClosed ? '새로운 영업 시작하기' : '영업 마감하기' }}
         </button>
@@ -316,7 +316,7 @@
       <div class="bg-white rounded-2xl shadow-xl w-full max-w-md border border-gray-100">
         <div class="border-b border-gray-100 p-5 flex justify-between items-center bg-gray-50 rounded-t-2xl">
           <h2 class="text-lg font-bold text-gray-800">결제 수단 선택</h2>
-          <button @click="showPaymentModal = false" class="text-gray-400 hover:text-gray-600">
+          <button @click="showPaymentModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">
             <X class="w-5 h-5" />
           </button>
         </div>
@@ -327,12 +327,12 @@
           </div>
           <div class="grid grid-cols-2 gap-4">
             <button @click="processPayment('card')"
-              class="flex flex-col items-center justify-center p-6 border border-gray-200 rounded-xl hover:border-blue-400 hover:bg-blue-50 transition-all group shadow-sm hover:shadow-md">
+              class="flex flex-col items-center justify-center p-6 border border-gray-200 rounded-xl hover:border-blue-400 hover:bg-blue-50 transition-all group shadow-sm hover:shadow-md cursor-pointer">
               <CreditCard class="w-10 h-10 text-gray-400 group-hover:text-blue-500 mb-3 transition-colors" />
               <span class="font-semibold text-gray-700 group-hover:text-blue-600">신용카드</span>
             </button>
             <button @click="processPayment('cash')"
-              class="flex flex-col items-center justify-center p-6 border border-gray-200 rounded-xl hover:border-emerald-400 hover:bg-emerald-50 transition-all group shadow-sm hover:shadow-md">
+              class="flex flex-col items-center justify-center p-6 border border-gray-200 rounded-xl hover:border-emerald-400 hover:bg-emerald-50 transition-all group shadow-sm hover:shadow-md cursor-pointer">
               <Banknote class="w-10 h-10 text-gray-400 group-hover:text-emerald-500 mb-3 transition-colors" />
               <span class="font-semibold text-gray-700 group-hover:text-emerald-600">현금</span>
             </button>
@@ -357,11 +357,11 @@
         </p>
         <div class="flex gap-3">
           <button @click="showCloseModal = false"
-            class="flex-1 py-3 bg-white border border-gray-200 text-gray-600 rounded-xl text-sm font-bold hover:bg-gray-50 transition-colors">
+            class="flex-1 py-3 bg-white border border-gray-200 text-gray-600 rounded-xl text-sm font-bold hover:bg-gray-50 transition-colors cursor-pointer">
             취소
           </button>
           <button @click="confirmClose"
-            class="flex-1 py-3 bg-red-500 text-white rounded-xl text-sm font-bold hover:bg-red-600 shadow-sm transition-colors">
+            class="flex-1 py-3 bg-red-500 text-white rounded-xl text-sm font-bold hover:bg-red-600 shadow-sm transition-colors cursor-pointer">
             마감 승인
           </button>
         </div>

--- a/frontend/src/views/store/PosView.vue
+++ b/frontend/src/views/store/PosView.vue
@@ -34,10 +34,6 @@
       </div>
     </div>
 
-    <p class="px-6 py-2 border-b border-gray-100 bg-gray-50/80 text-[11px] text-gray-500 leading-relaxed shrink-0">
-      <code class="font-mono text-gray-400">MENU_001 · PAY_001~002 · CLOSED_001</code>
-      메뉴·카테고리·검색, 장바구니 결제, 일일 마감 시 본사로 판매·재고 데이터 전송 및 전산 재고 차감에 연동됩니다.
-    </p>
 
     <!-- ── 주문/결제 탭 ─────────────────────────────── -->
     <div v-if="activeTab === 'order'" class="flex-1 flex overflow-hidden">
@@ -372,7 +368,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import {
-  ShoppingCart, ShoppingBag,
+  ShoppingCart, ShoppingBag, TrendingUp,
   Search, XCircle, X, Minus, Plus,
   CreditCard, Banknote,
   CheckCircle, AlertCircle,

--- a/frontend/src/views/store/PosView.vue
+++ b/frontend/src/views/store/PosView.vue
@@ -235,7 +235,7 @@
           </div>
           <table class="w-full text-sm">
             <thead class="bg-gray-50 text-xs text-gray-500 uppercase">
-              <tr>
+              <tr class="border-b border-gray-200">
                 <th class="px-5 py-3 text-left">수단</th>
                 <th class="px-5 py-3 text-center">비율</th>
                 <th class="px-5 py-3 text-right">금액</th>
@@ -269,7 +269,7 @@
           <div class="overflow-auto flex-1">
             <table class="w-full text-sm">
               <thead class="bg-gray-50 text-xs text-gray-500 uppercase sticky top-0">
-                <tr>
+                <tr class="border-b border-gray-200">
                   <th class="px-6 py-3 text-left">결제 시간</th>
                   <th class="px-6 py-3 text-left">주문 내역</th>
                   <th class="px-6 py-3 text-center">결제 수단</th>

--- a/frontend/src/views/store/PosView.vue
+++ b/frontend/src/views/store/PosView.vue
@@ -446,7 +446,7 @@ const totalQuantity = computed(() => cart.value.reduce((s, i) => s + i.quantity,
 
 // ── 유틸 ──────────────────────────────────────────────
 function formatPrice(price) {
-  return price.toLocaleString() + '원'
+  return '₩ ' + price.toLocaleString()
 }
 
 function showToastMsg(msg) {

--- a/frontend/src/views/store/StoreDashboardView.vue
+++ b/frontend/src/views/store/StoreDashboardView.vue
@@ -101,7 +101,7 @@
               @keydown.enter="router.push('/store-order')">
               <td class="px-5 py-3.5 font-semibold text-gray-800">{{ o.product }}</td>
               <td class="px-5 py-3.5 text-right text-gray-600">{{ o.qty.toLocaleString() }}개</td>
-              <td class="px-5 py-3.5 text-right font-semibold text-gray-700">{{ (o.qty * o.unitPrice).toLocaleString() }}원</td>
+              <td class="px-5 py-3.5 text-right font-semibold text-gray-700">₩ {{ (o.qty * o.unitPrice).toLocaleString() }}</td>
               <td class="px-5 py-3.5 text-right">
                 <span class="text-xs font-bold px-2 py-0.5 rounded bg-blue-50 text-blue-600 border border-blue-200">제안중</span>
               </td>

--- a/frontend/src/views/store/StoreDashboardView.vue
+++ b/frontend/src/views/store/StoreDashboardView.vue
@@ -86,23 +86,23 @@
         </div>
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b border-gray-100 bg-gray-50">
-              <th class="px-5 py-2.5 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
-              <th class="px-5 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">제안 수량</th>
-              <th class="px-5 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">금액</th>
-              <th class="px-5 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
+            <tr class="border-b border-gray-200 bg-gray-50">
+              <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
+              <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">제안 수량</th>
+              <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">금액</th>
+              <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-50">
+          <tbody class="divide-y divide-gray-100">
             <tr v-for="o in pendingOrders" :key="o.id"
               class="hover:bg-gray-50/50 cursor-pointer"
               role="button" tabindex="0"
               @click="router.push('/store-order')"
               @keydown.enter="router.push('/store-order')">
-              <td class="px-5 py-3 font-semibold text-gray-800">{{ o.product }}</td>
-              <td class="px-5 py-3 text-right text-gray-600">{{ o.qty.toLocaleString() }}개</td>
-              <td class="px-5 py-3 text-right font-semibold text-gray-700">{{ (o.qty * o.unitPrice).toLocaleString() }}원</td>
-              <td class="px-5 py-3 text-right">
+              <td class="px-5 py-3.5 font-semibold text-gray-800">{{ o.product }}</td>
+              <td class="px-5 py-3.5 text-right text-gray-600">{{ o.qty.toLocaleString() }}개</td>
+              <td class="px-5 py-3.5 text-right font-semibold text-gray-700">{{ (o.qty * o.unitPrice).toLocaleString() }}원</td>
+              <td class="px-5 py-3.5 text-right">
                 <span class="text-xs font-bold px-2 py-0.5 rounded bg-blue-50 text-blue-600 border border-blue-200">제안중</span>
               </td>
             </tr>
@@ -117,23 +117,23 @@
         </div>
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b border-gray-100 bg-gray-50">
-              <th class="px-5 py-2.5 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
-              <th class="px-5 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">현재 재고</th>
-              <th class="px-5 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">최소 재고</th>
-              <th class="px-5 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
+            <tr class="border-b border-gray-200 bg-gray-50">
+              <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
+              <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">현재 재고</th>
+              <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">최소 재고</th>
+              <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-50">
+          <tbody class="divide-y divide-gray-100">
             <tr v-for="w in warnings" :key="w.product"
               class="hover:bg-gray-50/50 cursor-pointer"
               role="button" tabindex="0"
               @click="router.push('/store-inventory')"
               @keydown.enter="router.push('/store-inventory')">
-              <td class="px-5 py-3 font-semibold text-gray-800">{{ w.product }}</td>
-              <td class="px-5 py-3 text-right font-bold text-red-600">{{ w.current }}</td>
-              <td class="px-5 py-3 text-right text-gray-400">{{ w.min }}</td>
-              <td class="px-5 py-3 text-right">
+              <td class="px-5 py-3.5 font-semibold text-gray-800">{{ w.product }}</td>
+              <td class="px-5 py-3.5 text-right font-bold text-red-600">{{ w.current }}</td>
+              <td class="px-5 py-3.5 text-right text-gray-400">{{ w.min }}</td>
+              <td class="px-5 py-3.5 text-right">
                 <span class="text-xs font-bold px-2 py-0.5 rounded"
                   :class="w.danger ? 'bg-red-50 text-red-600 border border-red-200' : 'bg-orange-50 text-orange-600 border border-orange-200'">
                   {{ w.danger ? '위험' : '주의' }}

--- a/frontend/src/views/store/StoreDeliveryView.vue
+++ b/frontend/src/views/store/StoreDeliveryView.vue
@@ -118,12 +118,10 @@
     </div>
 
     <div v-if="isModalOpen" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-gray-900/40 backdrop-blur-sm" @click="closeModal">
-      <div class="bg-white rounded-lg shadow-xl w-full max-w-sm overflow-hidden" @click.stop>
-        <div class="px-5 py-4 border-b border-red-100 bg-red-50 flex justify-between items-center">
+      <div class="bg-white rounded-xl border border-gray-200 shadow-xl w-full max-w-sm overflow-hidden" @click.stop>
+        <div class="px-6 py-4 border-b border-red-100 bg-red-50 flex justify-between items-center">
           <h3 class="text-base font-bold text-red-700">배송 지연 안내</h3>
-          <button @click="closeModal" class="text-red-400 hover:text-red-600 transition-colors">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
-          </button>
+          <button @click="closeModal" class="text-red-400 hover:text-red-600 cursor-pointer">✕</button>
         </div>
         <div class="p-6 space-y-4">
           <div class="flex flex-col gap-1">
@@ -141,8 +139,8 @@
             </div>
           </div>
         </div>
-        <div class="px-6 py-4 bg-gray-50 flex justify-end border-t border-gray-100">
-          <button @click="closeModal" class="px-4 py-2 bg-blue-500 text-white text-sm font-bold hover:bg-blue-600 rounded transition-colors shadow-sm">
+        <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
+          <button @click="closeModal" class="px-4 py-2 bg-blue-500 text-white text-sm font-bold hover:bg-blue-600 rounded cursor-pointer transition-colors shadow-sm">
             확인
           </button>
         </div>

--- a/frontend/src/views/store/StoreDeliveryView.vue
+++ b/frontend/src/views/store/StoreDeliveryView.vue
@@ -45,7 +45,7 @@
       <div class="flex gap-2 flex-wrap pt-1">
         <button v-for="f in filterOptions" :key="f"
                 @click="currentFilter = f"
-                class="px-3.5 py-1.5 text-sm font-semibold border rounded-md transition-colors cursor-pointer"
+                class="px-3.5 py-1.5 text-sm font-semibold border rounded-lg transition-colors cursor-pointer"
                 :class="currentFilter === f
             ? 'bg-blue-500 text-white border-blue-500 shadow-sm'
             : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'">

--- a/frontend/src/views/store/StoreDeliveryView.vue
+++ b/frontend/src/views/store/StoreDeliveryView.vue
@@ -45,7 +45,7 @@
       <div class="flex gap-2 flex-wrap pt-1">
         <button v-for="f in filterOptions" :key="f"
                 @click="currentFilter = f"
-                class="px-3.5 py-1.5 text-sm font-semibold border rounded-md transition-colors"
+                class="px-3.5 py-1.5 text-sm font-semibold border rounded-md transition-colors cursor-pointer"
                 :class="currentFilter === f
             ? 'bg-blue-500 text-white border-blue-500 shadow-sm'
             : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'">

--- a/frontend/src/views/store/StoreInventoryView.vue
+++ b/frontend/src/views/store/StoreInventoryView.vue
@@ -107,14 +107,14 @@
           </div>
 
           <div class="shrink-0 px-6 py-4 border-t border-gray-100 flex justify-end gap-2">
-            <button type="button" class="flex-1 py-2.5 rounded-lg border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50" @click="closeDetail">
-              닫기
-            </button>
             <button type="button"
               class="flex-1 py-2.5 rounded-lg text-sm font-semibold text-white bg-blue-500 hover:bg-blue-600 disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
               :disabled="!hasDraftLotChanges"
               @click="applyLotAdjustments">
               lot 보정 반영
+            </button>
+            <button type="button" class="flex-1 py-2.5 rounded-lg border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50" @click="closeDetail">
+              닫기
             </button>
           </div>
         </div>

--- a/frontend/src/views/store/StoreInventoryView.vue
+++ b/frontend/src/views/store/StoreInventoryView.vue
@@ -53,8 +53,8 @@
         aria-modal="true"
         :aria-labelledby="detailTitleId"
         @click.self="closeDetail">
-        <div class="bg-white rounded-xl shadow-xl w-full max-w-lg border border-gray-100 max-h-[90vh] flex flex-col overflow-hidden">
-          <div class="px-5 py-4 border-b border-gray-100 flex justify-between items-center shrink-0 bg-gray-50/80">
+        <div class="bg-white rounded-xl shadow-xl w-full max-w-lg border border-gray-200 max-h-[85vh] flex flex-col overflow-hidden">
+          <div class="shrink-0 px-6 py-4 border-b border-gray-200 flex justify-between items-center">
             <div class="min-w-0 pr-2">
               <h2 :id="detailTitleId" class="text-base font-bold text-gray-900 truncate">{{ detailItem.name }}</h2>
               <p class="text-xs font-mono text-gray-500 mt-0.5">{{ detailItem.code }}</p>
@@ -62,12 +62,10 @@
                 합계 <span class="font-semibold text-gray-800">{{ totalStock(detailItem).toLocaleString() }}</span>
               </p>
             </div>
-            <button type="button" class="text-gray-400 hover:text-gray-600 p-1 rounded-md hover:bg-white shrink-0" aria-label="닫기" @click="closeDetail">
-              <X class="w-5 h-5" />
-            </button>
+            <button type="button" class="text-gray-400 hover:text-gray-600 cursor-pointer" aria-label="닫기" @click="closeDetail">✕</button>
           </div>
 
-          <div class="p-5 space-y-4 overflow-y-auto flex-1">
+          <div class="p-6 space-y-4 overflow-y-auto flex-1">
             <div>
               <p class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-1">최소 재고</p>
               <p class="text-sm text-gray-700">{{ detailItem.min.toLocaleString() }}</p>
@@ -108,7 +106,7 @@
             </div>
           </div>
 
-          <div class="flex gap-2 p-5 pt-0 shrink-0">
+          <div class="shrink-0 px-6 py-4 border-t border-gray-100 flex justify-end gap-2">
             <button type="button" class="flex-1 py-2.5 rounded-lg border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50" @click="closeDetail">
               닫기
             </button>

--- a/frontend/src/views/store/StoreNewsView.vue
+++ b/frontend/src/views/store/StoreNewsView.vue
@@ -44,21 +44,19 @@
     <Teleport to="body">
     <div v-if="selectedNews" class="fixed inset-0 z-50 flex items-center justify-center">
       <div class="absolute inset-0 bg-black/40" @click="selectedNews = null"></div>
-      <div class="relative bg-white rounded-2xl shadow-2xl w-full max-w-2xl mx-4 max-h-[80vh] flex flex-col overflow-hidden">
+      <div class="relative bg-white rounded-xl border border-gray-200 shadow-xl w-full max-w-2xl max-h-[85vh] flex flex-col overflow-hidden">
 
         <!-- 모달 헤더 -->
-        <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100 shrink-0">
+        <div class="shrink-0 flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div class="flex items-center gap-2">
             <Newspaper class="w-4 h-4 text-blue-500" />
             <span class="font-bold text-gray-900 text-sm">{{ selectedNews.summary_title }}</span>
           </div>
-          <button @click="selectedNews = null" class="text-gray-400 hover:text-gray-700 transition-colors">
-            <X class="w-5 h-5" />
-          </button>
+          <button @click="selectedNews = null" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
 
         <!-- 모달 내용 -->
-        <div class="overflow-y-auto px-6 py-5 flex flex-col gap-4">
+        <div class="flex-1 overflow-y-auto px-6 py-5 flex flex-col gap-4">
           <div class="flex items-center gap-2">
             <span
               class="text-[11px] font-semibold px-2 py-0.5 rounded-full border"
@@ -102,6 +100,10 @@
             </div>
           </div>
         </div>
+        <div class="shrink-0 px-6 py-4 border-t border-gray-100 flex justify-end">
+          <button @click="selectedNews = null"
+            class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">닫기</button>
+        </div>
       </div>
     </div>
     </Teleport>
@@ -110,7 +112,7 @@
 
 <script setup>
 import { ref } from 'vue'
-import { Newspaper, Lightbulb, ExternalLink, X } from 'lucide-vue-next'
+import { Newspaper, Lightbulb, ExternalLink } from 'lucide-vue-next'
 
 const selectedNews = ref(null)
 

--- a/frontend/src/views/store/StoreNotificationView.vue
+++ b/frontend/src/views/store/StoreNotificationView.vue
@@ -6,7 +6,7 @@
       <button
         v-if="unreadCount > 0"
         @click="store.markAllRead('STORE_OWNER')"
-        class="text-sm text-blue-600 hover:underline font-medium"
+        class="text-sm text-blue-600 hover:underline font-medium cursor-pointer"
       >
         전체 읽음 처리
       </button>
@@ -18,7 +18,7 @@
         v-for="tab in tabs"
         :key="tab.value"
         @click="activeTab = tab.value"
-        class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px"
+        class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px cursor-pointer"
         :class="activeTab === tab.value
           ? 'border-blue-500 text-blue-600'
           : 'border-transparent text-gray-500 hover:text-gray-700'"

--- a/frontend/src/views/store/StoreOrderView.vue
+++ b/frontend/src/views/store/StoreOrderView.vue
@@ -41,29 +41,29 @@
         </div>
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b border-gray-100 bg-gray-50">
-              <th class="px-5 py-2.5 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목명</th>
-              <th class="px-5 py-2.5 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">현재 재고</th>
-              <th class="px-5 py-2.5 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">최소 재고</th>
-              <th class="px-5 py-2.5 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">제안 수량</th>
-              <th class="px-5 py-2.5 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">수정 수량</th>
-              <th class="px-5 py-2.5 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider"></th>
+            <tr class="border-b border-gray-200 bg-gray-50">
+              <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목명</th>
+              <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">현재 재고</th>
+              <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">최소 재고</th>
+              <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">제안 수량</th>
+              <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">수정 수량</th>
+              <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider"></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-100">
             <tr v-for="item in order.items" :key="item.product" class="hover:bg-gray-50/50">
-              <td class="px-5 py-3 font-semibold text-gray-900">{{ item.product }}</td>
-              <td class="px-5 py-3 font-bold text-red-500">{{ item.current }}<span class="text-xs font-normal ml-0.5">{{ PRODUCT_UNIT[item.product] ?? '' }}</span></td>
-              <td class="px-5 py-3 text-gray-500">{{ item.min }}<span class="text-xs ml-0.5">{{ PRODUCT_UNIT[item.product] ?? '' }}</span></td>
-              <td class="px-5 py-3 font-semibold text-blue-600">{{ item.suggested }}<span class="text-xs font-normal ml-0.5">{{ PRODUCT_UNIT[item.product] ?? '' }}</span></td>
-              <td class="px-5 py-3">
+              <td class="px-5 py-3.5 font-semibold text-gray-900">{{ item.product }}</td>
+              <td class="px-5 py-3.5 font-bold text-red-500">{{ item.current }}<span class="text-xs font-normal ml-0.5">{{ PRODUCT_UNIT[item.product] ?? '' }}</span></td>
+              <td class="px-5 py-3.5 text-gray-500">{{ item.min }}<span class="text-xs ml-0.5">{{ PRODUCT_UNIT[item.product] ?? '' }}</span></td>
+              <td class="px-5 py-3.5 font-semibold text-blue-600">{{ item.suggested }}<span class="text-xs font-normal ml-0.5">{{ PRODUCT_UNIT[item.product] ?? '' }}</span></td>
+              <td class="px-5 py-3.5">
                 <div class="flex items-center gap-1.5">
                   <input v-model.number="item.adjusted" type="number" min="0"
                     class="w-20 px-2 py-1.5 rounded border border-gray-200 text-sm focus:border-blue-400 outline-none" />
                   <span class="text-xs text-gray-400 font-medium">{{ PRODUCT_UNIT[item.product] ?? '' }}</span>
                 </div>
               </td>
-              <td class="px-5 py-3">
+              <td class="px-5 py-3.5">
                 <button
                   @click="removeOrderItem(order, item)"
                   :disabled="order.items.length <= 1"

--- a/frontend/src/views/store/StoreOrderView.vue
+++ b/frontend/src/views/store/StoreOrderView.vue
@@ -47,6 +47,7 @@
               <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">최소 재고</th>
               <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">제안 수량</th>
               <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">수정 수량</th>
+              <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">금액</th>
               <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider"></th>
             </tr>
           </thead>
@@ -62,6 +63,9 @@
                     class="w-20 px-2 py-1.5 rounded border border-gray-200 text-sm focus:border-blue-400 outline-none" />
                   <span class="text-xs text-gray-400 font-medium">{{ PRODUCT_UNIT[item.product] ?? '' }}</span>
                 </div>
+              </td>
+              <td class="px-5 py-3.5 text-right font-semibold text-gray-700">
+                ₩ {{ ((item.adjusted || 0) * (PRODUCT_PRICES[item.product] ?? 0)).toLocaleString() }}
               </td>
               <td class="px-5 py-3.5">
                 <button
@@ -86,6 +90,7 @@
                 <input v-model.number="addItemForm.qty" type="number" min="1" placeholder="수량"
                   class="w-24 px-2 py-1.5 rounded border border-blue-200 text-sm outline-none focus:border-blue-400" />
               </td>
+              <td class="px-5 py-3 text-xs text-gray-400 text-right">—</td>
               <td class="px-5 py-3">
                 <div class="flex gap-1.5">
                   <button @click="confirmAddItem(order)"
@@ -100,6 +105,16 @@
               </td>
             </tr>
           </tbody>
+          <tfoot class="border-t border-gray-200 bg-gray-50/60">
+            <tr>
+              <td class="px-5 py-3 text-left text-xs font-bold text-gray-500">합계</td>
+              <td colspan="4"></td>
+              <td class="px-5 py-3 text-right font-black text-blue-600">
+                ₩ {{ orderTotal(order).toLocaleString() }}
+              </td>
+              <td></td>
+            </tr>
+          </tfoot>
         </table>
       </div>
 
@@ -436,6 +451,10 @@ function confirmAddItem(order) {
 function removeOrderItem(order, item) {
   const idx = order.items.indexOf(item)
   if (idx > -1) order.items.splice(idx, 1)
+}
+
+function orderTotal(order) {
+  return order.items.reduce((s, item) => s + (item.adjusted || 0) * (PRODUCT_PRICES[item.product] ?? 0), 0)
 }
 
 function rejectOrder(order) {

--- a/frontend/src/views/store/StoreOrderView.vue
+++ b/frontend/src/views/store/StoreOrderView.vue
@@ -75,7 +75,7 @@
             <tr v-if="addItemForm?.orderId === order.id" class="bg-blue-50/50 border-t border-blue-100">
               <td class="px-5 py-3" colspan="2">
                 <select v-model="addItemForm.product"
-                  class="w-full px-2 py-1.5 rounded border border-blue-200 text-sm outline-none focus:border-blue-400 bg-white">
+                  class="w-full px-2 py-1.5 rounded-lg border border-blue-200 text-sm outline-none focus:border-blue-400 bg-white">
                   <option value="">품목 선택</option>
                   <option v-for="p in availableProducts(order)" :key="p" :value="p">{{ p }}</option>
                 </select>

--- a/frontend/src/views/store/StoreOrderView.vue
+++ b/frontend/src/views/store/StoreOrderView.vue
@@ -140,7 +140,7 @@
                 <span v-if="h.items.length > 1" class="text-xs text-gray-400 font-normal"> 외 {{ h.items.length - 1 }}건</span>
               </td>
               <td class="px-5 py-3.5 font-semibold text-gray-700">
-                {{ h.items.reduce((s, i) => s + (PRODUCT_PRICES[i.product] ?? 0) * i.qty, 0).toLocaleString() }}원
+                ₩ {{ h.items.reduce((s, i) => s + (PRODUCT_PRICES[i.product] ?? 0) * i.qty, 0).toLocaleString() }}
               </td>
               <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ h.date }}</td>
               <td class="px-5 py-3.5">
@@ -204,15 +204,15 @@
                   <tr v-for="item in selectedHistory.items" :key="item.product">
                     <td class="px-4 py-2.5 text-gray-800 font-semibold">{{ item.product }}</td>
                     <td class="px-4 py-2.5 text-right text-gray-600">{{ item.qty.toLocaleString() }}개</td>
-                    <td class="px-4 py-2.5 text-right text-xs text-gray-500">{{ (PRODUCT_PRICES[item.product] ?? 0).toLocaleString() }}원</td>
-                    <td class="px-4 py-2.5 text-right font-bold text-blue-600">{{ ((PRODUCT_PRICES[item.product] ?? 0) * item.qty).toLocaleString() }}원</td>
+                    <td class="px-4 py-2.5 text-right text-xs text-gray-500">₩ {{ (PRODUCT_PRICES[item.product] ?? 0).toLocaleString() }}</td>
+                    <td class="px-4 py-2.5 text-right font-bold text-blue-600">₩ {{ ((PRODUCT_PRICES[item.product] ?? 0) * item.qty).toLocaleString() }}</td>
                   </tr>
                 </tbody>
                 <tfoot class="bg-gray-50 border-t border-gray-200">
                   <tr>
                     <td colspan="3" class="px-4 py-2.5 text-right text-xs font-bold text-gray-500">합계</td>
                     <td class="px-4 py-2.5 text-right font-black text-blue-600">
-                      {{ selectedHistory.items.reduce((s, i) => s + (PRODUCT_PRICES[i.product] ?? 0) * i.qty, 0).toLocaleString() }}원
+                      ₩ {{ selectedHistory.items.reduce((s, i) => s + (PRODUCT_PRICES[i.product] ?? 0) * i.qty, 0).toLocaleString() }}
                     </td>
                   </tr>
                 </tfoot>
@@ -255,12 +255,12 @@
             <div class="space-y-2 pb-3 border-b border-gray-200">
               <div v-for="item in selectedOrder?.items" :key="item.product" class="flex justify-between text-xs">
                 <span class="text-gray-500">{{ item.product }} ({{ item.adjusted }}개 × {{ (PRODUCT_PRICES[item.product] ?? 0).toLocaleString() }}원)</span>
-                <span class="font-medium text-gray-900">₩{{ ((item.adjusted * (PRODUCT_PRICES[item.product] ?? 0))).toLocaleString() }}</span>
+                <span class="font-medium text-gray-900">₩ {{((item.adjusted * (PRODUCT_PRICES[item.product] ?? 0))).toLocaleString() }}</span>
               </div>
             </div>
             <div class="flex justify-between items-center pt-3">
               <span class="text-sm font-bold text-gray-900">총 결제 금액</span>
-              <span class="text-lg font-black text-blue-600">₩{{ totalPrice.toLocaleString() }}</span>
+              <span class="text-lg font-black text-blue-600">₩ {{totalPrice.toLocaleString() }}</span>
             </div>
           </section>
 

--- a/frontend/src/views/store/StoreOrderView.vue
+++ b/frontend/src/views/store/StoreOrderView.vue
@@ -6,7 +6,7 @@
 
     <div class="flex border-b border-gray-200">
       <button v-for="tab in tabs" :key="tab.id" @click="activeTab = tab.id"
-        class="px-5 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors"
+        class="px-5 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors cursor-pointer"
         :class="activeTab === tab.id ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'">
         {{ tab.label }}
         <span v-if="tab.count > 0" class="ml-1.5 text-xs font-bold px-1.5 py-0.5 rounded"
@@ -26,15 +26,15 @@
           </div>
           <div class="flex gap-2">
             <button @click="openPaymentModal(order)"
-              class="px-4 py-2 bg-blue-500 text-white text-sm font-bold hover:bg-blue-600 rounded transition-colors">
+              class="px-4 py-2 bg-blue-500 text-white text-sm font-bold hover:bg-blue-600 rounded transition-colors cursor-pointer">
               전체 확정
             </button>
             <button @click="openAddItemForm(order)"
-              class="px-4 py-2 border border-blue-200 text-blue-500 bg-blue-50 text-sm font-semibold hover:bg-blue-100 rounded transition-colors">
+              class="px-4 py-2 border border-blue-200 text-blue-500 bg-blue-50 text-sm font-semibold hover:bg-blue-100 rounded transition-colors cursor-pointer">
               + 품목 추가
             </button>
             <button @click="rejectOrder(order)"
-              class="px-4 py-2 border border-gray-200 text-gray-600 text-sm font-semibold hover:bg-gray-50 rounded">
+              class="px-4 py-2 border border-gray-200 text-gray-600 text-sm font-semibold hover:bg-gray-50 rounded cursor-pointer">
               거절
             </button>
           </div>
@@ -166,7 +166,7 @@
             <h3 class="font-bold text-gray-900">발주 상세</h3>
             <p class="text-xs text-gray-400 font-mono mt-0.5">{{ selectedHistory?.id }}</p>
           </div>
-          <button @click="showHistoryDetail = false" class="text-gray-400 hover:text-gray-600">✕</button>
+          <button @click="showHistoryDetail = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
         <div v-if="selectedHistory" class="p-6 space-y-4 text-sm">
           <div class="grid grid-cols-2 gap-4">
@@ -222,7 +222,7 @@
         </div>
         <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
           <button @click="showHistoryDetail = false"
-            class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50">닫기</button>
+            class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">닫기</button>
         </div>
       </div>
     </div>
@@ -231,7 +231,7 @@
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md overflow-hidden animate-modal-up">
         <div class="px-6 py-4 border-b border-gray-100 flex justify-between items-center">
           <h2 class="text-lg font-bold text-gray-900">결제 및 승인</h2>
-          <button @click="isModalOpen = false" class="text-gray-400 hover:text-gray-600"><X class="w-5 h-5"/></button>
+          <button @click="isModalOpen = false" class="text-gray-400 hover:text-gray-600 cursor-pointer"><X class="w-5 h-5"/></button>
         </div>
 
         <div class="p-6 space-y-6">
@@ -247,7 +247,7 @@
                   <p class="text-[10px] text-gray-500 mt-1">현대카드 (****-1234)</p>
                 </div>
               </div>
-              <button class="flex-1 border border-dashed border-gray-300 rounded-lg p-3 text-gray-400 text-xs font-bold hover:bg-gray-50">+ 신규 등록</button>
+              <button class="flex-1 border border-dashed border-gray-300 rounded-lg p-3 text-gray-400 text-xs font-bold hover:bg-gray-50 cursor-pointer">+ 신규 등록</button>
             </div>
           </section>
 
@@ -272,8 +272,8 @@
         </div>
 
         <div class="px-6 py-4 bg-gray-50 flex gap-2">
-          <button @click="isModalOpen = false" class="flex-1 py-3 bg-white border border-gray-200 text-gray-600 font-bold rounded-lg text-sm">취소</button>
-          <button @click="processPayment" class="flex-2 py-3 bg-blue-600 text-white font-bold rounded-lg text-sm flex items-center justify-center gap-2">
+          <button @click="isModalOpen = false" class="flex-1 py-3 bg-white border border-gray-200 text-gray-600 font-bold rounded-lg text-sm cursor-pointer">취소</button>
+          <button @click="processPayment" class="flex-2 py-3 bg-blue-600 text-white font-bold rounded-lg text-sm flex items-center justify-center gap-2 cursor-pointer">
             <CreditCard class="w-4 h-4"/> 결제 및 승인 요청
           </button>
         </div>

--- a/frontend/src/views/store/StoreOrderView.vue
+++ b/frontend/src/views/store/StoreOrderView.vue
@@ -26,15 +26,15 @@
           </div>
           <div class="flex gap-2">
             <button @click="openPaymentModal(order)"
-              class="px-4 py-2 bg-blue-500 text-white text-sm font-bold hover:bg-blue-600 rounded transition-colors cursor-pointer">
+              class="px-4 py-2 bg-blue-500 text-white text-sm font-bold hover:bg-blue-600 rounded-lg transition-colors cursor-pointer">
               전체 확정
             </button>
             <button @click="openAddItemForm(order)"
-              class="px-4 py-2 border border-blue-200 text-blue-500 bg-blue-50 text-sm font-semibold hover:bg-blue-100 rounded transition-colors cursor-pointer">
+              class="px-4 py-2 border border-blue-200 text-blue-500 bg-blue-50 text-sm font-semibold hover:bg-blue-100 rounded-lg transition-colors cursor-pointer">
               + 품목 추가
             </button>
             <button @click="rejectOrder(order)"
-              class="px-4 py-2 border border-gray-200 text-gray-600 text-sm font-semibold hover:bg-gray-50 rounded cursor-pointer">
+              class="px-4 py-2 border border-gray-200 text-gray-600 text-sm font-semibold hover:bg-gray-50 rounded-lg cursor-pointer">
               거절
             </button>
           </div>
@@ -60,7 +60,7 @@
               <td class="px-5 py-3.5">
                 <div class="flex items-center gap-1.5">
                   <input v-model.number="item.adjusted" type="number" min="0"
-                    class="w-20 px-2 py-1.5 rounded border border-gray-200 text-sm focus:border-blue-400 outline-none" />
+                    class="w-20 px-2 py-1.5 rounded-lg border border-gray-200 text-sm focus:border-blue-400 outline-none" />
                   <span class="text-xs text-gray-400 font-medium">{{ PRODUCT_UNIT[item.product] ?? '' }}</span>
                 </div>
               </td>
@@ -71,7 +71,7 @@
                 <button
                   @click="removeOrderItem(order, item)"
                   :disabled="order.items.length <= 1"
-                  class="px-3 py-1.5 text-xs font-semibold rounded border border-red-200 text-red-500 bg-red-50 hover:bg-red-500 hover:text-white hover:cursor-pointer transition-colors disabled:opacity-30 disabled:cursor-not-allowed">
+                  class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-red-200 text-red-500 bg-red-50 hover:bg-red-500 hover:text-white hover:cursor-pointer transition-colors disabled:opacity-30 disabled:cursor-not-allowed">
                   삭제
                 </button>
               </td>
@@ -88,17 +88,17 @@
               <td class="px-5 py-3 text-xs text-gray-400">—</td>
               <td class="px-5 py-3">
                 <input v-model.number="addItemForm.qty" type="number" min="1" placeholder="수량"
-                  class="w-24 px-2 py-1.5 rounded border border-blue-200 text-sm outline-none focus:border-blue-400" />
+                  class="w-24 px-2 py-1.5 rounded-lg border border-blue-200 text-sm outline-none focus:border-blue-400" />
               </td>
               <td class="px-5 py-3 text-xs text-gray-400 text-right">—</td>
               <td class="px-5 py-3">
                 <div class="flex gap-1.5">
                   <button @click="confirmAddItem(order)"
-                    class="px-3 py-1.5 text-xs font-semibold rounded border border-blue-300 text-blue-600 bg-white hover:bg-blue-500 hover:text-white hover:cursor-pointer transition-colors">
+                    class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-blue-300 text-blue-600 bg-white hover:bg-blue-500 hover:text-white hover:cursor-pointer transition-colors">
                     추가
                   </button>
                   <button @click="addItemForm = null"
-                    class="px-3 py-1.5 text-xs font-semibold rounded border border-gray-200 text-gray-500 bg-white hover:bg-gray-100 hover:cursor-pointer transition-colors">
+                    class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-gray-200 text-gray-500 bg-white hover:bg-gray-100 hover:cursor-pointer transition-colors">
                     취소
                   </button>
                 </div>
@@ -237,7 +237,7 @@
         </div>
         <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
           <button @click="showHistoryDetail = false"
-            class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">닫기</button>
+            class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer">닫기</button>
         </div>
       </div>
     </div>
@@ -246,7 +246,7 @@
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md overflow-hidden animate-modal-up">
         <div class="px-6 py-4 border-b border-gray-100 flex justify-between items-center">
           <h2 class="text-lg font-bold text-gray-900">결제 및 승인</h2>
-          <button @click="isModalOpen = false" class="text-gray-400 hover:text-gray-600 cursor-pointer"><X class="w-5 h-5"/></button>
+          <button @click="isModalOpen = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
 
         <div class="p-6 space-y-6">
@@ -270,7 +270,7 @@
             <div class="space-y-2 pb-3 border-b border-gray-200">
               <div v-for="item in selectedOrder?.items" :key="item.product" class="flex justify-between text-xs">
                 <span class="text-gray-500">{{ item.product }} ({{ item.adjusted }}개 × {{ (PRODUCT_PRICES[item.product] ?? 0).toLocaleString() }}원)</span>
-                <span class="font-medium text-gray-900">₩ {{((item.adjusted * (PRODUCT_PRICES[item.product] ?? 0))).toLocaleString() }}</span>
+                <span class="font-medium text-gray-900">₩ {{ ((item.adjusted || 0) * (PRODUCT_PRICES[item.product] ?? 0)).toLocaleString() }}</span>
               </div>
             </div>
             <div class="flex justify-between items-center pt-3">
@@ -299,7 +299,7 @@
 
 <script setup>
 import { ref, computed } from 'vue'
-import { X, ClipboardList, CreditCard } from 'lucide-vue-next'
+import { ClipboardList, CreditCard } from 'lucide-vue-next'
 
 const PRODUCT_UNIT = {
   '생닭(1kg)':      'kg',

--- a/frontend/src/views/store/StoreSettlementView.vue
+++ b/frontend/src/views/store/StoreSettlementView.vue
@@ -30,22 +30,22 @@
         <h1 class="text-xl font-bold text-gray-900 tracking-tight">매출 정산 내역</h1>
 
         <div class="flex gap-2 mt-3">
-          <select v-model="salesYear" class="px-3 py-2 rounded border border-gray-200 text-sm bg-white">
+          <select v-model="salesYear" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white">
             <option value="">년도</option>
             <option v-for="y in years" :key="y">{{ y }}</option>
           </select>
 
-          <select v-model="salesMonth" class="px-3 py-2 rounded border border-gray-200 text-sm bg-white">
+          <select v-model="salesMonth" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white">
             <option value="">월</option>
             <option v-for="m in months" :key="m">{{ m }}</option>
           </select>
 
-          <select v-model="salesWeek" class="px-3 py-2 rounded border border-gray-200 text-sm bg-white">
+          <select v-model="salesWeek" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white">
             <option value="">주간</option>
             <option v-for="w in weeks" :key="w" :value="w">{{ w }}주차</option>
           </select>
 
-          <select v-model="salesDay" class="px-3 py-2 rounded border border-gray-200 text-sm bg-white">
+          <select v-model="salesDay" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white">
             <option value="">일</option>
             <option v-for="d in days" :key="d">{{ d }}</option>
           </select>
@@ -115,22 +115,22 @@
         <h1 class="text-xl font-bold text-gray-900 tracking-tight">발주 정산 내역</h1>
 
         <div class="flex gap-2 mt-3">
-          <select v-model="selectedYear" class="px-3 py-2 rounded border border-gray-200 text-sm bg-white">
+          <select v-model="selectedYear" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white">
             <option value="">년도</option>
             <option v-for="y in years" :key="y">{{ y }}</option>
           </select>
 
-          <select v-model="selectedMonth" class="px-3 py-2 rounded border border-gray-200 text-sm bg-white">
+          <select v-model="selectedMonth" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white">
             <option value="">월</option>
             <option v-for="m in months" :key="m">{{ m }}</option>
           </select>
 
-          <select v-model="selectedWeek" class="px-3 py-2 rounded border border-gray-200 text-sm bg-white">
+          <select v-model="selectedWeek" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white">
             <option value="">주간</option>
             <option v-for="w in weeks" :key="w" :value="w">{{ w }}주차</option>
           </select>
 
-          <select v-model="selectedDay" class="px-3 py-2 rounded border border-gray-200 text-sm bg-white">
+          <select v-model="selectedDay" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white">
             <option value="">일</option>
             <option v-for="d in days" :key="d">{{ d }}</option>
           </select>

--- a/frontend/src/views/store/StoreSettlementView.vue
+++ b/frontend/src/views/store/StoreSettlementView.vue
@@ -4,6 +4,7 @@
     <div class="flex gap-6 border-b border-gray-200 pb-2">
       <button
         @click="activeTab = 'sales'"
+        class="cursor-pointer"
         :class="activeTab === 'sales'
           ? 'text-blue-600 font-bold border-b-2 border-blue-600 pb-2'
           : 'text-gray-400'"
@@ -13,6 +14,7 @@
 
       <button
         @click="activeTab = 'order'"
+        class="cursor-pointer"
         :class="activeTab === 'order'
           ? 'text-blue-600 font-bold border-b-2 border-blue-600 pb-2'
           : 'text-gray-400'"
@@ -189,7 +191,7 @@
               <td class="px-5 py-3.5 text-center">
                 <button
                   type="button"
-                  class="text-gray-300 hover:text-[#F37321] transition-colors"
+                  class="text-gray-300 hover:text-[#F37321] transition-colors cursor-pointer"
                   @click="downloadStatement(s)"
                 >
                   <Download class="w-4 h-4 mx-auto" />

--- a/frontend/src/views/store/StoreSettlementView.vue
+++ b/frontend/src/views/store/StoreSettlementView.vue
@@ -58,7 +58,7 @@
                 {{ salesYear }}-{{ salesMonth }} 총 매출액
               </p>
               <p class="text-2xl font-black text-gray-900 mt-2">
-                ₩{{ salesTotal.toLocaleString() }}
+                ₩ {{ salesTotal.toLocaleString() }}
               </p>
             </div>
           </div>
@@ -67,7 +67,7 @@
             <div class="p-5">
               <p class="text-xs font-bold text-gray-400">계산 완료</p>
               <p class="text-2xl font-black text-green-600 mt-2">
-                ₩{{ salesPaid.toLocaleString() }}
+                ₩ {{ salesPaid.toLocaleString() }}
               </p>
             </div>
           </div>
@@ -91,7 +91,7 @@
               <td class="px-5 py-3 text-gray-600">{{ s.count }}건</td>
               <td class="px-5 py-3 text-xs text-gray-400">{{ s.period }}</td>
               <td class="px-5 py-3 font-bold">
-                ₩{{ s.amount.toLocaleString() }}
+                ₩ {{ s.amount.toLocaleString() }}
               </td>
               <td class="px-5 py-3">
                   <span class="text-xs px-2 py-0.5 rounded"
@@ -143,7 +143,7 @@
                 {{ selectedYear }}-{{ selectedMonth }} 총 납부액
               </p>
               <p class="text-2xl font-black text-gray-900 mt-2">
-                ₩{{ totalAmount.toLocaleString() }}
+                ₩ {{ totalAmount.toLocaleString() }}
               </p>
             </div>
           </div>
@@ -152,7 +152,7 @@
             <div class="p-5">
               <p class="text-xs font-bold text-gray-400">납부 완료</p>
               <p class="text-2xl font-black text-green-600 mt-2">
-                ₩{{ paidAmount.toLocaleString() }}
+                ₩ {{ paidAmount.toLocaleString() }}
               </p>
             </div>
           </div>
@@ -178,7 +178,7 @@
               <td class="px-5 py-3 text-gray-600">{{ s.count }}건</td>
               <td class="px-5 py-3 text-xs text-gray-400">{{ s.period }}</td>
               <td class="px-5 py-3 font-bold">
-                ₩{{ s.amount.toLocaleString() }}
+                ₩ {{ s.amount.toLocaleString() }}
               </td>
               <td class="px-5 py-3">
                   <span class="text-xs px-2 py-0.5 rounded"


### PR DESCRIPTION
## Summary
- 점주 페이지 전체 버튼 cursor-pointer 추가
- 드롭다운/필터 버튼 rounded-lg 통일
- 모달 디자인 통일 (rounded-xl, 표준 헤더/푸터, 닫기 버튼)
- 테이블 스타일 통일 (thead border, divide-gray-100, 행 패딩)
- 금액 표시 ₩ 형식 통일 (₩ + 공백)
- 본사/점주 알림 페이지 배지 스타일 통일
- 제안 발주서 품목별 금액 및 합계 표시 추가
- POS 일일 마감 탭 TrendingUp 아이콘 import 누락 수정

## Test plan
- [ ] 점주 로그인 후 각 페이지 버튼 hover 시 cursor-pointer 확인
- [ ] 발주서 확인 페이지 제안 발주서 금액/합계 표시 확인
- [ ] POS 주문/결제, 일일 마감 탭 전환 및 아이콘 확인
- [ ] 결제 모달, 마감 확인 모달 디자인 확인
- [ ] 배송 현황 지연 모달 디자인 확인
- [ ] 본사/점주 알림 페이지 배지 스타일 확인
- [ ] 정산 내역 ₩ 금액 표시 확인

## Issue
Closes #270 
