### PR TITLE
[Feat] #317 - NewsSummary 도메인 기본 구조 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/newssummary/NewsSummaryController.java
+++ b/backend/src/main/java/com/example/nexus/newssummary/NewsSummaryController.java
@@ -1,0 +1,12 @@
+package com.example.nexus.newssummary;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/newssummary")
+@RestController
+@RequiredArgsConstructor
+public class NewsSummaryController {
+    private final NewsSummaryService newsSummaryService;
+}

--- a/backend/src/main/java/com/example/nexus/newssummary/NewsSummaryRepository.java
+++ b/backend/src/main/java/com/example/nexus/newssummary/NewsSummaryRepository.java
@@ -1,0 +1,7 @@
+package com.example.nexus.newssummary;
+
+import com.example.nexus.newssummary.model.NewsSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsSummaryRepository extends JpaRepository<NewsSummary, Long> {
+}

--- a/backend/src/main/java/com/example/nexus/newssummary/NewsSummaryService.java
+++ b/backend/src/main/java/com/example/nexus/newssummary/NewsSummaryService.java
@@ -1,0 +1,10 @@
+package com.example.nexus.newssummary;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NewsSummaryService {
+    private final NewsSummaryRepository newsSummaryRepository;
+}

--- a/backend/src/main/java/com/example/nexus/newssummary/model/NewsSummary.java
+++ b/backend/src/main/java/com/example/nexus/newssummary/model/NewsSummary.java
@@ -1,0 +1,38 @@
+package com.example.nexus.newssummary.model;
+
+import com.example.nexus.newscollect.model.NewsCollectTarget;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "news_summary")
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsSummary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "news_summary_idx")
+    private Long idx;
+
+    @Column(name = "summary_date", nullable = false)
+    private LocalDateTime summaryDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target", nullable = false)
+    private NewsCollectTarget target;
+
+    @Column(name = "summary_title", nullable = false)
+    private String summaryTitle;
+
+    @Column(name = "summary_contents", nullable = false, columnDefinition = "TEXT")
+    private String summaryContents;
+
+}

--- a/backend/src/main/java/com/example/nexus/newssummary/model/newsSummary.java
+++ b/backend/src/main/java/com/example/nexus/newssummary/model/newsSummary.java
@@ -1,4 +1,0 @@
-package com.example.nexus.newssummary.model;
-
-public class newsSummary {
-}


### PR DESCRIPTION
## Summary
- NewsSummary Entity, Controller, Service, Repository 기본 구조 구현
- NewsCollectTarget Enum 재사용으로 target 필드 타입 통일

## 변경 파일
- `backend/src/main/java/com/example/nexus/newssummary/model/NewsSummary.java`
- `backend/src/main/java/com/example/nexus/newssummary/NewsSummaryController.java`
- `backend/src/main/java/com/example/nexus/newssummary/NewsSummaryService.java`
- `backend/src/main/java/com/example/nexus/newssummary/NewsSummaryRepository.java`

## 주요 변경 사항
- `NewsSummary` Entity: idx, summaryDate, target, summaryTitle, summaryContents 필드 정의 및 JPA 매핑
- `NewsSummaryController`: 기본 구조 생성
- `NewsSummaryService`: NewsSummaryRepository 의존성 주입
- `NewsSummaryRepository`: 기본 구조 생성

## Test Plan
- [ ] 서버 실행 시 news_summary 테이블 정상 생성 확인
- [ ] NewsSummaryController 빈 등록 정상 확인

## Issue
Closes #317
