### PR TITLE
[Feat] #342 - HeadIncome 도메인 기본 구조 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/headincome/HeadIncomeController.java
+++ b/backend/src/main/java/com/example/nexus/headincome/HeadIncomeController.java
@@ -1,0 +1,12 @@
+package com.example.nexus.headincome;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/headincome")
+@RestController
+@RequiredArgsConstructor
+public class HeadIncomeController {
+    private final HeadIncomeService headIncomeService;
+}

--- a/backend/src/main/java/com/example/nexus/headincome/HeadIncomeRepository.java
+++ b/backend/src/main/java/com/example/nexus/headincome/HeadIncomeRepository.java
@@ -1,0 +1,7 @@
+package com.example.nexus.headincome;
+
+import com.example.nexus.headincome.model.HeadIncome;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HeadIncomeRepository extends JpaRepository<HeadIncome, Long> {
+}

--- a/backend/src/main/java/com/example/nexus/headincome/HeadIncomeService.java
+++ b/backend/src/main/java/com/example/nexus/headincome/HeadIncomeService.java
@@ -1,0 +1,10 @@
+package com.example.nexus.headincome;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HeadIncomeService {
+    private final HeadIncomeRepository headIncomeRepository;
+}

--- a/backend/src/main/java/com/example/nexus/headincome/model/HeadIncome.java
+++ b/backend/src/main/java/com/example/nexus/headincome/model/HeadIncome.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class headIncome {
+public class HeadIncome {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/example/nexus/headincome/model/headIncome.java
+++ b/backend/src/main/java/com/example/nexus/headincome/model/headIncome.java
@@ -1,4 +1,28 @@
 package com.example.nexus.headincome.model;
 
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "head_income")
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class headIncome {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "head_income_idx")
+    private Long idx;
+
+    @Column(name = "price", nullable = false)
+    private Long price;
+
+    @Column(name = "status", nullable = false)
+    private Boolean status;
+
 }


### PR DESCRIPTION
## Summary
- HeadIncome Entity, Controller, Service, Repository 기본 구조 구현
- JpaRepository 상속으로 기본 CRUD 제공

## 변경 파일
- `backend/src/main/java/com/example/nexus/headincome/model/HeadIncome.java`
- `backend/src/main/java/com/example/nexus/headincome/HeadIncomeController.java`
- `backend/src/main/java/com/example/nexus/headincome/HeadIncomeService.java`
- `backend/src/main/java/com/example/nexus/headincome/HeadIncomeRepository.java`

## 주요 변경 사항
- `HeadIncome` Entity: idx, price, status 필드 정의 및 JPA 매핑
- `HeadIncomeController`: `/headincome` 엔드포인트 기본 구조 생성
- `HeadIncomeService`: HeadIncomeRepository 의존성 주입
- `HeadIncomeRepository`: JpaRepository 상속으로 생성
- 클래스명 파스칼케이스로 수정 (headIncome → HeadIncome)

## Test Plan
- [ ] 서버 실행 시 head_income 테이블 정상 생성 확인
- [ ] HeadIncomeController 빈 등록 정상 확인

## Issue
Closes #342
