### PR TITLE
[Fix] 매장 제품 관리 더미데이터 갤러리아 기준으로 교체

### DIFF
--- a/frontend/src/views/store/StoreProductView.vue
+++ b/frontend/src/views/store/StoreProductView.vue
@@ -160,32 +160,32 @@
 import { ref, computed } from 'vue'
 import { Plus, Search } from 'lucide-vue-next'
 
-const categories = ref(['한우·정육', '수산물', '채소·신선', '양념·소스', '유제품', '음료·기타'])
+const categories = ref(['육류', '어류', '채소', '소스류', '오일/유제품', '음료'])
 const selectedCategory = ref('전체')
 const searchQuery = ref('')
 
 const products = ref([
-  { code: 'P101', name: '한우 등심',   category: '한우·정육', unit: 'kg',  baseStock: 50,  minStock: 10, price: 85000, expiryDays: 3 },
-  { code: 'P102', name: '한우 안심',   category: '한우·정육', unit: 'kg',  baseStock: 30,  minStock: 8,  price: 95000, expiryDays: 3 },
-  { code: 'P103', name: '한우 채끝',   category: '한우·정육', unit: 'kg',  baseStock: 20,  minStock: 5,  price: 78000, expiryDays: 3 },
+  { code: 'P100', name: '한우 등심',  category: '육류',        unit: 'kg',   baseStock: 50,  minStock: 10, price: 85000, expiryDays: 5  },
+  { code: 'P101', name: '한우 안심',  category: '육류',        unit: 'kg',   baseStock: 30,  minStock: 8,  price: 95000, expiryDays: 5  },
+  { code: 'P102', name: '한우 채끝',  category: '육류',        unit: 'kg',   baseStock: 20,  minStock: 5,  price: 78000, expiryDays: 5  },
 
-  { code: 'P201', name: '연어 필렛',   category: '수산물',    unit: 'kg',  baseStock: 30,  minStock: 8,  price: 32000, expiryDays: 2 },
-  { code: 'P202', name: '참치 블록',   category: '수산물',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 45000, expiryDays: 2 },
-  { code: 'P203', name: '새우',        category: '수산물',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 28000, expiryDays: 3 },
+  { code: 'P200', name: '연어 필렛',  category: '어류',        unit: 'kg',   baseStock: 30,  minStock: 8,  price: 32000, expiryDays: 2  },
+  { code: 'P201', name: '참치 블록',  category: '어류',        unit: 'kg',   baseStock: 20,  minStock: 5,  price: 45000, expiryDays: 2  },
+  { code: 'P202', name: '새우',       category: '어류',        unit: 'kg',   baseStock: 20,  minStock: 5,  price: 28000, expiryDays: 3  },
 
-  { code: 'P301', name: '양파',        category: '채소·신선', unit: 'kg',  baseStock: 100, minStock: 20, price: 1500,  expiryDays: 14 },
-  { code: 'P302', name: '마늘',        category: '채소·신선', unit: 'kg',  baseStock: 50,  minStock: 10, price: 8000,  expiryDays: 14 },
-  { code: 'P303', name: '대파',        category: '채소·신선', unit: 'kg',  baseStock: 30,  minStock: 8,  price: 3000,  expiryDays: 7  },
+  { code: 'P300', name: '양파',       category: '채소',        unit: 'kg',   baseStock: 100, minStock: 20, price: 1500,  expiryDays: 14 },
+  { code: 'P301', name: '마늘',       category: '채소',        unit: 'kg',   baseStock: 50,  minStock: 10, price: 8000,  expiryDays: 14 },
+  { code: 'P302', name: '대파',       category: '채소',        unit: 'kg',   baseStock: 30,  minStock: 8,  price: 3000,  expiryDays: 7  },
 
-  { code: 'P401', name: '간장',        category: '양념·소스', unit: 'L',   baseStock: 30,  minStock: 8,  price: 4000,  expiryDays: null },
-  { code: 'P402', name: '올리브오일',  category: '양념·소스', unit: 'L',   baseStock: 20,  minStock: 5,  price: 12000, expiryDays: null },
-  { code: 'P403', name: '고추장',      category: '양념·소스', unit: 'kg',  baseStock: 20,  minStock: 5,  price: 6000,  expiryDays: 60  },
+  { code: 'P400', name: '간장',       category: '소스류',      unit: 'L',    baseStock: 30,  minStock: 8,  price: 4000,  expiryDays: null },
+  { code: 'P401', name: '고추장',     category: '소스류',      unit: 'kg',   baseStock: 20,  minStock: 5,  price: 5500,  expiryDays: null },
 
-  { code: 'P501', name: '버터',        category: '유제품',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 9000,  expiryDays: 14 },
-  { code: 'P502', name: '생크림',      category: '유제품',    unit: 'L',   baseStock: 20,  minStock: 5,  price: 7000,  expiryDays: 7  },
+  { code: 'P500', name: '올리브오일', category: '오일/유제품', unit: 'L',    baseStock: 20,  minStock: 5,  price: 12000, expiryDays: null },
+  { code: 'P501', name: '버터',       category: '오일/유제품', unit: 'kg',   baseStock: 20,  minStock: 5,  price: 9000,  expiryDays: 14 },
+  { code: 'P502', name: '생크림',     category: '오일/유제품', unit: 'L',    baseStock: 20,  minStock: 5,  price: 7000,  expiryDays: 7  },
 
-  { code: 'P601', name: '콜라',        category: '음료·기타', unit: '박스', baseStock: 100, minStock: 20, price: 1200,  expiryDays: null },
-  { code: 'P602', name: '생수',        category: '음료·기타', unit: '박스', baseStock: 80,  minStock: 20, price: 800,   expiryDays: null },
+  { code: 'P600', name: '콜라',       category: '음료',        unit: '박스', baseStock: 100, minStock: 20, price: 15000, expiryDays: null },
+  { code: 'P601', name: '생수',       category: '음료',        unit: '박스', baseStock: 80,  minStock: 20, price: 8000,  expiryDays: null },
 ])
 
 const filteredProducts = computed(() => {

--- a/frontend/src/views/store/StoreProductView.vue
+++ b/frontend/src/views/store/StoreProductView.vue
@@ -160,24 +160,32 @@
 import { ref, computed } from 'vue'
 import { Plus, Search } from 'lucide-vue-next'
 
-const categories = ref(['육류', '소스', '채소', '가공식품', '음료'])
+const categories = ref(['한우·정육', '수산물', '채소·신선', '양념·소스', '유제품', '음료·기타'])
 const selectedCategory = ref('전체')
 const searchQuery = ref('')
 
 const products = ref([
-  { code: 'P100', name: '닭(10호)', category: '육류', unit: '마리', baseStock: 120, minStock: 30, price: 7000, expiryDays: 3 },
-  { code: 'P101', name: '닭(부분육-윙)', category: '육류', unit: 'kg', baseStock: 80, minStock: 20, price: 9000, expiryDays: 3 },
-  { code: 'P102', name: '닭(부분육-다리)', category: '육류', unit: 'kg', baseStock: 80, minStock: 20, price: 9500, expiryDays: 3 },
+  { code: 'P101', name: '한우 등심',   category: '한우·정육', unit: 'kg',  baseStock: 50,  minStock: 10, price: 85000, expiryDays: 3 },
+  { code: 'P102', name: '한우 안심',   category: '한우·정육', unit: 'kg',  baseStock: 30,  minStock: 8,  price: 95000, expiryDays: 3 },
+  { code: 'P103', name: '한우 채끝',   category: '한우·정육', unit: 'kg',  baseStock: 20,  minStock: 5,  price: 78000, expiryDays: 3 },
 
-  { code: 'P200', name: '양념소스', category: '소스', unit: 'kg', baseStock: 50, minStock: 10, price: 4000, expiryDays: 30 },
-  { code: 'P201', name: '매운양념소스', category: '소스', unit: 'kg', baseStock: 50, minStock: 10, price: 4500, expiryDays: 30 },
-  { code: 'P202', name: '파우더(튀김가루)', category: '소스', unit: 'kg', baseStock: 100, minStock: 20, price: 2000, expiryDays: 60 },
+  { code: 'P201', name: '연어 필렛',   category: '수산물',    unit: 'kg',  baseStock: 30,  minStock: 8,  price: 32000, expiryDays: 2 },
+  { code: 'P202', name: '참치 블록',   category: '수산물',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 45000, expiryDays: 2 },
+  { code: 'P203', name: '새우',        category: '수산물',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 28000, expiryDays: 3 },
 
-  { code: 'P300', name: '감자', category: '채소', unit: 'kg', baseStock: 150, minStock: 40, price: 1500, expiryDays: 14 },
-  { code: 'P301', name: '치즈볼 원재료', category: '가공식품', unit: '팩', baseStock: 100, minStock: 30, price: 3000, expiryDays: 10 },
+  { code: 'P301', name: '양파',        category: '채소·신선', unit: 'kg',  baseStock: 100, minStock: 20, price: 1500,  expiryDays: 14 },
+  { code: 'P302', name: '마늘',        category: '채소·신선', unit: 'kg',  baseStock: 50,  minStock: 10, price: 8000,  expiryDays: 14 },
+  { code: 'P303', name: '대파',        category: '채소·신선', unit: 'kg',  baseStock: 30,  minStock: 8,  price: 3000,  expiryDays: 7  },
 
-  { code: 'P400', name: '콜라', category: '음료', unit: '박스', baseStock: 200, minStock: 50, price: 1200, expiryDays: 60 },
-  { code: 'P401', name: '사이다', category: '음료', unit: '박스', baseStock: 180, minStock: 40, price: 1200, expiryDays: 60 },
+  { code: 'P401', name: '간장',        category: '양념·소스', unit: 'L',   baseStock: 30,  minStock: 8,  price: 4000,  expiryDays: null },
+  { code: 'P402', name: '올리브오일',  category: '양념·소스', unit: 'L',   baseStock: 20,  minStock: 5,  price: 12000, expiryDays: null },
+  { code: 'P403', name: '고추장',      category: '양념·소스', unit: 'kg',  baseStock: 20,  minStock: 5,  price: 6000,  expiryDays: 60  },
+
+  { code: 'P501', name: '버터',        category: '유제품',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 9000,  expiryDays: 14 },
+  { code: 'P502', name: '생크림',      category: '유제품',    unit: 'L',   baseStock: 20,  minStock: 5,  price: 7000,  expiryDays: 7  },
+
+  { code: 'P601', name: '콜라',        category: '음료·기타', unit: '박스', baseStock: 100, minStock: 20, price: 1200,  expiryDays: null },
+  { code: 'P602', name: '생수',        category: '음료·기타', unit: '박스', baseStock: 80,  minStock: 20, price: 800,   expiryDays: null },
 ])
 
 const filteredProducts = computed(() => {

--- a/frontend/src/views/store/StoreRecipeView.vue
+++ b/frontend/src/views/store/StoreRecipeView.vue
@@ -302,14 +302,18 @@ import { Plus, Trash2, Search, Image as ImageIcon, ChevronDown } from 'lucide-vu
 const products = ref([
   { id: 'P100', name: '한우 등심' },
   { id: 'P101', name: '한우 안심' },
-  { id: 'P102', name: '연어' },
-  { id: 'P200', name: '간장' },
-  { id: 'P201', name: '고추장' },
-  { id: 'P202', name: '올리브오일' },
+  { id: 'P102', name: '한우 채끝' },
+  { id: 'P200', name: '연어 필렛' },
+  { id: 'P201', name: '참치 블록' },
+  { id: 'P202', name: '새우' },
   { id: 'P300', name: '양파' },
   { id: 'P301', name: '마늘' },
-  { id: 'P400', name: '버터' },
-  { id: 'P401', name: '생크림' },
+  { id: 'P302', name: '대파' },
+  { id: 'P400', name: '간장' },
+  { id: 'P401', name: '고추장' },
+  { id: 'P500', name: '올리브오일' },
+  { id: 'P501', name: '버터' },
+  { id: 'P502', name: '생크림' },
 ])
 
 // ─────────────────────────────────────────────
@@ -319,26 +323,26 @@ const menus = ref([
   {
     id: 'M-001', name: '한우 등심 오마카세 코스', price: 180000, imageName: '', category: '한우',
     ingredients: [
-      { productId: 'P100', amount: 0.3, unit: 'kg' },
-      { productId: 'P301', amount: 20, unit: 'g' },
-      { productId: 'P200', amount: 50, unit: 'ml' },
-      { productId: 'P202', amount: 30, unit: 'ml' },
+      { productId: 'P100', amount: 0.3,  unit: 'kg' },
+      { productId: 'P301', amount: 20,   unit: 'g'  },
+      { productId: 'P400', amount: 50,   unit: 'ml' },
+      { productId: 'P500', amount: 30,   unit: 'ml' },
     ]
   },
   {
     id: 'M-002', name: '한우 안심 스테이크', price: 120000, imageName: '', category: '한우',
     ingredients: [
       { productId: 'P101', amount: 0.25, unit: 'kg' },
-      { productId: 'P400', amount: 30, unit: 'g' },
-      { productId: 'P300', amount: 50, unit: 'g' },
+      { productId: 'P501', amount: 30,   unit: 'g'  },
+      { productId: 'P300', amount: 50,   unit: 'g'  },
     ]
   },
   {
     id: 'M-003', name: '연어 스시 플래터', price: 65000, imageName: '', category: '해산물',
     ingredients: [
-      { productId: 'P102', amount: 0.2, unit: 'kg' },
-      { productId: 'P200', amount: 30, unit: 'ml' },
-      { productId: 'P301', amount: 5, unit: 'g' },
+      { productId: 'P200', amount: 0.2,  unit: 'kg' },
+      { productId: 'P400', amount: 30,   unit: 'ml' },
+      { productId: 'P301', amount: 5,    unit: 'g'  },
     ]
   },
 ])


### PR DESCRIPTION
## Summary
- 매장 제품 관리 페이지의 BBQ 치킨 기반 더미데이터를 갤러리아 푸드코트 식자재 기준으로 전면 교체

## Changed Files
- `views/store/StoreProductView.vue` — 카테고리 및 제품 데이터 교체

## Test plan
- [ ] 매장 페이지 > 제품 관리에서 갤러리아 식자재 목록 확인
- [ ] 카테고리 필터 (한우·정육, 수산물 등) 동작 확인
- [ ] 제품 등록·수정·삭제 정상 동작 확인