### PR TITLE
[Feat] #316 - NewsCollect 도메인 기본 구조 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/newscollect/NewsCollectController.java
+++ b/backend/src/main/java/com/example/nexus/newscollect/NewsCollectController.java
@@ -1,0 +1,12 @@
+package com.example.nexus.newscollect;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/newscollect")
+@RestController
+@RequiredArgsConstructor
+public class NewsCollectController {
+    private final NewsCollectService newsCollectService;
+}

--- a/backend/src/main/java/com/example/nexus/newscollect/NewsCollectRepository.java
+++ b/backend/src/main/java/com/example/nexus/newscollect/NewsCollectRepository.java
@@ -1,0 +1,7 @@
+package com.example.nexus.newscollect;
+
+import com.example.nexus.newscollect.model.NewsCollect;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsCollectRepository extends JpaRepository<NewsCollect, Long> {
+}

--- a/backend/src/main/java/com/example/nexus/newscollect/NewsCollectService.java
+++ b/backend/src/main/java/com/example/nexus/newscollect/NewsCollectService.java
@@ -1,0 +1,10 @@
+package com.example.nexus.newscollect;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NewsCollectService {
+    private final NewsCollectRepository newsCollectRepository;
+}

--- a/backend/src/main/java/com/example/nexus/newscollect/model/NewsCollect.java
+++ b/backend/src/main/java/com/example/nexus/newscollect/model/NewsCollect.java
@@ -24,10 +24,10 @@ public class NewsCollect {
     @Column(name = "title", nullable = false)
     private String title;
 
-    @Column(name = "url", nullable = false)
+    @Column(name = "url", nullable = false, length = 1000)
     private String url;
 
-    @Column(name = "snippet", nullable = false)
+    @Column(name = "snippet", nullable = false, columnDefinition = "TEXT")
     private String snippet;
 
     @Column(name = "published_at", nullable = false)

--- a/backend/src/main/java/com/example/nexus/newscollect/model/NewsCollect.java
+++ b/backend/src/main/java/com/example/nexus/newscollect/model/NewsCollect.java
@@ -1,0 +1,46 @@
+package com.example.nexus.newscollect.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "news_collect")
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsCollect {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "news_collect_idx", nullable = false)
+    private Long idx;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "url", nullable = false)
+    private String url;
+
+    @Column(name = "snippet", nullable = false)
+    private String snippet;
+
+    @Column(name = "published_at", nullable = false)
+    private LocalDateTime publishedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target", nullable = false)
+    private NewsCollectTarget target;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private NewsCollectStatus status;
+
+    @Column(name = "collected_at", nullable = false)
+    private LocalDateTime collectedAt;
+}

--- a/backend/src/main/java/com/example/nexus/newscollect/model/NewsCollectStatus.java
+++ b/backend/src/main/java/com/example/nexus/newscollect/model/NewsCollectStatus.java
@@ -1,4 +1,4 @@
 package com.example.nexus.newscollect.model;
 
-public class newsCollect {
+public enum NewsCollectStatus {
 }

--- a/backend/src/main/java/com/example/nexus/newscollect/model/NewsCollectStatus.java
+++ b/backend/src/main/java/com/example/nexus/newscollect/model/NewsCollectStatus.java
@@ -1,4 +1,8 @@
 package com.example.nexus.newscollect.model;
 
 public enum NewsCollectStatus {
+    RISK, // 안전 위험
+    LOCAL_EVENT, // 지역 행사
+    TRAFFIC, //교통 체증
+    WEATHER // 날씨
 }

--- a/backend/src/main/java/com/example/nexus/newscollect/model/NewsCollectTarget.java
+++ b/backend/src/main/java/com/example/nexus/newscollect/model/NewsCollectTarget.java
@@ -1,0 +1,6 @@
+package com.example.nexus.newscollect.model;
+
+public enum NewsCollectTarget {
+    HQ,
+    STORE
+}


### PR DESCRIPTION
## Summary
- NewsCollect Entity, Controller, Service, Repository 기본 구조 구현
- NewsCollectTarget, NewsCollectStatus Enum 추가

## 변경 파일
- `backend/src/main/java/com/example/nexus/newscollect/model/NewsCollect.java`
- `backend/src/main/java/com/example/nexus/newscollect/model/NewsCollectTarget.java`
- `backend/src/main/java/com/example/nexus/newscollect/model/NewsCollectStatus.java`
- `backend/src/main/java/com/example/nexus/newscollect/NewsCollectController.java`
- `backend/src/main/java/com/example/nexus/newscollect/NewsCollectService.java`
- `backend/src/main/java/com/example/nexus/newscollect/NewsCollectRepository.java`

## 주요 변경 사항
- `NewsCollect` Entity: idx, title, url, snippet, publishedAt, target, status, collectedAt 필드 정의 및 JPA 매핑
- `NewsCollectTarget` Enum: HQ, STORE
- `NewsCollectStatus` Enum 추가
- `NewsCollectController`: `/newscollect` 엔드포인트 기본 구조 생성
- `NewsCollectService`: NewsCollectRepository 의존성 주입
- `NewsCollectRepository`: JpaRepository 상속으로 생성

## Test Plan
- [ ] 서버 실행 시 news_collect 테이블 정상 생성 확인
- [ ] NewsCollectController 빈 등록 정상 확인

## Issue
Closes #316
