### PR TITLE
 [Feat] #315 - Report 도메인 기본 구조 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/report/ReportController.java
+++ b/backend/src/main/java/com/example/nexus/report/ReportController.java
@@ -1,0 +1,12 @@
+package com.example.nexus.report;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/report")
+@RestController
+@RequiredArgsConstructor
+public class ReportController {
+    private final ReportService reportService;
+}

--- a/backend/src/main/java/com/example/nexus/report/ReportRepository.java
+++ b/backend/src/main/java/com/example/nexus/report/ReportRepository.java
@@ -1,0 +1,7 @@
+package com.example.nexus.report;
+
+import com.example.nexus.report.model.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/backend/src/main/java/com/example/nexus/report/ReportService.java
+++ b/backend/src/main/java/com/example/nexus/report/ReportService.java
@@ -1,0 +1,10 @@
+package com.example.nexus.report;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+    private final ReportRepository reportRepository;
+}

--- a/backend/src/main/java/com/example/nexus/report/model/Report.java
+++ b/backend/src/main/java/com/example/nexus/report/model/Report.java
@@ -1,0 +1,32 @@
+package com.example.nexus.report.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report")
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_idx")
+    private Long idx;
+
+    @Column(name = "report_title", nullable = false)
+    private String reportTitle;
+
+    @Column(name = "report_file_path", nullable = false)
+    private String reportFilePath;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/example/nexus/report/model/report.java
+++ b/backend/src/main/java/com/example/nexus/report/model/report.java
@@ -1,4 +1,0 @@
-package com.example.nexus.report.model;
-
-public class report {
-}


### PR DESCRIPTION
## Summary
- Report Entity, Controller, Service, Repository 기본 구조 구현
- JpaRepository 상속으로 기본 CRUD 제공

## 변경 파일
- `backend/src/main/java/com/example/nexus/report/model/Report.java`
- `backend/src/main/java/com/example/nexus/report/ReportController.java`
- `backend/src/main/java/com/example/nexus/report/ReportService.java`
- `backend/src/main/java/com/example/nexus/report/ReportRepository.java`

## 주요 변경 사항
- `Report` Entity: idx, reportTitle, reportFilePath, createdAt 필드 정의 및 JPA 매핑
- `ReportController`: `/report` 엔드포인트 기본 구조 생성
- `ReportService`: ReportRepository 의존성 주입
- `ReportRepository`: JpaRepository 상속으로 생성

## Test Plan
- [ ] 서버 실행 시 report 테이블 정상 생성 확인
- [ ] ReportController 빈 등록 정상 확인

## Issue
Closes #315
