### PR TITLE
[Feat] 매장 발주서 AI 추천 이유 패널 추가

### DIFF
--- a/frontend/src/views/store/StoreOrderView.vue
+++ b/frontend/src/views/store/StoreOrderView.vue
@@ -39,6 +39,58 @@
             </button>
           </div>
         </div>
+
+        <!-- AI 추천 이유 배너 -->
+        <div class="border-b border-purple-100 bg-purple-50/60">
+          <button
+            class="w-full px-5 py-3 flex items-center justify-between cursor-pointer hover:bg-purple-50 transition-colors"
+            @click="toggleAiReason(order.id)">
+            <div class="flex items-center gap-2.5">
+              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-purple-100">
+                <Sparkles class="w-3.5 h-3.5 text-purple-600" />
+              </span>
+              <span class="text-xs font-bold text-purple-700">AI 추천 이유</span>
+              <span class="text-xs text-purple-600/80">{{ order.aiReason.summary }}</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <div class="flex gap-1.5">
+                <span
+                  v-for="tag in order.aiReason.contexts"
+                  :key="tag"
+                  class="hidden sm:inline text-[10px] font-semibold px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 border border-purple-200">
+                  {{ tag }}
+                </span>
+              </div>
+              <ChevronDown
+                class="w-4 h-4 text-purple-400 transition-transform duration-200 shrink-0"
+                :class="expandedAiReasons.has(order.id) ? 'rotate-180' : ''" />
+            </div>
+          </button>
+
+          <div v-if="expandedAiReasons.has(order.id)" class="px-5 pb-4 space-y-3">
+            <div class="sm:hidden flex gap-1.5 flex-wrap">
+              <span
+                v-for="tag in order.aiReason.contexts"
+                :key="tag"
+                class="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 border border-purple-200">
+                {{ tag }}
+              </span>
+            </div>
+            <p class="text-xs text-gray-600 leading-relaxed bg-white border border-purple-100 rounded-lg px-4 py-3">
+              {{ order.aiReason.detail }}
+            </p>
+            <div class="grid grid-cols-2 gap-3">
+              <div class="bg-white border border-purple-100 rounded-lg px-4 py-2.5 text-center">
+                <p class="text-[10px] font-bold text-gray-400 uppercase tracking-wider mb-1">최소 발주량</p>
+                <p class="text-sm font-bold text-gray-700">{{ order.aiReason.minQtyLabel }}</p>
+              </div>
+              <div class="bg-purple-600 rounded-lg px-4 py-2.5 text-center">
+                <p class="text-[10px] font-bold text-purple-200 uppercase tracking-wider mb-1">AI 추천 수량</p>
+                <p class="text-sm font-bold text-white">{{ order.aiReason.recommendedQtyLabel }}</p>
+              </div>
+            </div>
+          </div>
+        </div>
         <table class="w-full text-sm">
           <thead>
             <tr class="border-b border-gray-200 bg-gray-50">
@@ -298,8 +350,8 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
-import { ClipboardList, CreditCard } from 'lucide-vue-next'
+import { ref, computed, reactive } from 'vue'
+import { ClipboardList, CreditCard, Sparkles, ChevronDown } from 'lucide-vue-next'
 
 const PRODUCT_UNIT = {
   '한우 등심':  'kg',
@@ -339,9 +391,26 @@ const isModalOpen = ref(false)
 const selectedOrder = ref(null)
 const approvalMessage = ref('')
 
+const expandedAiReasons = reactive(new Set())
+
+function toggleAiReason(orderId) {
+  if (expandedAiReasons.has(orderId)) {
+    expandedAiReasons.delete(orderId)
+  } else {
+    expandedAiReasons.add(orderId)
+  }
+}
+
 const pendingOrders = ref([
   {
     id: 'AUTO-20260413-001', createdAt: '2026-04-13 08:00',
+    aiReason: {
+      summary: '갤러리아 봄 기획전 및 주말 한파 예보로 한우 수요 증가 예상',
+      detail: '4월 15~17일 갤러리아 타임월드 봄 기획전이 예정되어 있습니다. 작년 동일 이벤트 기간에 한우 등심 발주량은 평소 대비 38% 증가했습니다. 또한 이번 주말 기온이 5°C 이하로 내려갈 것으로 예보되어 외식 수요가 높아질 것으로 예상됩니다. 이벤트 기간 품절 방지를 위해 최소 발주량 기준보다 높은 수량을 추천합니다.',
+      contexts: ['갤러리아 봄 기획전 (4/15~17)', '주말 기온 5°C 예보', '작년 동기 발주 +38%'],
+      minQtyLabel: '한우 등심 10kg · 버터 5kg',
+      recommendedQtyLabel: '한우 등심 20kg · 버터 10kg',
+    },
     items: [
       { product: '한우 등심', current: 5, min: 10, suggested: 20, adjusted: 20 },
       { product: '버터',      current: 2, min: 5,  suggested: 10, adjusted: 10 },
@@ -349,6 +418,13 @@ const pendingOrders = ref([
   },
   {
     id: 'AUTO-20260413-002', createdAt: '2026-04-13 08:00',
+    aiReason: {
+      summary: '주말 예약 집중 및 코스 메뉴 소비 증가 패턴 감지',
+      detail: '최근 3주간 올리브오일과 생크림의 주말 소비량이 평일 대비 평균 42% 높게 나타났습니다. 이번 주말은 갤러리아 봄 기획전과 겹쳐 예약이 집중될 것으로 예상되며, 코스 메뉴 레시피 기준 소모량을 고려해 평소보다 높은 수량을 추천합니다. 생크림은 유통기한이 짧으므로 소비 속도에 맞춰 조정하시기 바랍니다.',
+      contexts: ['주말 소비량 평일 대비 +42%', '갤러리아 봄 기획전', '생크림 유통기한 주의'],
+      minQtyLabel: '올리브오일 5L · 생크림 4L',
+      recommendedQtyLabel: '올리브오일 15L · 생크림 12L',
+    },
     items: [
       { product: '올리브오일', current: 2, min: 5, suggested: 15, adjusted: 15 },
       { product: '생크림',     current: 1, min: 4, suggested: 12, adjusted: 12 },

--- a/frontend/src/views/store/StoreOrderView.vue
+++ b/frontend/src/views/store/StoreOrderView.vue
@@ -41,22 +41,22 @@
         </div>
 
         <!-- AI 추천 이유 배너 -->
-        <div class="border-b border-purple-100 bg-purple-50/60">
+        <div v-if="order.aiReason" class="border-b border-purple-100 bg-purple-50/60">
           <button
             class="w-full px-5 py-3 flex items-center justify-between cursor-pointer hover:bg-purple-50 transition-colors"
             @click="toggleAiReason(order.id)">
-            <div class="flex items-center gap-2.5">
-              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-purple-100">
+            <div class="flex items-center gap-2.5 min-w-0">
+              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-purple-100 shrink-0">
                 <Sparkles class="w-3.5 h-3.5 text-purple-600" />
               </span>
-              <span class="text-xs font-bold text-purple-700">AI 추천 이유</span>
-              <span class="text-xs text-purple-600/80">{{ order.aiReason.summary }}</span>
+              <span class="text-xs font-bold text-purple-700 shrink-0">AI 추천 이유</span>
+              <span class="text-xs text-purple-600/80 truncate">{{ order.aiReason.summary }}</span>
             </div>
-            <div class="flex items-center gap-2">
+            <div class="flex items-center gap-2 shrink-0 ml-2">
               <div class="flex gap-1.5">
                 <span
-                  v-for="tag in order.aiReason.contexts"
-                  :key="tag"
+                  v-for="(tag, idx) in order.aiReason.contexts"
+                  :key="`${order.id}-tag-${idx}`"
                   class="hidden sm:inline text-[10px] font-semibold px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 border border-purple-200">
                   {{ tag }}
                 </span>
@@ -70,8 +70,8 @@
           <div v-if="expandedAiReasons.has(order.id)" class="px-5 pb-4 space-y-3">
             <div class="sm:hidden flex gap-1.5 flex-wrap">
               <span
-                v-for="tag in order.aiReason.contexts"
-                :key="tag"
+                v-for="(tag, idx) in order.aiReason.contexts"
+                :key="`${order.id}-tag-mobile-${idx}`"
                 class="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 border border-purple-200">
                 {{ tag }}
               </span>
@@ -82,11 +82,11 @@
             <div class="grid grid-cols-2 gap-3">
               <div class="bg-white border border-purple-100 rounded-lg px-4 py-2.5 text-center">
                 <p class="text-[10px] font-bold text-gray-400 uppercase tracking-wider mb-1">최소 발주량</p>
-                <p class="text-sm font-bold text-gray-700">{{ order.aiReason.minQtyLabel }}</p>
+                <p class="text-sm font-bold text-gray-700">{{ minQtyLabel(order) }}</p>
               </div>
               <div class="bg-purple-600 rounded-lg px-4 py-2.5 text-center">
                 <p class="text-[10px] font-bold text-purple-200 uppercase tracking-wider mb-1">AI 추천 수량</p>
-                <p class="text-sm font-bold text-white">{{ order.aiReason.recommendedQtyLabel }}</p>
+                <p class="text-sm font-bold text-white">{{ recommendedQtyLabel(order) }}</p>
               </div>
             </div>
           </div>
@@ -401,6 +401,18 @@ function toggleAiReason(orderId) {
   }
 }
 
+function minQtyLabel(order) {
+  return order.items
+    .map(i => `${i.product} ${i.min}${PRODUCT_UNIT[i.product] ?? ''}`)
+    .join(' · ')
+}
+
+function recommendedQtyLabel(order) {
+  return order.items
+    .map(i => `${i.product} ${i.suggested}${PRODUCT_UNIT[i.product] ?? ''}`)
+    .join(' · ')
+}
+
 const pendingOrders = ref([
   {
     id: 'AUTO-20260413-001', createdAt: '2026-04-13 08:00',
@@ -408,8 +420,6 @@ const pendingOrders = ref([
       summary: '갤러리아 봄 기획전 및 주말 한파 예보로 한우 수요 증가 예상',
       detail: '4월 15~17일 갤러리아 타임월드 봄 기획전이 예정되어 있습니다. 작년 동일 이벤트 기간에 한우 등심 발주량은 평소 대비 38% 증가했습니다. 또한 이번 주말 기온이 5°C 이하로 내려갈 것으로 예보되어 외식 수요가 높아질 것으로 예상됩니다. 이벤트 기간 품절 방지를 위해 최소 발주량 기준보다 높은 수량을 추천합니다.',
       contexts: ['갤러리아 봄 기획전 (4/15~17)', '주말 기온 5°C 예보', '작년 동기 발주 +38%'],
-      minQtyLabel: '한우 등심 10kg · 버터 5kg',
-      recommendedQtyLabel: '한우 등심 20kg · 버터 10kg',
     },
     items: [
       { product: '한우 등심', current: 5, min: 10, suggested: 20, adjusted: 20 },
@@ -422,8 +432,6 @@ const pendingOrders = ref([
       summary: '주말 예약 집중 및 코스 메뉴 소비 증가 패턴 감지',
       detail: '최근 3주간 올리브오일과 생크림의 주말 소비량이 평일 대비 평균 42% 높게 나타났습니다. 이번 주말은 갤러리아 봄 기획전과 겹쳐 예약이 집중될 것으로 예상되며, 코스 메뉴 레시피 기준 소모량을 고려해 평소보다 높은 수량을 추천합니다. 생크림은 유통기한이 짧으므로 소비 속도에 맞춰 조정하시기 바랍니다.',
       contexts: ['주말 소비량 평일 대비 +42%', '갤러리아 봄 기획전', '생크림 유통기한 주의'],
-      minQtyLabel: '올리브오일 5L · 생크림 4L',
-      recommendedQtyLabel: '올리브오일 15L · 생크림 12L',
     },
     items: [
       { product: '올리브오일', current: 2, min: 5, suggested: 15, adjusted: 15 },


### PR DESCRIPTION
## Summary
- 자동 발주서에 AI가 해당 수량을 추천한 이유를 확인할 수 있는 패널 추가
- 이벤트·날씨·과거 발주 이력 등 맥락 정보를 컨텍스트 태그로 시각화
- 최소 발주량과 AI 추천 수량을 나란히 비교할 수 있는 카드 UI 제공

## 변경 파일
- `frontend/src/views/store/StoreOrderView.vue`

## 주요 변경 사항
- 발주서 카드 헤더와 테이블 사이에 AI 추천 이유 배너 삽입
- 배너 클릭 시 상세 이유 펼치기/접기 (토글)
- 상세 영역 구성
  - AI 추천 근거 텍스트 (이벤트, 날씨, 과거 발주 패턴 등)
  - 컨텍스트 태그 (`갤러리아 봄 기획전`, `주말 기온 5°C 예보` 등)
  - 최소 발주량 vs AI 추천 수량 비교 카드

## Test Plan
- [ ] 발주서 카드에 AI 추천 이유 배너가 노출되는지 확인
- [ ] 배너 클릭 시 상세 패널이 정상적으로 펼쳐지고 접히는지 확인
- [ ] 컨텍스트 태그가 올바르게 표시되는지 확인
- [ ] 최소 발주량 / AI 추천 수량 비교 카드 UI 확인
- [ ] 기존 전체 확정 · 품목 추가 · 거절 기능 정상 동작 여부 확인

## Issue
Closes #297 