### PR TITLE
[Refactor] 본사 제품/메뉴 관리 페이지 갤러리아 푸드코트 기준으로 개편

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -282,11 +282,6 @@ const activeMenuClass = computed(() => {
   return 'text-gray-900 bg-gray-100 font-semibold'
 })
 
-const activeBorderClass = computed(() => {
-  if (auth.isAdmin)      return 'bg-[#F37321]'
-  if (auth.isStoreOwner) return 'bg-blue-500'
-  return 'bg-gray-700'
-})
 
 const activeIconClass = computed(() => {
   if (auth.isAdmin)      return 'text-[#F37321]'

--- a/frontend/src/views/ProductView.vue
+++ b/frontend/src/views/ProductView.vue
@@ -2,105 +2,147 @@
   <div class="p-5 space-y-4">
     <!-- Header -->
     <div class="flex justify-between items-center">
-      <div>
-        <h1 class="text-xl font-bold text-gray-900 tracking-tight">제품 목록 관리</h1>
+      <h1 class="text-xl font-bold text-gray-900 tracking-tight">제품 목록 관리</h1>
+      <button @click="showCategoryModal = true"
+              class="px-4 py-2 rounded-lg border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 flex items-center gap-2 cursor-pointer">
+        <Tag class="w-4 h-4" /> 카테고리 관리
+      </button>
+    </div>
+
+    <!-- Tabs -->
+    <div class="flex border-b border-gray-200">
+      <button v-for="tab in tabs" :key="tab.id" @click="activeTab = tab.id"
+        class="px-5 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors cursor-pointer"
+        :class="activeTab === tab.id
+          ? 'border-[#F37321] text-[#F37321]'
+          : 'border-transparent text-gray-500 hover:text-gray-700'">
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <!-- ── 전체 제품 목록 탭 ── -->
+    <div v-if="activeTab === 'all'">
+      <div class="flex gap-3 items-center flex-wrap mb-4">
+        <div class="relative">
+          <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input v-model="searchQuery" type="text" placeholder="제품명 검색..."
+            class="pl-10 pr-4 py-2 rounded-lg border border-gray-200 text-sm w-52 bg-white shadow-sm
+                   focus:border-[#F37321] focus:ring-1 focus:ring-[#F37321] outline-none transition-colors" />
+        </div>
+        <div class="flex gap-1.5 flex-wrap">
+          <button v-for="cat in ['전체', ...categories]" :key="cat" @click="selectedCategory = cat"
+            class="px-3 py-1.5 text-sm font-semibold border rounded-lg transition-colors shadow-sm cursor-pointer"
+            :class="selectedCategory === cat
+              ? 'bg-[#F37321] text-white border-[#F37321]'
+              : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'">
+            {{ cat }}
+          </button>
+        </div>
       </div>
-      <div class="flex gap-2">
-        <button @click="showCategoryModal = true"
-                class="px-4 py-2 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 flex items-center gap-2 cursor-pointer">
-          <Tag class="w-4 h-4" /> 카테고리 관리
-        </button>
-        <button @click="openModal(null)"
-                class="bg-[#F37321] text-white px-4 py-2 text-sm font-semibold rounded hover:bg-[#e0661d] transition-colors flex items-center gap-2 cursor-pointer">
-          <Plus class="w-4 h-4" /> 제품 등록
-        </button>
+
+      <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+        <table class="w-full text-sm text-left">
+          <thead>
+            <tr class="border-b border-gray-200 bg-gray-50">
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품코드</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품명</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">카테고리</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">최대재고</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">최소재고</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단가</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">위험 유통기한</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">관리</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            <tr v-for="p in filteredProducts" :key="p.code" class="hover:bg-gray-50/50 transition-colors">
+              <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ p.code }}</td>
+              <td class="px-5 py-3.5 font-semibold text-gray-900">{{ p.name }}</td>
+              <td class="px-5 py-3.5">
+                <span class="text-xs font-semibold px-2 py-0.5 bg-gray-100 text-gray-600 border border-gray-200 rounded">{{ p.category }}</span>
+              </td>
+              <td class="px-5 py-3.5 text-gray-600">{{ p.unit }}</td>
+              <td class="px-5 py-3.5 font-medium text-gray-900">{{ p.baseStock.toLocaleString() }}</td>
+              <td class="px-5 py-3.5 font-semibold text-[#F37321]">{{ p.minStock.toLocaleString() }}</td>
+              <td class="px-5 py-3.5 font-medium text-gray-900">₩ {{ p.price.toLocaleString() }}</td>
+              <td class="px-5 py-3.5 text-xs font-mono"
+                  :class="p.expiryDays ? 'text-amber-600 font-semibold' : 'text-gray-400'">
+                {{ p.expiryDays ? `D-${p.expiryDays}` : '-' }}
+              </td>
+              <td class="px-5 py-3.5">
+                <div class="flex justify-center gap-2">
+                  <button @click="openModal(p)" class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer">수정</button>
+                  <button @click="deleteProduct(p.code)" class="px-3 py-1.5 text-xs font-semibold text-red-500 border border-red-400 rounded hover:bg-red-50 transition-colors cursor-pointer">삭제</button>
+                </div>
+              </td>
+            </tr>
+            <tr v-if="filteredProducts.length === 0">
+              <td colspan="9" class="px-5 py-12 text-center text-gray-400 text-sm">검색 결과가 없습니다.</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
 
-    <!-- Search + Category filter -->
-    <div class="flex gap-3 items-center flex-wrap">
-      <div class="relative">
-        <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-        <input
-          v-model="searchQuery"
-          type="text"
-          placeholder="제품명 검색..."
-          class="pl-10 pr-4 py-2 rounded-lg border border-gray-200 text-sm w-52
-             bg-white shadow-sm
-             focus:border-[#F37321] focus:ring-1 focus:ring-[#F37321]
-             outline-none transition-colors"
-        />
+    <!-- ── 매장별 제품 목록 탭 ── -->
+    <div v-if="activeTab === 'store'">
+      <div class="flex gap-3 items-center mb-4">
+        <div class="relative w-64">
+          <select v-model="selectedStoreId"
+            class="w-full px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm outline-none
+                   focus:border-[#F37321] focus:ring-1 focus:ring-[#F37321] transition-colors shadow-sm cursor-pointer text-gray-700">
+            <option value="">매장을 선택하세요</option>
+            <option v-for="s in stores" :key="s.id" :value="s.id">{{ s.name }}</option>
+          </select>
+        </div>
       </div>
-      <div class="flex gap-1.5 flex-wrap">
-        <button
-          v-for="cat in ['전체', ...categories]"
-          :key="cat"
-          @click="selectedCategory = cat"
-          class="px-3 py-1.5 text-sm font-semibold border rounded-lg
-                transition-colors shadow-sm cursor-pointer"
-          :class="selectedCategory === cat
-            ? 'bg-[#F37321] text-white border-[#F37321]'
-            : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'">
-          {{ cat }}
-        </button>
+
+      <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+        <div v-if="!selectedStoreId" class="py-16 text-center text-gray-400 text-sm">
+          <p>조회할 매장을 선택해주세요.</p>
+        </div>
+        <table v-else class="w-full text-sm text-left">
+          <thead>
+            <tr class="border-b border-gray-200 bg-gray-50">
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품코드</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품명</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">카테고리</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단가</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">관리</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            <tr v-for="p in storeProducts" :key="p.code" class="hover:bg-gray-50/50 transition-colors">
+              <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ p.code }}</td>
+              <td class="px-5 py-3.5 font-semibold text-gray-900">{{ p.name }}</td>
+              <td class="px-5 py-3.5">
+                <span class="text-xs font-semibold px-2 py-0.5 bg-gray-100 text-gray-600 border border-gray-200 rounded">{{ p.category }}</span>
+              </td>
+              <td class="px-5 py-3.5 text-gray-600">{{ p.unit }}</td>
+              <td class="px-5 py-3.5 font-medium text-gray-900">₩ {{ p.price.toLocaleString() }}</td>
+              <td class="px-5 py-3.5">
+                <div class="flex justify-center gap-2">
+                  <button @click="openModal(p)" class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer">수정</button>
+                  <button @click="deleteProduct(p.code)" class="px-3 py-1.5 text-xs font-semibold text-red-500 border border-red-400 rounded hover:bg-red-50 transition-colors cursor-pointer">삭제</button>
+                </div>
+              </td>
+            </tr>
+            <tr v-if="storeProducts.length === 0">
+              <td colspan="6" class="px-5 py-12 text-center text-gray-400 text-sm">해당 매장에 등록된 제품이 없습니다.</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
 
-    <!-- Table -->
-    <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
-      <table class="w-full text-sm text-left">
-        <thead>
-        <tr class="border-b border-gray-200 bg-gray-50">
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품코드</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품명</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">카테고리</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">최대재고</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">최소재고</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단가</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">위험 유통기한</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">관리</th>
-        </tr>
-        </thead>
-        <tbody class="divide-y divide-gray-100">
-        <tr v-for="p in filteredProducts" :key="p.code" class="hover:bg-gray-50/50 transition-colors">
-          <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ p.code }}</td>
-          <td class="px-5 py-3.5 font-semibold text-gray-900">{{ p.name }}</td>
-          <td class="px-5 py-3.5">
-            <span class="text-xs font-semibold px-2 py-0.5 bg-gray-100 text-gray-600 border border-gray-200 rounded">{{ p.category }}</span>
-          </td>
-          <td class="px-5 py-3.5 text-gray-600">{{ p.unit }}</td>
-          <td class="px-5 py-3.5 font-medium text-gray-900">{{ p.baseStock.toLocaleString() }}</td>
-          <td class="px-5 py-3.5 font-semibold text-[#F37321]">{{ p.minStock.toLocaleString() }}</td>
-          <td class="px-5 py-3.5 font-medium text-gray-900">₩ {{ p.price.toLocaleString() }}</td>
-          <td class="px-5 py-3.5 text-xs font-mono"
-              :class="p.expiryDays ? 'text-amber-600 font-semibold' : 'text-gray-400'">
-            {{ p.expiryDays ? `D-${p.expiryDays}` : '-' }}
-          </td>
-          <td class="px-5 py-3.5">
-            <div class="flex justify-center gap-2">
-              <button @click="openModal(p)" class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer">
-                수정
-              </button>
-              <button @click="deleteProduct(p.code)" class="px-3 py-1.5 text-xs font-semibold text-red-500 border border-red-400 rounded hover:bg-red-50 transition-colors cursor-pointer">
-                삭제
-              </button>
-            </div>
-          </td>
-        </tr>
-        <tr v-if="filteredProducts.length === 0">
-          <td colspan="9" class="px-5 py-12 text-center text-gray-400 text-sm">검색 결과가 없습니다.</td>
-        </tr>
-        </tbody>
-      </table>
-    </div>
-
-    <!-- Product Modal -->
+    <!-- 제품 수정 모달 -->
     <div v-if="showModal" class="fixed inset-0 z-50 flex items-center justify-center">
       <div class="absolute inset-0 bg-black/40" @click="showModal = false"></div>
       <div class="relative bg-white rounded-lg w-full max-w-lg border border-gray-200 shadow-xl">
         <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
-          <h3 class="font-bold text-gray-900">{{ editTarget ? '제품 정보 수정' : '신규 제품 등록' }}</h3>
+          <h3 class="font-bold text-gray-900">제품 정보 수정</h3>
           <button @click="showModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
         <form @submit.prevent="saveProduct" class="p-6 space-y-4">
@@ -157,7 +199,7 @@
       </div>
     </div>
 
-    <!-- Category Management Modal (CATEGORY_001~003) -->
+    <!-- 카테고리 관리 모달 -->
     <div v-if="showCategoryModal" class="fixed inset-0 z-50 flex items-center justify-center">
       <div class="absolute inset-0 bg-black/40" @click="showCategoryModal = false"></div>
       <div class="relative bg-white rounded-lg w-full max-w-md border border-gray-200 shadow-xl">
@@ -166,17 +208,13 @@
           <button @click="showCategoryModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
         </div>
         <div class="p-6 space-y-4">
-          <!-- 등록 폼 -->
           <div class="flex gap-2">
             <input v-model="newCategory" type="text" placeholder="새 카테고리명 입력"
                    @keyup.enter="addCategory"
                    class="flex-1 px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none" />
             <button @click="addCategory"
-                    class="px-4 py-2 bg-[#F37321] text-white text-sm font-semibold rounded hover:bg-[#e0661d] cursor-pointer">
-              추가
-            </button>
+                    class="px-4 py-2 bg-[#F37321] text-white text-sm font-semibold rounded hover:bg-[#e0661d] cursor-pointer">추가</button>
           </div>
-          <!-- 목록 -->
           <div class="border border-gray-200 rounded-lg overflow-hidden">
             <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-100">
               <p class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">카테고리 목록 ({{ categories.length }}개)</p>
@@ -185,21 +223,17 @@
               <div v-for="cat in categories" :key="cat"
                    class="flex items-center justify-between px-4 py-2.5 hover:bg-gray-50">
                 <span class="text-sm font-medium text-gray-700">{{ cat }}</span>
-                <button @click="deleteCategory(cat)"
-                        class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer">
+                <button @click="deleteCategory(cat)" class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer">
                   <Trash2 class="w-3.5 h-3.5" />
                 </button>
               </div>
-              <div v-if="categories.length === 0"
-                   class="px-4 py-6 text-center text-gray-400 text-sm">
+              <div v-if="categories.length === 0" class="px-4 py-6 text-center text-gray-400 text-sm">
                 등록된 카테고리가 없습니다.
               </div>
             </div>
           </div>
           <button @click="showCategoryModal = false"
-                  class="w-full py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer">
-            닫기
-          </button>
+                  class="w-full py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer">닫기</button>
         </div>
       </div>
     </div>
@@ -208,28 +242,60 @@
 
 <script setup>
 import { ref, computed } from 'vue'
-import { Plus, Trash2, Search, Tag } from 'lucide-vue-next'
+import { Trash2, Search, Tag } from 'lucide-vue-next'
 
-const categories = ref(['육류', '소스', '채소', '가공식품', '음료'])
+const tabs = [
+  { id: 'all',   label: '전체 제품 목록' },
+  { id: 'store', label: '매장별 제품 목록' },
+]
+const activeTab = ref('all')
+
+const categories = ref(['육류', '어류', '채소', '소스류', '오일/유제품', '음료', '기타'])
 const selectedCategory = ref('전체')
 const searchQuery = ref('')
 const newCategory = ref('')
 
 const products = ref([
-  { code: 'P100', name: '닭(10호)', category: '육류', unit: '마리', baseStock: 120, minStock: 30, price: 7000, expiryDays: 3 },
-  { code: 'P101', name: '닭(부분육-윙)', category: '육류', unit: 'kg', baseStock: 80, minStock: 20, price: 9000, expiryDays: 3 },
-  { code: 'P102', name: '닭(부분육-다리)', category: '육류', unit: 'kg', baseStock: 80, minStock: 20, price: 9500, expiryDays: 3 },
-
-  { code: 'P200', name: '양념소스', category: '소스', unit: 'kg', baseStock: 50, minStock: 10, price: 4000, expiryDays: 30 },
-  { code: 'P201', name: '매운양념소스', category: '소스', unit: 'kg', baseStock: 50, minStock: 10, price: 4500, expiryDays: 30 },
-  { code: 'P202', name: '파우더(튀김가루)', category: '소스', unit: 'kg', baseStock: 100, minStock: 20, price: 2000, expiryDays: 60 },
-
-  { code: 'P300', name: '감자', category: '채소', unit: 'kg', baseStock: 150, minStock: 40, price: 1500, expiryDays: 14 },
-  { code: 'P301', name: '치즈볼 원재료', category: '가공식품', unit: '팩', baseStock: 100, minStock: 30, price: 3000, expiryDays: 10 },
-
-  { code: 'P400', name: '콜라', category: '음료', unit: '박스', baseStock: 200, minStock: 50, price: 1200, expiryDays: 60 },
-  { code: 'P401', name: '사이다', category: '음료', unit: '박스', baseStock: 180, minStock: 40, price: 1200, expiryDays: 60 },
+  { code: 'P100', name: '한우 등심',       category: '육류',       unit: 'kg',  baseStock: 50,  minStock: 10, price: 85000, expiryDays: 5  },
+  { code: 'P101', name: '한우 안심',       category: '육류',       unit: 'kg',  baseStock: 30,  minStock: 8,  price: 95000, expiryDays: 5  },
+  { code: 'P102', name: '돼지 삼겹살',     category: '육류',       unit: 'kg',  baseStock: 80,  minStock: 20, price: 18000, expiryDays: 5  },
+  { code: 'P103', name: '닭 가슴살',       category: '육류',       unit: 'kg',  baseStock: 60,  minStock: 15, price: 8000,  expiryDays: 4  },
+  { code: 'P200', name: '연어 (생선)',     category: '어류',       unit: 'kg',  baseStock: 40,  minStock: 10, price: 32000, expiryDays: 3  },
+  { code: 'P201', name: '참치 (생선)',     category: '어류',       unit: 'kg',  baseStock: 30,  minStock: 8,  price: 45000, expiryDays: 3  },
+  { code: 'P202', name: '새우 (냉동)',     category: '어류',       unit: 'kg',  baseStock: 50,  minStock: 12, price: 22000, expiryDays: 60 },
+  { code: 'P300', name: '양파',           category: '채소',       unit: 'kg',  baseStock: 100, minStock: 30, price: 1500,  expiryDays: 14 },
+  { code: 'P301', name: '마늘',           category: '채소',       unit: 'kg',  baseStock: 50,  minStock: 15, price: 8000,  expiryDays: 30 },
+  { code: 'P302', name: '대파',           category: '채소',       unit: '단',  baseStock: 80,  minStock: 20, price: 2000,  expiryDays: 7  },
+  { code: 'P303', name: '파프리카',        category: '채소',       unit: 'kg',  baseStock: 40,  minStock: 10, price: 5000,  expiryDays: 7  },
+  { code: 'P400', name: '간장',           category: '소스류',     unit: 'L',   baseStock: 30,  minStock: 8,  price: 4000,  expiryDays: null },
+  { code: 'P401', name: '고추장',         category: '소스류',     unit: 'kg',  baseStock: 20,  minStock: 5,  price: 5500,  expiryDays: null },
+  { code: 'P402', name: '된장',           category: '소스류',     unit: 'kg',  baseStock: 20,  minStock: 5,  price: 4500,  expiryDays: null },
+  { code: 'P500', name: '올리브오일',      category: '오일/유제품', unit: 'L',   baseStock: 25,  minStock: 6,  price: 12000, expiryDays: null },
+  { code: 'P501', name: '버터',           category: '오일/유제품', unit: 'kg',  baseStock: 20,  minStock: 5,  price: 9000,  expiryDays: 30 },
+  { code: 'P502', name: '생크림',         category: '오일/유제품', unit: 'L',   baseStock: 15,  minStock: 4,  price: 7000,  expiryDays: 10 },
+  { code: 'P600', name: '콜라',           category: '음료',       unit: '박스', baseStock: 50,  minStock: 15, price: 15000, expiryDays: null },
+  { code: 'P601', name: '생수 (2L)',      category: '음료',       unit: '박스', baseStock: 80,  minStock: 20, price: 8000,  expiryDays: null },
 ])
+
+// 매장 목록 (STORE)
+const stores = ref([
+  { id: 'S001', name: '한우 오마카세' },
+  { id: 'S002', name: '이탈리안 키친' },
+  { id: 'S003', name: '일식 스시바' },
+  { id: 'S004', name: '차이나 가든' },
+  { id: 'S005', name: '프렌치 비스트로' },
+])
+
+// 매장-제품 매핑 (STORE_PRODUCT)
+const storeProductMap = {
+  S001: ['P100', 'P101', 'P300', 'P301', 'P400', 'P500'],
+  S002: ['P102', 'P300', 'P301', 'P302', 'P303', 'P500', 'P501', 'P502', 'P600'],
+  S003: ['P200', 'P201', 'P202', 'P300', 'P301', 'P400', 'P601'],
+  S004: ['P102', 'P103', 'P300', 'P301', 'P302', 'P400', 'P401', 'P600'],
+  S005: ['P101', 'P103', 'P300', 'P303', 'P500', 'P501', 'P502', 'P601'],
+}
+
+const selectedStoreId = ref('')
 
 const filteredProducts = computed(() => {
   return products.value.filter(p => {
@@ -237,6 +303,12 @@ const filteredProducts = computed(() => {
     const matchSearch = !searchQuery.value || p.name.includes(searchQuery.value) || p.code.includes(searchQuery.value)
     return matchCat && matchSearch
   })
+})
+
+const storeProducts = computed(() => {
+  if (!selectedStoreId.value) return []
+  const codes = storeProductMap[selectedStoreId.value] ?? []
+  return products.value.filter(p => codes.includes(p.code))
 })
 
 // 카테고리 CRUD
@@ -257,25 +329,20 @@ function deleteCategory(cat) {
   if (selectedCategory.value === cat) selectedCategory.value = '전체'
 }
 
-// 제품 CRUD
+// 제품 수정
 const showModal = ref(false)
 const editTarget = ref(null)
-const form = ref({ name: '', category: '원두', unit: '', baseStock: 0, minStock: 0, price: 0, expiryDays: null })
+const form = ref({ name: '', category: '', unit: '', baseStock: 0, minStock: 0, price: 0, expiryDays: null })
 
 function openModal(product) {
   editTarget.value = product
-  form.value = product
-    ? { ...product }
-    : { name: '', category: categories.value[0] || '', unit: '', baseStock: 0, minStock: 0, price: 0, expiryDays: null }
+  form.value = { ...product }
   showModal.value = true
 }
 
 function saveProduct() {
   if (editTarget.value) {
     Object.assign(editTarget.value, form.value)
-  } else {
-    const newCode = 'P' + String((products.value.length + 1) * 100)
-    products.value.push({ code: newCode, ...form.value })
   }
   showModal.value = false
 }

--- a/frontend/src/views/ProductView.vue
+++ b/frontend/src/views/ProductView.vue
@@ -9,24 +9,13 @@
       </button>
     </div>
 
-    <!-- Tabs -->
-    <div class="flex border-b border-gray-200">
-      <button v-for="tab in tabs" :key="tab.id" @click="activeTab = tab.id"
-        class="px-5 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors cursor-pointer"
-        :class="activeTab === tab.id
-          ? 'border-[#F37321] text-[#F37321]'
-          : 'border-transparent text-gray-500 hover:text-gray-700'">
-        {{ tab.label }}
-      </button>
-    </div>
-
-    <!-- ── 전체 제품 목록 탭 ── -->
-    <div v-if="activeTab === 'all'">
+    <!-- ── 전체 제품 목록 ── -->
+    <div>
       <div class="flex gap-3 items-center flex-wrap mb-4">
         <div class="relative">
           <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-          <input v-model="searchQuery" type="text" placeholder="제품명 검색..."
-            class="pl-10 pr-4 py-2 rounded-lg border border-gray-200 text-sm w-52 bg-white shadow-sm
+          <input v-model="searchQuery" type="text" placeholder="제품명 또는 매장명 검색..."
+            class="pl-10 pr-4 py-2 rounded-lg border border-gray-200 text-sm w-64 bg-white shadow-sm
                    focus:border-[#F37321] focus:ring-1 focus:ring-[#F37321] outline-none transition-colors" />
         </div>
         <div class="flex gap-1.5 flex-wrap">
@@ -46,6 +35,7 @@
             <tr class="border-b border-gray-200 bg-gray-50">
               <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품코드</th>
               <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품명</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">입점 매장</th>
               <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">카테고리</th>
               <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</th>
               <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">최대재고</th>
@@ -56,9 +46,14 @@
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-100">
-            <tr v-for="p in filteredProducts" :key="p.code" class="hover:bg-gray-50/50 transition-colors">
+            <tr v-for="p in filteredProducts" :key="p.code + '_' + p.storeId" class="hover:bg-gray-50/50 transition-colors">
               <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ p.code }}</td>
               <td class="px-5 py-3.5 font-semibold text-gray-900">{{ p.name }}</td>
+              <td class="px-5 py-3.5">
+                <span class="text-xs font-semibold px-2 py-0.5 rounded bg-blue-50 text-blue-500 border border-blue-100">
+                  {{ p.storeName }}
+                </span>
+              </td>
               <td class="px-5 py-3.5">
                 <span class="text-xs font-semibold px-2 py-0.5 bg-gray-100 text-gray-600 border border-gray-200 rounded">{{ p.category }}</span>
               </td>
@@ -78,59 +73,7 @@
               </td>
             </tr>
             <tr v-if="filteredProducts.length === 0">
-              <td colspan="9" class="px-5 py-12 text-center text-gray-400 text-sm">검색 결과가 없습니다.</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-    <!-- ── 매장별 제품 목록 탭 ── -->
-    <div v-if="activeTab === 'store'">
-      <div class="flex gap-3 items-center mb-4">
-        <div class="relative w-64">
-          <select v-model="selectedStoreId"
-            class="w-full px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm outline-none
-                   focus:border-[#F37321] focus:ring-1 focus:ring-[#F37321] transition-colors shadow-sm cursor-pointer text-gray-700">
-            <option value="">매장을 선택하세요</option>
-            <option v-for="s in stores" :key="s.id" :value="s.id">{{ s.name }}</option>
-          </select>
-        </div>
-      </div>
-
-      <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
-        <div v-if="!selectedStoreId" class="py-16 text-center text-gray-400 text-sm">
-          <p>조회할 매장을 선택해주세요.</p>
-        </div>
-        <table v-else class="w-full text-sm text-left">
-          <thead>
-            <tr class="border-b border-gray-200 bg-gray-50">
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품코드</th>
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품명</th>
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">카테고리</th>
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</th>
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단가</th>
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">관리</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-100">
-            <tr v-for="p in storeProducts" :key="p.code" class="hover:bg-gray-50/50 transition-colors">
-              <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ p.code }}</td>
-              <td class="px-5 py-3.5 font-semibold text-gray-900">{{ p.name }}</td>
-              <td class="px-5 py-3.5">
-                <span class="text-xs font-semibold px-2 py-0.5 bg-gray-100 text-gray-600 border border-gray-200 rounded">{{ p.category }}</span>
-              </td>
-              <td class="px-5 py-3.5 text-gray-600">{{ p.unit }}</td>
-              <td class="px-5 py-3.5 font-medium text-gray-900">₩ {{ p.price.toLocaleString() }}</td>
-              <td class="px-5 py-3.5">
-                <div class="flex justify-center gap-2">
-                  <button @click="openModal(p)" class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer">수정</button>
-                  <button @click="deleteProduct(p.code)" class="px-3 py-1.5 text-xs font-semibold text-red-500 border border-red-400 rounded hover:bg-red-50 transition-colors cursor-pointer">삭제</button>
-                </div>
-              </td>
-            </tr>
-            <tr v-if="storeProducts.length === 0">
-              <td colspan="6" class="px-5 py-12 text-center text-gray-400 text-sm">해당 매장에 등록된 제품이 없습니다.</td>
+              <td colspan="10" class="px-5 py-12 text-center text-gray-400 text-sm">검색 결과가 없습니다.</td>
             </tr>
           </tbody>
         </table>
@@ -244,12 +187,6 @@
 import { ref, computed } from 'vue'
 import { Trash2, Search, Tag } from 'lucide-vue-next'
 
-const tabs = [
-  { id: 'all',   label: '전체 제품 목록' },
-  { id: 'store', label: '매장별 제품 목록' },
-]
-const activeTab = ref('all')
-
 const categories = ref(['육류', '어류', '채소', '소스류', '오일/유제품', '음료', '기타'])
 const selectedCategory = ref('전체')
 const searchQuery = ref('')
@@ -295,20 +232,25 @@ const storeProductMap = {
   S005: ['P101', 'P103', 'P300', 'P303', 'P500', 'P501', 'P502', 'P601'],
 }
 
-const selectedStoreId = ref('')
-
-const filteredProducts = computed(() => {
-  return products.value.filter(p => {
-    const matchCat = selectedCategory.value === '전체' || p.category === selectedCategory.value
-    const matchSearch = !searchQuery.value || p.name.includes(searchQuery.value) || p.code.includes(searchQuery.value)
-    return matchCat && matchSearch
-  })
+const expandedProducts = computed(() => {
+  const result = []
+  for (const [storeId, codes] of Object.entries(storeProductMap)) {
+    const store = stores.value.find(s => s.id === storeId)
+    for (const code of codes) {
+      const product = products.value.find(p => p.code === code)
+      if (product) result.push({ ...product, storeId, storeName: store?.name ?? storeId })
+    }
+  }
+  return result
 })
 
-const storeProducts = computed(() => {
-  if (!selectedStoreId.value) return []
-  const codes = storeProductMap[selectedStoreId.value] ?? []
-  return products.value.filter(p => codes.includes(p.code))
+const filteredProducts = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  return expandedProducts.value.filter(p => {
+    const matchCat = selectedCategory.value === '전체' || p.category === selectedCategory.value
+    const matchSearch = !q || p.name.toLowerCase().includes(q) || p.storeName.toLowerCase().includes(q)
+    return matchCat && matchSearch
+  })
 })
 
 // 카테고리 CRUD

--- a/frontend/src/views/ProductView.vue
+++ b/frontend/src/views/ProductView.vue
@@ -233,12 +233,14 @@ const storeProductMap = {
 }
 
 const expandedProducts = computed(() => {
+  const productMap = new Map(products.value.map(p => [p.code, p]))
+  const storeMap = new Map(stores.value.map(s => [s.id, s.name]))
   const result = []
   for (const [storeId, codes] of Object.entries(storeProductMap)) {
-    const store = stores.value.find(s => s.id === storeId)
+    const storeName = storeMap.get(storeId) ?? storeId
     for (const code of codes) {
-      const product = products.value.find(p => p.code === code)
-      if (product) result.push({ ...product, storeId, storeName: store?.name ?? storeId })
+      const product = productMap.get(code)
+      if (product) result.push({ ...product, storeId, storeName })
     }
   }
   return result
@@ -273,19 +275,17 @@ function deleteCategory(cat) {
 
 // 제품 수정
 const showModal = ref(false)
-const editTarget = ref(null)
 const form = ref({ name: '', category: '', unit: '', baseStock: 0, minStock: 0, price: 0, expiryDays: null })
 
 function openModal(product) {
-  editTarget.value = product
-  form.value = { ...product }
+  const { storeId, storeName, ...fields } = product
+  form.value = { ...fields }
   showModal.value = true
 }
 
 function saveProduct() {
-  if (editTarget.value) {
-    Object.assign(editTarget.value, form.value)
-  }
+  const original = products.value.find(p => p.code === form.value.code)
+  if (original) Object.assign(original, form.value)
   showModal.value = false
 }
 

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -5,38 +5,32 @@
     <div class="flex items-center justify-between">
       <div>
         <h1 class="text-xl font-bold text-gray-900 tracking-tight">메뉴 관리</h1>
-
       </div>
-      <button @click="openNewMenuModal"
-              class="flex items-center gap-2 px-4 py-2 bg-[#F97316] text-white text-sm font-bold rounded-lg hover:bg-[#EA6700] transition-colors shadow-sm cursor-pointer">
-        <Plus class="w-4 h-4" /> 신규 메뉴 등록
-      </button>
     </div>
 
-    <!-- 텍스트 검색 및 드롭다운 -->
+    <!-- 텍스트 검색 및 매장 드롭다운 -->
     <div class="flex items-center gap-3 mb-4 flex-wrap">
       <div class="relative">
         <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
         <input
           v-model="searchQuery"
           type="text"
-          placeholder="메뉴명 검색..."
-          class="pl-10 pr-4 py-2 rounded-lg border border-gray-200 text-sm w-52
+          placeholder="메뉴명 또는 매장명 검색..."
+          class="pl-10 pr-4 py-2 rounded-lg border border-gray-200 text-sm w-64
              bg-white shadow-sm
              focus:border-[#F37321] focus:ring-1 focus:ring-[#F37321]
              outline-none transition-colors"
         />
       </div>
 
-      <!-- 수정된 부분: 재료(제품명) 선택 드롭다운 -->
-      <div class="relative w-64">
+      <div class="relative w-52">
         <select
-          v-model="selectedProductId"
+          v-model="selectedStoreId"
           class="w-full pl-4 pr-10 py-2 bg-white border border-gray-200 rounded-lg text-sm appearance-none outline-none focus:border-[#F97316] focus:ring-1 focus:ring-[#F97316] transition-colors shadow-sm cursor-pointer text-gray-600"
         >
-          <option value="">전체 제품 보기</option>
-          <option v-for="product in products" :key="product.id" :value="product.id">
-            {{ product.name }}
+          <option value="">전체 매장</option>
+          <option v-for="store in stores" :key="store.id" :value="store.id">
+            {{ store.name }}
           </option>
         </select>
         <div class="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400">
@@ -45,17 +39,17 @@
       </div>
     </div>
 
-    <!-- ── 검색 ── -->
+    <!-- ── 메뉴 목록 테이블 ── -->
     <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
       <div class="overflow-x-auto">
         <table class="w-full text-sm text-left">
           <thead>
           <tr class="border-b border-gray-200 bg-gray-50">
             <th class="px-4 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">메뉴번호</th>
+            <th class="px-4 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">매장명</th>
             <th class="px-4 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">메뉴명</th>
             <th class="px-4 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">가격</th>
             <th class="px-4 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">재료 수</th>
-            <th class="px-4 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">관리</th>
           </tr>
           </thead>
           <tbody class="divide-y divide-gray-100">
@@ -63,24 +57,13 @@
               @click="openIngredientModal(menu)"
               class="hover:bg-gray-50/50 transition-colors cursor-pointer group">
             <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ menu.id }}</td>
+            <td class="px-5 py-3.5 text-gray-600 font-medium">{{ getStoreName(menu.storeId) }}</td>
             <td class="px-5 py-3.5 font-bold text-gray-900 group-hover:text-[#F97316] transition-colors">{{ menu.name }}</td>
             <td class="px-5 py-3.5 text-gray-700 font-semibold">{{ formatPrice(menu.price) }}</td>
             <td class="px-5 py-3.5 text-center">
                 <span class="text-xs font-bold px-2 py-0.5 rounded-full bg-orange-50 text-orange-600">
                   {{ menu.ingredients.length }}종
                 </span>
-            </td>
-            <td class="px-5 py-3.5" @click.stop>
-              <div class="flex justify-center gap-2">
-                <button @click="openEditMenuModal(menu)"
-                        class="px-3 py-1.5 text-xs font-semibold text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer">
-                  수정
-                </button>
-                <button @click="openDeleteConfirm(menu)"
-                        class="px-3 py-1.5 text-xs font-semibold text-red-500 border border-red-400 rounded hover:bg-red-50 transition-colors cursor-pointer">
-                  삭제
-                </button>
-              </div>
             </td>
           </tr>
           <tr v-if="filteredMenus.length === 0">
@@ -92,142 +75,15 @@
     </div>
 
     <!-- ══════════════════════════════════════════
-         신규 메뉴 등록 / 수정 모달
-    ══════════════════════════════════════════ -->
-    <div v-if="showMenuModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div class="absolute inset-0 bg-black/40 " @click="showMenuModal = false"></div>
-      <div class="relative bg-white rounded-xl w-full max-w-xl border border-gray-200 shadow-xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
-
-        <!-- 모달 헤더 -->
-        <div class="px-7 py-5 border-b border-gray-100 flex justify-between items-center bg-gray-50">
-          <h3 class="font-bold text-gray-900 text-lg">{{ editTarget ? '메뉴 수정' : '신규 메뉴 등록' }}</h3>
-          <button @click="showMenuModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl cursor-pointer">✕</button>
-        </div>
-
-        <form @submit.prevent="saveMenu" class="p-7 space-y-5">
-
-          <!-- 메뉴명 / 가격 -->
-          <div class="grid grid-cols-2 gap-4">
-            <div class="space-y-1.5">
-              <label class="text-[11px] font-bold text-gray-400 uppercase tracking-widest">메뉴명</label>
-              <input v-model="menuForm.name" required type="text" placeholder="예: 삼겹살 세트"
-                     class="w-full px-4 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] focus:ring-4 focus:ring-[#F97316]/5 transition-all" />
-            </div>
-            <div class="space-y-1.5">
-              <label class="text-[11px] font-bold text-gray-400 uppercase tracking-widest">가격 (원)</label>
-              <input :value="formattedPriceInput"
-                     @input="onPriceInput"
-                     required
-                     type="text"
-                     placeholder="0"
-                     class="w-full px-4 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] focus:ring-4 focus:ring-[#F97316]/5 transition-all text-right" />
-            </div>
-          </div>
-
-          <!-- 카테고리 -->
-          <div class="space-y-1.5">
-            <label class="text-[11px] font-bold text-gray-400 uppercase tracking-widest">카테고리</label>
-            <div class="flex items-center gap-2 flex-wrap">
-              <button v-for="cat in categories.filter(c => c !== '전체')" :key="cat"
-                      type="button"
-                      @click="menuForm.category = cat"
-                      :class="menuForm.category === cat
-                        ? 'bg-[#F97316] text-white border-[#F97316]'
-                        : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300 hover:bg-gray-50'"
-                      class="px-3 py-1.5 rounded-lg border text-xs font-semibold transition-all cursor-pointer">
-                {{ cat }}
-              </button>
-            </div>
-          </div>
-
-          <!-- 이미지 업로드 -->
-          <div class="space-y-1.5">
-            <label class="text-[11px] font-bold text-gray-400 uppercase tracking-widest">메뉴 이미지</label>
-            <label class="cursor-pointer block">
-              <div class="w-full px-4 py-3 rounded-lg border-2 border-dashed border-gray-200 text-sm text-gray-400 bg-gray-50 hover:bg-gray-100 hover:border-[#F97316]/40 transition-all flex items-center justify-between">
-                <span>{{ menuForm.imageName || '이미지를 업로드하세요' }}</span>
-                <ImageIcon class="w-4 h-4 flex-shrink-0" />
-              </div>
-              <input type="file" class="hidden" @change="handleImageChange" accept="image/*" />
-            </label>
-          </div>
-
-          <div class="border-t border-gray-100 pt-5">
-            <!-- 재료 헤더 -->
-            <div class="flex items-center justify-between mb-3">
-              <span class="text-sm font-bold text-gray-700">재료 등록</span>
-              <button type="button" @click="addIngredientRow"
-                      class="flex items-center gap-1 text-xs font-bold text-[#F97316] hover:text-[#EA6700] transition-colors cursor-pointer">
-                <Plus class="w-3.5 h-3.5" /> 재료 추가
-              </button>
-            </div>
-
-            <!-- 재료 컬럼 레이블 -->
-            <div class="grid grid-cols-[2fr_1fr_1fr_32px] gap-2 mb-2 px-0.5">
-              <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">상품명</span>
-              <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">소요량</span>
-              <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</span>
-              <span></span>
-            </div>
-
-            <!-- 재료 행 목록 -->
-            <div class="space-y-2">
-              <div v-for="(item, idx) in menuForm.ingredients" :key="idx"
-                   class="grid grid-cols-[2fr_1fr_1fr_32px] gap-2 items-center">
-                <select v-model="item.productId"
-                        class="w-full px-3 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] focus:ring-4 focus:ring-[#F97316]/5 transition-all">
-                  <option value="">상품 선택</option>
-                  <option v-for="p in products" :key="p.id" :value="p.id">{{ p.name }}</option>
-                </select>
-                <input v-model.number="item.amount" type="number" placeholder="0" min="0" step="any"
-                       class="w-full px-3 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] focus:ring-4 focus:ring-[#F97316]/5 transition-all" />
-                <select v-model="item.unit"
-                        class="w-full px-3 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] focus:ring-4 focus:ring-[#F97316]/5 transition-all">
-                  <option value="">단위 선택</option>
-                  <option>kg</option>
-                  <option>g</option>
-                  <option>L</option>
-                  <option>ml</option>
-                  <option>개</option>
-                  <option>봉</option>
-                  <option>박스</option>
-                  <option>묶음</option>
-                </select>
-                <button type="button" @click="removeIngredientRow(idx)"
-                        class="w-8 h-8 flex items-center justify-center rounded-lg bg-red-50 text-red-400 hover:bg-red-100 hover:text-red-600 transition-colors text-sm font-bold cursor-pointer">
-                  ✕
-                </button>
-              </div>
-              <p v-if="menuForm.ingredients.length === 0" class="text-xs text-gray-300 py-2 text-center">
-                재료를 추가해주세요
-              </p>
-            </div>
-          </div>
-
-          <!-- 버튼 -->
-          <div class="flex gap-3 pt-2">
-            <button type="button" @click="showMenuModal = false"
-                    class="flex-1 py-3 rounded-lg border border-gray-200 text-sm font-bold text-gray-500 hover:bg-gray-50 transition-colors cursor-pointer">
-              취소
-            </button>
-            <button type="submit"
-                    class="flex-1 py-3 rounded-lg bg-[#F97316] text-white text-sm font-bold hover:bg-[#EA6700] transition-colors shadow-sm cursor-pointer">
-              {{ editTarget ? '수정 저장' : '등록하기' }}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-
-    <!-- ══════════════════════════════════════════
          재료 목록 상세 모달
     ══════════════════════════════════════════ -->
     <div v-if="showIngredientModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div class="absolute inset-0 bg-black/40 " @click="showIngredientModal = false"></div>
-      <div class="relative bg-white rounded-xl w-full max-w-lg border border-gray-200 shadow-xl overflow-hidden max-h-[85vh] flex flex-col animate-in fade-in slide-in-from-bottom-4 duration-200">
+      <div class="absolute inset-0 bg-black/40" @click="showIngredientModal = false"></div>
+      <div class="relative bg-white rounded-xl w-full max-w-lg border border-gray-200 shadow-xl overflow-hidden max-h-[85vh] flex flex-col">
 
         <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
           <div>
+            <p class="text-xs text-gray-400 font-medium mb-0.5">{{ getStoreName(selectedMenu?.storeId) }}</p>
             <h3 class="font-bold text-gray-900">{{ selectedMenu?.name }}</h3>
             <p class="text-xs text-gray-400 font-mono mt-0.5">{{ selectedMenu?.id }}</p>
           </div>
@@ -258,32 +114,10 @@
             </tbody>
           </table>
         </div>
-        <div class="px-6 py-4 border-t border-gray-100 flex justify-end">
+        <div class="shrink-0 px-6 py-4 border-t border-gray-100 flex justify-end">
           <button @click="showIngredientModal = false"
-                  class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded hover:bg-gray-50 cursor-pointer">
+                  class="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors">
             닫기
-          </button>
-        </div>
-      </div>
-    </div>
-
-    <!-- ══════════════════════════════════════════
-         삭제 확인 모달
-    ══════════════════════════════════════════ -->
-    <div v-if="showDeleteConfirm" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div class="absolute inset-0 bg-black/40 " @click="showDeleteConfirm = false"></div>
-      <div class="relative bg-white rounded-xl w-full max-w-sm border border-gray-200 shadow-xl p-8 text-center animate-in fade-in zoom-in-95 duration-200">
-        <div class="text-4xl mb-4">🗑️</div>
-        <h3 class="font-bold text-gray-900 text-base mb-2">메뉴를 삭제하시겠습니까?</h3>
-        <p class="text-xs text-gray-400 mb-6">이 작업은 되돌릴 수 없습니다.</p>
-        <div class="flex gap-3">
-          <button @click="showDeleteConfirm = false"
-                  class="flex-1 py-2.5 rounded-lg border border-gray-200 text-sm font-bold text-gray-500 hover:bg-gray-50 transition-colors cursor-pointer">
-            취소
-          </button>
-          <button @click="confirmDelete"
-                  class="flex-1 py-2.5 rounded-lg bg-red-500 text-white text-sm font-bold hover:bg-red-600 transition-colors cursor-pointer">
-            삭제
           </button>
         </div>
       </div>
@@ -294,17 +128,42 @@
 
 <script setup>
 import { ref, computed } from 'vue'
-import { Plus, Trash2, Search, Image as ImageIcon, ChevronDown } from 'lucide-vue-next'
+import { Search, ChevronDown } from 'lucide-vue-next'
 
 // ─────────────────────────────────────────────
-//  상품 목록 (제품 관리에서 연동 가정)
+//  매장 목록
+// ─────────────────────────────────────────────
+const stores = ref([
+  { id: 'S001', name: '한우 오마카세' },
+  { id: 'S002', name: '이탈리안 키친' },
+  { id: 'S003', name: '일식 스시바' },
+  { id: 'S004', name: '차이나 가든' },
+  { id: 'S005', name: '프렌치 비스트로' },
+])
+
+// ─────────────────────────────────────────────
+//  제품 목록
 // ─────────────────────────────────────────────
 const products = ref([
-  { id: 'P-001', name: 'BBQ 생닭 ' },
-  { id: 'P-002', name: '황금올리브 파우더' },
-  { id: 'P-003', name: '엑스트라버진 올리브오일' },
-  { id: 'P-004', name: '시크릿 양념' },
-  { id: 'P-005', name: '치킨무 ' },
+  { id: 'P-001', name: '한우 등심' },
+  { id: 'P-002', name: '한우 안심' },
+  { id: 'P-003', name: '돼지 삼겹살' },
+  { id: 'P-004', name: '닭 가슴살' },
+  { id: 'P-005', name: '연어' },
+  { id: 'P-006', name: '참치' },
+  { id: 'P-007', name: '새우' },
+  { id: 'P-008', name: '양파' },
+  { id: 'P-009', name: '마늘' },
+  { id: 'P-010', name: '대파' },
+  { id: 'P-011', name: '파프리카' },
+  { id: 'P-012', name: '간장' },
+  { id: 'P-013', name: '고추장' },
+  { id: 'P-014', name: '된장' },
+  { id: 'P-015', name: '올리브오일' },
+  { id: 'P-016', name: '버터' },
+  { id: 'P-017', name: '생크림' },
+  { id: 'P-018', name: '콜라' },
+  { id: 'P-019', name: '생수' },
 ])
 
 // ─────────────────────────────────────────────
@@ -312,31 +171,90 @@ const products = ref([
 // ─────────────────────────────────────────────
 const menus = ref([
   {
-    id: 'M-001', name: '황금올리브치킨', price: 20000, imageName: '', category: '육류',
+    id: 'M-001', storeId: 'S001', name: '한우 등심 오마카세 코스', price: 180000,
     ingredients: [
-      { productId: 'P-001', amount: 1, unit: '개' },
-      { productId: 'P-002', amount: 150, unit: 'g' },
-      { productId: 'P-003', amount: 100, unit: 'ml' },
-      { productId: 'P-005', amount: 1, unit: '개' },
-    ]
+      { productId: 'P-001', amount: 0.3, unit: 'kg' },
+      { productId: 'P-009', amount: 20, unit: 'g' },
+      { productId: 'P-012', amount: 50, unit: 'ml' },
+      { productId: 'P-015', amount: 30, unit: 'ml' },
+    ],
   },
   {
-    id: 'M-002', name: '황금올리브 양념치킨', price: 21500, imageName: '', category: '육류',
+    id: 'M-002', storeId: 'S001', name: '한우 안심 스테이크', price: 120000,
     ingredients: [
-      { productId: 'P-001', amount: 1, unit: '개' },
-      { productId: 'P-002', amount: 150, unit: 'g' },
-      { productId: 'P-003', amount: 100, unit: 'ml' },
-      { productId: 'P-004', amount: 200, unit: 'g' },
-      { productId: 'P-005', amount: 1, unit: '개' },
-    ]
+      { productId: 'P-002', amount: 0.25, unit: 'kg' },
+      { productId: 'P-016', amount: 30, unit: 'g' },
+      { productId: 'P-008', amount: 50, unit: 'g' },
+      { productId: 'P-011', amount: 40, unit: 'g' },
+    ],
   },
   {
-    id: 'M-003', name: '자메이카 통다리구이', price: 21500, imageName: '', category: '육류',
+    id: 'M-003', storeId: 'S002', name: '뇨끼 크림 파스타', price: 28000,
     ingredients: [
-      { productId: 'P-001', amount: 0.8, unit: 'kg' },
-      { productId: 'P-004', amount: 250, unit: 'g' },
-      { productId: 'P-005', amount: 1, unit: '개' },
-    ]
+      { productId: 'P-017', amount: 150, unit: 'ml' },
+      { productId: 'P-016', amount: 20, unit: 'g' },
+      { productId: 'P-008', amount: 30, unit: 'g' },
+      { productId: 'P-009', amount: 10, unit: 'g' },
+    ],
+  },
+  {
+    id: 'M-004', storeId: 'S002', name: '해산물 리조또', price: 32000,
+    ingredients: [
+      { productId: 'P-005', amount: 80, unit: 'g' },
+      { productId: 'P-007', amount: 60, unit: 'g' },
+      { productId: 'P-017', amount: 100, unit: 'ml' },
+      { productId: 'P-015', amount: 20, unit: 'ml' },
+      { productId: 'P-008', amount: 40, unit: 'g' },
+    ],
+  },
+  {
+    id: 'M-005', storeId: 'S003', name: '연어 스시 플래터', price: 65000,
+    ingredients: [
+      { productId: 'P-005', amount: 0.2, unit: 'kg' },
+      { productId: 'P-012', amount: 30, unit: 'ml' },
+      { productId: 'P-009', amount: 5, unit: 'g' },
+    ],
+  },
+  {
+    id: 'M-006', storeId: 'S003', name: '참치 사시미', price: 72000,
+    ingredients: [
+      { productId: 'P-006', amount: 0.18, unit: 'kg' },
+      { productId: 'P-012', amount: 30, unit: 'ml' },
+      { productId: 'P-010', amount: 10, unit: 'g' },
+    ],
+  },
+  {
+    id: 'M-007', storeId: 'S004', name: '새우 볶음밥', price: 22000,
+    ingredients: [
+      { productId: 'P-007', amount: 100, unit: 'g' },
+      { productId: 'P-008', amount: 60, unit: 'g' },
+      { productId: 'P-010', amount: 20, unit: 'g' },
+      { productId: 'P-012', amount: 20, unit: 'ml' },
+    ],
+  },
+  {
+    id: 'M-008', storeId: 'S004', name: '마파두부', price: 18000,
+    ingredients: [
+      { productId: 'P-003', amount: 80, unit: 'g' },
+      { productId: 'P-013', amount: 30, unit: 'g' },
+      { productId: 'P-009', amount: 15, unit: 'g' },
+      { productId: 'P-010', amount: 10, unit: 'g' },
+    ],
+  },
+  {
+    id: 'M-009', storeId: 'S005', name: '크로크무슈', price: 24000,
+    ingredients: [
+      { productId: 'P-016', amount: 25, unit: 'g' },
+      { productId: 'P-017', amount: 80, unit: 'ml' },
+      { productId: 'P-008', amount: 30, unit: 'g' },
+    ],
+  },
+  {
+    id: 'M-010', storeId: 'S005', name: '크렘브륄레', price: 16000,
+    ingredients: [
+      { productId: 'P-017', amount: 200, unit: 'ml' },
+      { productId: 'P-016', amount: 15, unit: 'g' },
+    ],
   },
 ])
 
@@ -344,100 +262,24 @@ const menus = ref([
 //  검색 및 필터링
 // ─────────────────────────────────────────────
 const searchQuery = ref('')
-const selectedProductId = ref('') // 제품 드롭다운 필터용 상태
-const categories = ['전체', '육류', '음료', '채소', '소스', '기타']
+const selectedStoreId = ref('')
 
 const filteredMenus = computed(() => {
   let list = menus.value
 
-  // 제품 드롭다운 필터: 선택한 제품이 재료(ingredients)에 포함되어 있는지 확인
-  if (selectedProductId.value) {
-    list = list.filter(m => m.ingredients.some(ing => ing.productId === selectedProductId.value))
+  if (selectedStoreId.value) {
+    list = list.filter(m => m.storeId === selectedStoreId.value)
   }
 
-  // 텍스트 검색 (메뉴명)
   const q = searchQuery.value.trim().toLowerCase()
   if (q) {
-    list = list.filter(m => m.name.toLowerCase().includes(q))
+    list = list.filter(m =>
+      m.name.toLowerCase().includes(q) ||
+      getStoreName(m.storeId).toLowerCase().includes(q)
+    )
   }
   return list
 })
-
-// ─────────────────────────────────────────────
-//  메뉴 등록 / 수정 모달
-// ─────────────────────────────────────────────
-const showMenuModal = ref(false)
-const editTarget = ref(null)
-const menuForm = ref({ name: '', price: 0, imageName: '', category: '전체', ingredients: [] })
-const formattedPriceInput = ref('')
-
-function openNewMenuModal() {
-  editTarget.value = null
-  menuForm.value = { name: '', price: 0, imageName: '', category: '육류', ingredients: [] }
-  formattedPriceInput.value = ''
-  showMenuModal.value = true
-}
-
-function openEditMenuModal(menu) {
-  editTarget.value = menu
-  menuForm.value = {
-    name: menu.name,
-    price: menu.price,
-    imageName: menu.imageName,
-    category: menu.category,
-    ingredients: menu.ingredients.map(i => ({ ...i })),
-  }
-  formattedPriceInput.value = menu.price.toLocaleString('ko-KR')
-  showMenuModal.value = true
-}
-
-const onPriceInput = (e) => {
-  const val = e.target.value.replace(/[^0-9]/g, '');
-  menuForm.value.price = val ? parseInt(val, 10) : 0;
-  e.target.value = val ? menuForm.value.price.toLocaleString('ko-KR') : '';
-};
-
-function addIngredientRow() {
-  menuForm.value.ingredients.push({ productId: '', amount: 0, unit: '' })
-}
-
-function removeIngredientRow(idx) {
-  menuForm.value.ingredients.splice(idx, 1)
-}
-
-function handleImageChange(e) {
-  const file = e.target.files[0]
-  if (file) menuForm.value.imageName = file.name
-}
-
-function saveMenu() {
-  if (editTarget.value) {
-    // 수정
-    Object.assign(editTarget.value, {
-      name: menuForm.value.name,
-      price: menuForm.value.price,
-      imageName: menuForm.value.imageName,
-      category: menuForm.value.category,
-      ingredients: menuForm.value.ingredients.map(i => ({ ...i })),
-    })
-  } else {
-    // 가장 큰 숫자 ID를 찾아 +1 하기 (ID 충돌 방지)
-    const maxIdNum = menus.value.reduce((max, menu) => {
-      const idNum = parseInt(menu.id.split('-')[1]);
-      return idNum > max ? idNum : max;
-    }, 0);
-    const newId = `M-${String(maxIdNum + 1).padStart(3, '0')}`;
-    menus.value.push({
-      id: newId,
-      name: menuForm.value.name,
-      price: menuForm.value.price,
-      imageName: menuForm.value.imageName,
-      category: menuForm.value.category,
-      ingredients: menuForm.value.ingredients.map(i => ({ ...i })),
-    })
-  }
-  showMenuModal.value = false
-}
 
 // ─────────────────────────────────────────────
 //  재료 목록 모달
@@ -450,44 +292,17 @@ function openIngredientModal(menu) {
   showIngredientModal.value = true
 }
 
+// ─────────────────────────────────────────────
+//  유틸
+// ─────────────────────────────────────────────
+function getStoreName(storeId) {
+  return stores.value.find(s => s.id === storeId)?.name ?? storeId
+}
+
 function getProductName(productId) {
   return products.value.find(p => p.id === productId)?.name ?? productId
 }
 
-function editIngredient(idx) {
-  // 재료 상세 모달을 닫고 수정 모달로 이동
-  showIngredientModal.value = false
-  openEditMenuModal(selectedMenu.value)
-}
-
-function deleteIngredient(idx) {
-  if (selectedMenu.value) {
-    selectedMenu.value.ingredients.splice(idx, 1)
-  }
-}
-
-// ─────────────────────────────────────────────
-//  삭제 확인 모달
-// ─────────────────────────────────────────────
-const showDeleteConfirm = ref(false)
-const deleteTarget = ref(null)
-
-function openDeleteConfirm(menu) {
-  deleteTarget.value = menu
-  showDeleteConfirm.value = true
-}
-
-function confirmDelete() {
-  if (deleteTarget.value) {
-    menus.value = menus.value.filter(m => m.id !== deleteTarget.value.id)
-  }
-  showDeleteConfirm.value = false
-  deleteTarget.value = null
-}
-
-// ─────────────────────────────────────────────
-//  유틸
-// ─────────────────────────────────────────────
 function formatPrice(price) {
   return '₩ ' + price.toLocaleString('ko-KR')
 }

--- a/frontend/src/views/StoreView.vue
+++ b/frontend/src/views/StoreView.vue
@@ -99,7 +99,7 @@
         </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
-        <tr v-for="(store, index) in filteredStores" :key="store.id"
+        <tr v-for="store in filteredStores" :key="store.id"
             @click="openDetail(store)"
             class="hover:bg-gray-50/50 transition-colors cursor-pointer group"
             :class="{ 'bg-gray-50/40 opacity-70': store.closeDate }">


### PR DESCRIPTION
## Summary
- 제품 관리: 갤러리아 식자재 19종 데이터로 교체, 매장별 탭 제거 후 입점 매장 컬럼으로 통합
- 제품 관리: 동일 제품을 여러 매장이 사용할 경우 매장별 행 분리 표시, 제품명·매장명 동시 검색 지원
- 메뉴 관리: 조회 전용으로 변경 (등록/수정/삭제 제거), 매장 필터 드롭다운 및 매장명 컬럼 추가

## Test plan
- [ ] 제품 목록에서 제품명으로 검색 시 정상 필터링
- [ ] 제품 목록에서 매장명으로 검색 시 해당 매장 제품만 표시
- [ ] 두 개 이상 매장이 공유하는 제품이 각 매장별로 별도 행으로 표시
- [ ] 카테고리 필터 정상 동작
- [ ] 메뉴 관리 페이지에서 등록/수정/삭제 버튼 미노출 확인
- [ ] 메뉴명 및 매장명으로 검색 정상 동작
- [ ] 행 클릭 시 재료 상세 모달 정상 표시 (읽기 전용)

## Issue
Closes #289 