### PR TITLE
 [Feat] #340 - MENU_ITEM 도메인 기본 구조 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/menuitem/MenuItemController.java
+++ b/backend/src/main/java/com/example/nexus/menuitem/MenuItemController.java
@@ -1,0 +1,12 @@
+package com.example.nexus.menuitem;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/MenuItem")
+@RestController
+@RequiredArgsConstructor
+public class MenuItemController {
+    private final MenuItemService menuItemService;
+}

--- a/backend/src/main/java/com/example/nexus/menuitem/MenuItemController.java
+++ b/backend/src/main/java/com/example/nexus/menuitem/MenuItemController.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/MenuItem")
+@RequestMapping("/menuitem")
 @RestController
 @RequiredArgsConstructor
 public class MenuItemController {

--- a/backend/src/main/java/com/example/nexus/menuitem/MenuItemRepository.java
+++ b/backend/src/main/java/com/example/nexus/menuitem/MenuItemRepository.java
@@ -1,0 +1,7 @@
+package com.example.nexus.menuitem;
+
+import com.example.nexus.menuitem.model.MenuItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuItemRepository extends JpaRepository<MenuItem, Long> {
+}

--- a/backend/src/main/java/com/example/nexus/menuitem/MenuItemService.java
+++ b/backend/src/main/java/com/example/nexus/menuitem/MenuItemService.java
@@ -1,0 +1,10 @@
+package com.example.nexus.menuitem;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MenuItemService {
+    private final MenuItemRepository menuItemRepository;
+}

--- a/backend/src/main/java/com/example/nexus/menuitem/model/MenuItem.java
+++ b/backend/src/main/java/com/example/nexus/menuitem/model/MenuItem.java
@@ -19,7 +19,7 @@ public class MenuItem {
     @Column(nullable = false)
     private Integer quantity;
 
-    @Column(nullable = false)
-    private String menu_unit;
+    @Column(name = "menu_unit", nullable = false)
+    private String menuUnit;
 
 }

--- a/backend/src/main/java/com/example/nexus/menuitem/model/MenuItem.java
+++ b/backend/src/main/java/com/example/nexus/menuitem/model/MenuItem.java
@@ -1,0 +1,25 @@
+package com.example.nexus.menuitem.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "menu_item")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "menu_item_idx", nullable = false, unique = true)
+    private Long idx;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Column(nullable = false)
+    private String menu_unit;
+
+}

--- a/backend/src/main/java/com/example/nexus/menuitem/model/menuItem.java
+++ b/backend/src/main/java/com/example/nexus/menuitem/model/menuItem.java
@@ -1,4 +1,0 @@
-package com.example.nexus.menuitem.model;
-
-public class menuItem {
-}


### PR DESCRIPTION
## 📋 Summary
- 메뉴 레시피(Menu_Item) 도메인의 Entity, Repository, Service, Controller를 구현한다.

## 📂 변경 파일
- `backend/src/main/java/com/example/nexus/menuitem/model/MenuItem`
- `backend/src/main/java/com/example/nexus/menuitem/MenuItemRepository`
- `backend/src/main/java/com/example/nexus/menuitem/MenuItemService`
- `backend/src/main/java/com/example/nexus/menuitem/MenuItemController`

## ✨ 주요 변경 사항
- 구체적인 작업 내용을 체크리스트로 작성해 주세요.
- [ ] Entity 정의 및 JPA 매핑 (`NewsCollect`)
- [ ] Controller/Service/Repository 기본 레이어 구축

## 🛠 DB & Infrastructure (해당 시)
- [ ] 엔티티 수정으로 인한 테이블 스키마 변경 여부

## ✅ Test Plan
- [ ] 서버 실행 시 테이블 정상 생성 확인


## 🔗 Issue
- Closes #340 