### PR TITLE
[Feat] #307 - Category 도메인 

### DIFF
--- a/backend/src/main/java/com/example/nexus/category/CategoryController.java
+++ b/backend/src/main/java/com/example/nexus/category/CategoryController.java
@@ -1,0 +1,12 @@
+package com.example.nexus.category;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/category")
+@RequiredArgsConstructor
+@RestController
+public class CategoryController {
+    private final CategoryService categoryService;
+}

--- a/backend/src/main/java/com/example/nexus/category/CategoryRepository.java
+++ b/backend/src/main/java/com/example/nexus/category/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.nexus.category;
+
+import com.example.nexus.category.model.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/backend/src/main/java/com/example/nexus/category/CategoryService.java
+++ b/backend/src/main/java/com/example/nexus/category/CategoryService.java
@@ -1,0 +1,10 @@
+package com.example.nexus.category;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+}

--- a/backend/src/main/java/com/example/nexus/category/model/Category.java
+++ b/backend/src/main/java/com/example/nexus/category/model/Category.java
@@ -1,0 +1,27 @@
+package com.example.nexus.category.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "category")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_idx", nullable = false)
+    private Long idx;
+
+    @Column(name = "category_name", nullable = false)
+    private Long categoryName;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+}

--- a/backend/src/main/java/com/example/nexus/category/model/category.java
+++ b/backend/src/main/java/com/example/nexus/category/model/category.java
@@ -1,4 +1,0 @@
-package com.example.nexus.category.model;
-
-public class category {
-}


### PR DESCRIPTION
## Summary
- Category Entity, Controller, Service, Repository 기본 구조 구현
- JpaRepository 상속으로 기본 CRUD 제공

## 변경 파일
- `backend/src/main/java/com/example/nexus/category/model/Category.java`
- `backend/src/main/java/com/example/nexus/category/CategoryController.java`
- `backend/src/main/java/com/example/nexus/category/CategoryService.java`
- `backend/src/main/java/com/example/nexus/category/CategoryRepository.java`

## 주요 변경 사항
- `Category` Entity: idx, count 필드 정의 및 JPA 매핑
- `CategoryController`: `/category` 엔드포인트 기본 구조 생성
- `CategoryService`: CategoryRepository 의존성 주입
- `CategoryRepository`: JpaRepository 상속으로 생성

## Test Plan


## Issue
Closes #307 