### PR TITLE
[Feat] #331 - MENU 도메인 기본 구조 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/menu/MenuController.java
+++ b/backend/src/main/java/com/example/nexus/menu/MenuController.java
@@ -1,0 +1,12 @@
+package com.example.nexus.menu;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/menu")
+@RestController
+@RequiredArgsConstructor
+public class MenuController {
+    private final MenuService menuService;
+}

--- a/backend/src/main/java/com/example/nexus/menu/MenuRepository.java
+++ b/backend/src/main/java/com/example/nexus/menu/MenuRepository.java
@@ -3,5 +3,5 @@ package com.example.nexus.menu;
 import com.example.nexus.menu.model.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MenuRepository extends JpaRepository<Menu,Long> {
+public interface MenuRepository extends JpaRepository<Menu, Long> {
 }

--- a/backend/src/main/java/com/example/nexus/menu/MenuRepository.java
+++ b/backend/src/main/java/com/example/nexus/menu/MenuRepository.java
@@ -1,0 +1,7 @@
+package com.example.nexus.menu;
+
+import com.example.nexus.menu.model.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu,Long> {
+}

--- a/backend/src/main/java/com/example/nexus/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/menu/MenuService.java
@@ -1,0 +1,10 @@
+package com.example.nexus.menu;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MenuService {
+    private final MenuRepository menuRepository;
+}

--- a/backend/src/main/java/com/example/nexus/menu/model/Menu.java
+++ b/backend/src/main/java/com/example/nexus/menu/model/Menu.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class menu {
+public class Menu {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name ="menu_idx", nullable = false, unique = true)

--- a/backend/src/main/java/com/example/nexus/menu/model/Menu.java
+++ b/backend/src/main/java/com/example/nexus/menu/model/Menu.java
@@ -20,12 +20,12 @@ public class Menu {
     private String menuName;
 
     @Column(name = "price", nullable = false)
-    private String price;
+    private Integer price;
 
     @Column(name = "img_path", nullable = false)
     private String imgPath;
 
     @Column(name = "is_deleted", nullable = false)
-    private Boolean isDeleted = false;
+    private boolean isDeleted = false;
 
 }

--- a/backend/src/main/java/com/example/nexus/menu/model/Menu.java
+++ b/backend/src/main/java/com/example/nexus/menu/model/Menu.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class Menu {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name ="menu_idx", nullable = false, unique = true)
+    @Column(name = "menu_idx", nullable = false, unique = true)
     private Long idx; // 메뉴 번호
 
     @Column(name = "menu_name", nullable = false, unique = true)

--- a/backend/src/main/java/com/example/nexus/menu/model/menu.java
+++ b/backend/src/main/java/com/example/nexus/menu/model/menu.java
@@ -1,4 +1,31 @@
 package com.example.nexus.menu.model;
 
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "menu")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class menu {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name ="menu_idx", nullable = false, unique = true)
+    private Long idx; // 메뉴 번호
+
+    @Column(name = "menu_name", nullable = false, unique = true)
+    private String menuName;
+
+    @Column(name = "price", nullable = false)
+    private String price;
+
+    @Column(name = "img_path", nullable = false)
+    private String imgPath;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
 }


### PR DESCRIPTION
## 📋 Summary
- 예: `Menu` Entity, Controller, Service, Repository 기본 구조 구현

## 📂 변경 파일
- `backend/src/main/java/com/example/nexus/menu/model/Menu`
- `backend/src/main/java/com/example/nexus/menu/MenuRepository`
- `backend/src/main/java/com/example/nexus/menu/MenuService`
- `backend/src/main/java/com/example/nexus/menu/MenuController`

## ✨ 주요 변경 사항
- [ ] Entity 정의 및 JPA 매핑 (`Menu`)
- [ ] Controller/Service/Repository 기본 레이어 구축

## 🛠 DB & Infrastructure (해당 시)
- [ ] 엔티티 수정으로 인한 테이블 스키마 변경 여부

## ✅ Test Plan
- [ ] 서버 실행 시 테이블 정상 생성 확인

## 🔗 Issue
- Closes #331 