### PR TITLE
[Feature] 매장 발주서 AI 추천 이유 패널 추가 및 안정성 개선

### DIFF
--- a/frontend/src/views/store/StoreOrderView.vue
+++ b/frontend/src/views/store/StoreOrderView.vue
@@ -39,6 +39,58 @@
             </button>
           </div>
         </div>
+
+        <!-- AI 추천 이유 배너 -->
+        <div class="border-b border-purple-100 bg-purple-50/60">
+          <button
+            class="w-full px-5 py-3 flex items-center justify-between cursor-pointer hover:bg-purple-50 transition-colors"
+            @click="toggleAiReason(order.id)">
+            <div class="flex items-center gap-2.5">
+              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-purple-100">
+                <Sparkles class="w-3.5 h-3.5 text-purple-600" />
+              </span>
+              <span class="text-xs font-bold text-purple-700">AI 추천 이유</span>
+              <span class="text-xs text-purple-600/80">{{ order.aiReason.summary }}</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <div class="flex gap-1.5">
+                <span
+                  v-for="tag in order.aiReason.contexts"
+                  :key="tag"
+                  class="hidden sm:inline text-[10px] font-semibold px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 border border-purple-200">
+                  {{ tag }}
+                </span>
+              </div>
+              <ChevronDown
+                class="w-4 h-4 text-purple-400 transition-transform duration-200 shrink-0"
+                :class="expandedAiReasons.has(order.id) ? 'rotate-180' : ''" />
+            </div>
+          </button>
+
+          <div v-if="expandedAiReasons.has(order.id)" class="px-5 pb-4 space-y-3">
+            <div class="sm:hidden flex gap-1.5 flex-wrap">
+              <span
+                v-for="tag in order.aiReason.contexts"
+                :key="tag"
+                class="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 border border-purple-200">
+                {{ tag }}
+              </span>
+            </div>
+            <p class="text-xs text-gray-600 leading-relaxed bg-white border border-purple-100 rounded-lg px-4 py-3">
+              {{ order.aiReason.detail }}
+            </p>
+            <div class="grid grid-cols-2 gap-3">
+              <div class="bg-white border border-purple-100 rounded-lg px-4 py-2.5 text-center">
+                <p class="text-[10px] font-bold text-gray-400 uppercase tracking-wider mb-1">최소 발주량</p>
+                <p class="text-sm font-bold text-gray-700">{{ order.aiReason.minQtyLabel }}</p>
+              </div>
+              <div class="bg-purple-600 rounded-lg px-4 py-2.5 text-center">
+                <p class="text-[10px] font-bold text-purple-200 uppercase tracking-wider mb-1">AI 추천 수량</p>
+                <p class="text-sm font-bold text-white">{{ order.aiReason.recommendedQtyLabel }}</p>
+              </div>
+            </div>
+          </div>
+        </div>
         <table class="w-full text-sm">
           <thead>
             <tr class="border-b border-gray-200 bg-gray-50">
@@ -298,8 +350,8 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
-import { ClipboardList, CreditCard } from 'lucide-vue-next'
+import { ref, computed, reactive } from 'vue'
+import { ClipboardList, CreditCard, Sparkles, ChevronDown } from 'lucide-vue-next'
 
 const PRODUCT_UNIT = {
   '한우 등심':  'kg',
@@ -339,9 +391,26 @@ const isModalOpen = ref(false)
 const selectedOrder = ref(null)
 const approvalMessage = ref('')
 
+const expandedAiReasons = reactive(new Set())
+
+function toggleAiReason(orderId) {
+  if (expandedAiReasons.has(orderId)) {
+    expandedAiReasons.delete(orderId)
+  } else {
+    expandedAiReasons.add(orderId)
+  }
+}
+
 const pendingOrders = ref([
   {
     id: 'AUTO-20260413-001', createdAt: '2026-04-13 08:00',
+    aiReason: {
+      summary: '갤러리아 봄 기획전 및 주말 한파 예보로 한우 수요 증가 예상',
+      detail: '4월 15~17일 갤러리아 타임월드 봄 기획전이 예정되어 있습니다. 작년 동일 이벤트 기간에 한우 등심 발주량은 평소 대비 38% 증가했습니다. 또한 이번 주말 기온이 5°C 이하로 내려갈 것으로 예보되어 외식 수요가 높아질 것으로 예상됩니다. 이벤트 기간 품절 방지를 위해 최소 발주량 기준보다 높은 수량을 추천합니다.',
+      contexts: ['갤러리아 봄 기획전 (4/15~17)', '주말 기온 5°C 예보', '작년 동기 발주 +38%'],
+      minQtyLabel: '한우 등심 10kg · 버터 5kg',
+      recommendedQtyLabel: '한우 등심 20kg · 버터 10kg',
+    },
     items: [
       { product: '한우 등심', current: 5, min: 10, suggested: 20, adjusted: 20 },
       { product: '버터',      current: 2, min: 5,  suggested: 10, adjusted: 10 },
@@ -349,6 +418,13 @@ const pendingOrders = ref([
   },
   {
     id: 'AUTO-20260413-002', createdAt: '2026-04-13 08:00',
+    aiReason: {
+      summary: '주말 예약 집중 및 코스 메뉴 소비 증가 패턴 감지',
+      detail: '최근 3주간 올리브오일과 생크림의 주말 소비량이 평일 대비 평균 42% 높게 나타났습니다. 이번 주말은 갤러리아 봄 기획전과 겹쳐 예약이 집중될 것으로 예상되며, 코스 메뉴 레시피 기준 소모량을 고려해 평소보다 높은 수량을 추천합니다. 생크림은 유통기한이 짧으므로 소비 속도에 맞춰 조정하시기 바랍니다.',
+      contexts: ['주말 소비량 평일 대비 +42%', '갤러리아 봄 기획전', '생크림 유통기한 주의'],
+      minQtyLabel: '올리브오일 5L · 생크림 4L',
+      recommendedQtyLabel: '올리브오일 15L · 생크림 12L',
+    },
     items: [
       { product: '올리브오일', current: 2, min: 5, suggested: 15, adjusted: 15 },
       { product: '생크림',     current: 1, min: 4, suggested: 12, adjusted: 12 },

--- a/frontend/src/views/store/StoreOrderView.vue
+++ b/frontend/src/views/store/StoreOrderView.vue
@@ -41,22 +41,22 @@
         </div>
 
         <!-- AI 추천 이유 배너 -->
-        <div class="border-b border-purple-100 bg-purple-50/60">
+        <div v-if="order.aiReason" class="border-b border-purple-100 bg-purple-50/60">
           <button
             class="w-full px-5 py-3 flex items-center justify-between cursor-pointer hover:bg-purple-50 transition-colors"
             @click="toggleAiReason(order.id)">
-            <div class="flex items-center gap-2.5">
-              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-purple-100">
+            <div class="flex items-center gap-2.5 min-w-0">
+              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-purple-100 shrink-0">
                 <Sparkles class="w-3.5 h-3.5 text-purple-600" />
               </span>
-              <span class="text-xs font-bold text-purple-700">AI 추천 이유</span>
-              <span class="text-xs text-purple-600/80">{{ order.aiReason.summary }}</span>
+              <span class="text-xs font-bold text-purple-700 shrink-0">AI 추천 이유</span>
+              <span class="text-xs text-purple-600/80 truncate">{{ order.aiReason.summary }}</span>
             </div>
-            <div class="flex items-center gap-2">
+            <div class="flex items-center gap-2 shrink-0 ml-2">
               <div class="flex gap-1.5">
                 <span
-                  v-for="tag in order.aiReason.contexts"
-                  :key="tag"
+                  v-for="(tag, idx) in order.aiReason.contexts"
+                  :key="`${order.id}-tag-${idx}`"
                   class="hidden sm:inline text-[10px] font-semibold px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 border border-purple-200">
                   {{ tag }}
                 </span>
@@ -70,8 +70,8 @@
           <div v-if="expandedAiReasons.has(order.id)" class="px-5 pb-4 space-y-3">
             <div class="sm:hidden flex gap-1.5 flex-wrap">
               <span
-                v-for="tag in order.aiReason.contexts"
-                :key="tag"
+                v-for="(tag, idx) in order.aiReason.contexts"
+                :key="`${order.id}-tag-mobile-${idx}`"
                 class="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 border border-purple-200">
                 {{ tag }}
               </span>
@@ -82,11 +82,11 @@
             <div class="grid grid-cols-2 gap-3">
               <div class="bg-white border border-purple-100 rounded-lg px-4 py-2.5 text-center">
                 <p class="text-[10px] font-bold text-gray-400 uppercase tracking-wider mb-1">최소 발주량</p>
-                <p class="text-sm font-bold text-gray-700">{{ order.aiReason.minQtyLabel }}</p>
+                <p class="text-sm font-bold text-gray-700">{{ minQtyLabel(order) }}</p>
               </div>
               <div class="bg-purple-600 rounded-lg px-4 py-2.5 text-center">
                 <p class="text-[10px] font-bold text-purple-200 uppercase tracking-wider mb-1">AI 추천 수량</p>
-                <p class="text-sm font-bold text-white">{{ order.aiReason.recommendedQtyLabel }}</p>
+                <p class="text-sm font-bold text-white">{{ recommendedQtyLabel(order) }}</p>
               </div>
             </div>
           </div>
@@ -401,6 +401,18 @@ function toggleAiReason(orderId) {
   }
 }
 
+function minQtyLabel(order) {
+  return order.items
+    .map(i => `${i.product} ${i.min}${PRODUCT_UNIT[i.product] ?? ''}`)
+    .join(' · ')
+}
+
+function recommendedQtyLabel(order) {
+  return order.items
+    .map(i => `${i.product} ${i.suggested}${PRODUCT_UNIT[i.product] ?? ''}`)
+    .join(' · ')
+}
+
 const pendingOrders = ref([
   {
     id: 'AUTO-20260413-001', createdAt: '2026-04-13 08:00',
@@ -408,8 +420,6 @@ const pendingOrders = ref([
       summary: '갤러리아 봄 기획전 및 주말 한파 예보로 한우 수요 증가 예상',
       detail: '4월 15~17일 갤러리아 타임월드 봄 기획전이 예정되어 있습니다. 작년 동일 이벤트 기간에 한우 등심 발주량은 평소 대비 38% 증가했습니다. 또한 이번 주말 기온이 5°C 이하로 내려갈 것으로 예보되어 외식 수요가 높아질 것으로 예상됩니다. 이벤트 기간 품절 방지를 위해 최소 발주량 기준보다 높은 수량을 추천합니다.',
       contexts: ['갤러리아 봄 기획전 (4/15~17)', '주말 기온 5°C 예보', '작년 동기 발주 +38%'],
-      minQtyLabel: '한우 등심 10kg · 버터 5kg',
-      recommendedQtyLabel: '한우 등심 20kg · 버터 10kg',
     },
     items: [
       { product: '한우 등심', current: 5, min: 10, suggested: 20, adjusted: 20 },
@@ -422,8 +432,6 @@ const pendingOrders = ref([
       summary: '주말 예약 집중 및 코스 메뉴 소비 증가 패턴 감지',
       detail: '최근 3주간 올리브오일과 생크림의 주말 소비량이 평일 대비 평균 42% 높게 나타났습니다. 이번 주말은 갤러리아 봄 기획전과 겹쳐 예약이 집중될 것으로 예상되며, 코스 메뉴 레시피 기준 소모량을 고려해 평소보다 높은 수량을 추천합니다. 생크림은 유통기한이 짧으므로 소비 속도에 맞춰 조정하시기 바랍니다.',
       contexts: ['주말 소비량 평일 대비 +42%', '갤러리아 봄 기획전', '생크림 유통기한 주의'],
-      minQtyLabel: '올리브오일 5L · 생크림 4L',
-      recommendedQtyLabel: '올리브오일 15L · 생크림 12L',
     },
     items: [
       { product: '올리브오일', current: 2, min: 5, suggested: 15, adjusted: 15 },

--- a/frontend/src/views/store/StoreProductView.vue
+++ b/frontend/src/views/store/StoreProductView.vue
@@ -160,32 +160,32 @@
 import { ref, computed } from 'vue'
 import { Plus, Search } from 'lucide-vue-next'
 
-const categories = ref(['한우·정육', '수산물', '채소·신선', '양념·소스', '유제품', '음료·기타'])
+const categories = ref(['육류', '어류', '채소', '소스류', '오일/유제품', '음료'])
 const selectedCategory = ref('전체')
 const searchQuery = ref('')
 
 const products = ref([
-  { code: 'P101', name: '한우 등심',   category: '한우·정육', unit: 'kg',  baseStock: 50,  minStock: 10, price: 85000, expiryDays: 3 },
-  { code: 'P102', name: '한우 안심',   category: '한우·정육', unit: 'kg',  baseStock: 30,  minStock: 8,  price: 95000, expiryDays: 3 },
-  { code: 'P103', name: '한우 채끝',   category: '한우·정육', unit: 'kg',  baseStock: 20,  minStock: 5,  price: 78000, expiryDays: 3 },
+  { code: 'P100', name: '한우 등심',  category: '육류',        unit: 'kg',   baseStock: 50,  minStock: 10, price: 85000, expiryDays: 5  },
+  { code: 'P101', name: '한우 안심',  category: '육류',        unit: 'kg',   baseStock: 30,  minStock: 8,  price: 95000, expiryDays: 5  },
+  { code: 'P102', name: '한우 채끝',  category: '육류',        unit: 'kg',   baseStock: 20,  minStock: 5,  price: 78000, expiryDays: 5  },
 
-  { code: 'P201', name: '연어 필렛',   category: '수산물',    unit: 'kg',  baseStock: 30,  minStock: 8,  price: 32000, expiryDays: 2 },
-  { code: 'P202', name: '참치 블록',   category: '수산물',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 45000, expiryDays: 2 },
-  { code: 'P203', name: '새우',        category: '수산물',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 28000, expiryDays: 3 },
+  { code: 'P200', name: '연어 필렛',  category: '어류',        unit: 'kg',   baseStock: 30,  minStock: 8,  price: 32000, expiryDays: 2  },
+  { code: 'P201', name: '참치 블록',  category: '어류',        unit: 'kg',   baseStock: 20,  minStock: 5,  price: 45000, expiryDays: 2  },
+  { code: 'P202', name: '새우',       category: '어류',        unit: 'kg',   baseStock: 20,  minStock: 5,  price: 28000, expiryDays: 3  },
 
-  { code: 'P301', name: '양파',        category: '채소·신선', unit: 'kg',  baseStock: 100, minStock: 20, price: 1500,  expiryDays: 14 },
-  { code: 'P302', name: '마늘',        category: '채소·신선', unit: 'kg',  baseStock: 50,  minStock: 10, price: 8000,  expiryDays: 14 },
-  { code: 'P303', name: '대파',        category: '채소·신선', unit: 'kg',  baseStock: 30,  minStock: 8,  price: 3000,  expiryDays: 7  },
+  { code: 'P300', name: '양파',       category: '채소',        unit: 'kg',   baseStock: 100, minStock: 20, price: 1500,  expiryDays: 14 },
+  { code: 'P301', name: '마늘',       category: '채소',        unit: 'kg',   baseStock: 50,  minStock: 10, price: 8000,  expiryDays: 14 },
+  { code: 'P302', name: '대파',       category: '채소',        unit: 'kg',   baseStock: 30,  minStock: 8,  price: 3000,  expiryDays: 7  },
 
-  { code: 'P401', name: '간장',        category: '양념·소스', unit: 'L',   baseStock: 30,  minStock: 8,  price: 4000,  expiryDays: null },
-  { code: 'P402', name: '올리브오일',  category: '양념·소스', unit: 'L',   baseStock: 20,  minStock: 5,  price: 12000, expiryDays: null },
-  { code: 'P403', name: '고추장',      category: '양념·소스', unit: 'kg',  baseStock: 20,  minStock: 5,  price: 6000,  expiryDays: 60  },
+  { code: 'P400', name: '간장',       category: '소스류',      unit: 'L',    baseStock: 30,  minStock: 8,  price: 4000,  expiryDays: null },
+  { code: 'P401', name: '고추장',     category: '소스류',      unit: 'kg',   baseStock: 20,  minStock: 5,  price: 5500,  expiryDays: null },
 
-  { code: 'P501', name: '버터',        category: '유제품',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 9000,  expiryDays: 14 },
-  { code: 'P502', name: '생크림',      category: '유제품',    unit: 'L',   baseStock: 20,  minStock: 5,  price: 7000,  expiryDays: 7  },
+  { code: 'P500', name: '올리브오일', category: '오일/유제품', unit: 'L',    baseStock: 20,  minStock: 5,  price: 12000, expiryDays: null },
+  { code: 'P501', name: '버터',       category: '오일/유제품', unit: 'kg',   baseStock: 20,  minStock: 5,  price: 9000,  expiryDays: 14 },
+  { code: 'P502', name: '생크림',     category: '오일/유제품', unit: 'L',    baseStock: 20,  minStock: 5,  price: 7000,  expiryDays: 7  },
 
-  { code: 'P601', name: '콜라',        category: '음료·기타', unit: '박스', baseStock: 100, minStock: 20, price: 1200,  expiryDays: null },
-  { code: 'P602', name: '생수',        category: '음료·기타', unit: '박스', baseStock: 80,  minStock: 20, price: 800,   expiryDays: null },
+  { code: 'P600', name: '콜라',       category: '음료',        unit: '박스', baseStock: 100, minStock: 20, price: 15000, expiryDays: null },
+  { code: 'P601', name: '생수',       category: '음료',        unit: '박스', baseStock: 80,  minStock: 20, price: 8000,  expiryDays: null },
 ])
 
 const filteredProducts = computed(() => {

--- a/frontend/src/views/store/StoreProductView.vue
+++ b/frontend/src/views/store/StoreProductView.vue
@@ -160,24 +160,32 @@
 import { ref, computed } from 'vue'
 import { Plus, Search } from 'lucide-vue-next'
 
-const categories = ref(['육류', '소스', '채소', '가공식품', '음료'])
+const categories = ref(['한우·정육', '수산물', '채소·신선', '양념·소스', '유제품', '음료·기타'])
 const selectedCategory = ref('전체')
 const searchQuery = ref('')
 
 const products = ref([
-  { code: 'P100', name: '닭(10호)', category: '육류', unit: '마리', baseStock: 120, minStock: 30, price: 7000, expiryDays: 3 },
-  { code: 'P101', name: '닭(부분육-윙)', category: '육류', unit: 'kg', baseStock: 80, minStock: 20, price: 9000, expiryDays: 3 },
-  { code: 'P102', name: '닭(부분육-다리)', category: '육류', unit: 'kg', baseStock: 80, minStock: 20, price: 9500, expiryDays: 3 },
+  { code: 'P101', name: '한우 등심',   category: '한우·정육', unit: 'kg',  baseStock: 50,  minStock: 10, price: 85000, expiryDays: 3 },
+  { code: 'P102', name: '한우 안심',   category: '한우·정육', unit: 'kg',  baseStock: 30,  minStock: 8,  price: 95000, expiryDays: 3 },
+  { code: 'P103', name: '한우 채끝',   category: '한우·정육', unit: 'kg',  baseStock: 20,  minStock: 5,  price: 78000, expiryDays: 3 },
 
-  { code: 'P200', name: '양념소스', category: '소스', unit: 'kg', baseStock: 50, minStock: 10, price: 4000, expiryDays: 30 },
-  { code: 'P201', name: '매운양념소스', category: '소스', unit: 'kg', baseStock: 50, minStock: 10, price: 4500, expiryDays: 30 },
-  { code: 'P202', name: '파우더(튀김가루)', category: '소스', unit: 'kg', baseStock: 100, minStock: 20, price: 2000, expiryDays: 60 },
+  { code: 'P201', name: '연어 필렛',   category: '수산물',    unit: 'kg',  baseStock: 30,  minStock: 8,  price: 32000, expiryDays: 2 },
+  { code: 'P202', name: '참치 블록',   category: '수산물',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 45000, expiryDays: 2 },
+  { code: 'P203', name: '새우',        category: '수산물',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 28000, expiryDays: 3 },
 
-  { code: 'P300', name: '감자', category: '채소', unit: 'kg', baseStock: 150, minStock: 40, price: 1500, expiryDays: 14 },
-  { code: 'P301', name: '치즈볼 원재료', category: '가공식품', unit: '팩', baseStock: 100, minStock: 30, price: 3000, expiryDays: 10 },
+  { code: 'P301', name: '양파',        category: '채소·신선', unit: 'kg',  baseStock: 100, minStock: 20, price: 1500,  expiryDays: 14 },
+  { code: 'P302', name: '마늘',        category: '채소·신선', unit: 'kg',  baseStock: 50,  minStock: 10, price: 8000,  expiryDays: 14 },
+  { code: 'P303', name: '대파',        category: '채소·신선', unit: 'kg',  baseStock: 30,  minStock: 8,  price: 3000,  expiryDays: 7  },
 
-  { code: 'P400', name: '콜라', category: '음료', unit: '박스', baseStock: 200, minStock: 50, price: 1200, expiryDays: 60 },
-  { code: 'P401', name: '사이다', category: '음료', unit: '박스', baseStock: 180, minStock: 40, price: 1200, expiryDays: 60 },
+  { code: 'P401', name: '간장',        category: '양념·소스', unit: 'L',   baseStock: 30,  minStock: 8,  price: 4000,  expiryDays: null },
+  { code: 'P402', name: '올리브오일',  category: '양념·소스', unit: 'L',   baseStock: 20,  minStock: 5,  price: 12000, expiryDays: null },
+  { code: 'P403', name: '고추장',      category: '양념·소스', unit: 'kg',  baseStock: 20,  minStock: 5,  price: 6000,  expiryDays: 60  },
+
+  { code: 'P501', name: '버터',        category: '유제품',    unit: 'kg',  baseStock: 20,  minStock: 5,  price: 9000,  expiryDays: 14 },
+  { code: 'P502', name: '생크림',      category: '유제품',    unit: 'L',   baseStock: 20,  minStock: 5,  price: 7000,  expiryDays: 7  },
+
+  { code: 'P601', name: '콜라',        category: '음료·기타', unit: '박스', baseStock: 100, minStock: 20, price: 1200,  expiryDays: null },
+  { code: 'P602', name: '생수',        category: '음료·기타', unit: '박스', baseStock: 80,  minStock: 20, price: 800,   expiryDays: null },
 ])
 
 const filteredProducts = computed(() => {

--- a/frontend/src/views/store/StoreRecipeView.vue
+++ b/frontend/src/views/store/StoreRecipeView.vue
@@ -302,14 +302,18 @@ import { Plus, Trash2, Search, Image as ImageIcon, ChevronDown } from 'lucide-vu
 const products = ref([
   { id: 'P100', name: '한우 등심' },
   { id: 'P101', name: '한우 안심' },
-  { id: 'P102', name: '연어' },
-  { id: 'P200', name: '간장' },
-  { id: 'P201', name: '고추장' },
-  { id: 'P202', name: '올리브오일' },
+  { id: 'P102', name: '한우 채끝' },
+  { id: 'P200', name: '연어 필렛' },
+  { id: 'P201', name: '참치 블록' },
+  { id: 'P202', name: '새우' },
   { id: 'P300', name: '양파' },
   { id: 'P301', name: '마늘' },
-  { id: 'P400', name: '버터' },
-  { id: 'P401', name: '생크림' },
+  { id: 'P302', name: '대파' },
+  { id: 'P400', name: '간장' },
+  { id: 'P401', name: '고추장' },
+  { id: 'P500', name: '올리브오일' },
+  { id: 'P501', name: '버터' },
+  { id: 'P502', name: '생크림' },
 ])
 
 // ─────────────────────────────────────────────
@@ -319,26 +323,26 @@ const menus = ref([
   {
     id: 'M-001', name: '한우 등심 오마카세 코스', price: 180000, imageName: '', category: '한우',
     ingredients: [
-      { productId: 'P100', amount: 0.3, unit: 'kg' },
-      { productId: 'P301', amount: 20, unit: 'g' },
-      { productId: 'P200', amount: 50, unit: 'ml' },
-      { productId: 'P202', amount: 30, unit: 'ml' },
+      { productId: 'P100', amount: 0.3,  unit: 'kg' },
+      { productId: 'P301', amount: 20,   unit: 'g'  },
+      { productId: 'P400', amount: 50,   unit: 'ml' },
+      { productId: 'P500', amount: 30,   unit: 'ml' },
     ]
   },
   {
     id: 'M-002', name: '한우 안심 스테이크', price: 120000, imageName: '', category: '한우',
     ingredients: [
       { productId: 'P101', amount: 0.25, unit: 'kg' },
-      { productId: 'P400', amount: 30, unit: 'g' },
-      { productId: 'P300', amount: 50, unit: 'g' },
+      { productId: 'P501', amount: 30,   unit: 'g'  },
+      { productId: 'P300', amount: 50,   unit: 'g'  },
     ]
   },
   {
     id: 'M-003', name: '연어 스시 플래터', price: 65000, imageName: '', category: '해산물',
     ingredients: [
-      { productId: 'P102', amount: 0.2, unit: 'kg' },
-      { productId: 'P200', amount: 30, unit: 'ml' },
-      { productId: 'P301', amount: 5, unit: 'g' },
+      { productId: 'P200', amount: 0.2,  unit: 'kg' },
+      { productId: 'P400', amount: 30,   unit: 'ml' },
+      { productId: 'P301', amount: 5,    unit: 'g'  },
     ]
   },
 ])


### PR DESCRIPTION
## Summary
- 자동 발주서에 AI가 해당 수량을 추천한 이유를 확인할 수 있는 패널 추가
- 이벤트·날씨·과거 발주 이력 등 맥락 정보를 컨텍스트 태그로 시각화
- 최소 발주량과 AI 추천 수량을 items 데이터 기반으로 동적 생성
- 코드 리뷰 반영으로 안정성 및 레이아웃 개선

## 변경 파일
- `frontend/src/views/store/StoreOrderView.vue`

## 주요 변경 사항
- 발주서 카드 헤더와 테이블 사이에 AI 추천 이유 배너 삽입 (토글)
- 컨텍스트 태그로 추천 근거 시각화 (이벤트, 날씨, 과거 발주 패턴)
- 최소 발주량 vs AI 추천 수량 비교 카드 UI
- `v-if="order.aiReason"` null 체크 추가
- summary 텍스트 `truncate` 처리로 레이아웃 안정화
- 리스트 key를 인덱스 기반으로 변경하여 중복 방지
- 수량 라벨을 하드코딩 대신 items 데이터에서 동적 생성

## Test Plan
- [ ] AI 추천 이유 배너 정상 노출 확인
- [ ] 배너 토글(펼치기/접기) 동작 확인
- [ ] 긴 summary 텍스트에서 레이아웃 깨지지 않는지 확인
- [ ] aiReason 없는 발주서에서 오류 없이 렌더링되는지 확인
- [ ] 최소 발주량 / AI 추천 수량이 items 기준으로 정확히 표시되는지 확인
- [ ] 기존 전체 확정·품목 추가·거절 기능 정상 동작 확인
