### PR TITLE
[Feat] #76 - 이상 발주 기준 설정 API 구현

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_생성_템플릿.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_생성_템플릿.md
@@ -2,31 +2,31 @@
 형식: `[태그] #{이슈번호} - 작업 내용 요약`
 예시: `[Feat] #316 - NewsCollect 도메인 기본 구조 구현`
 
-## 📋 Summary
+## Summary
 - 작업 내용에 대한 간략한 설명을 작성해 주세요.
 - 예: `NewsCollect` Entity, Controller, Service, Repository 기본 구조 구현
 
-## 📂 변경 파일
+## 변경 파일
 - 수정한 파일 목록을 작성해 주세요.
 - 예: `backend/src/main/java/com/example/nexus/newscollect/model/NewsCollect.java`
 
-## ✨ 주요 변경 사항
+## 주요 변경 사항
 - 구체적인 작업 내용을 체크리스트로 작성해 주세요.
 - [ ] Entity 정의 및 JPA 매핑 (`NewsCollect`)
 - [ ] Enum 추가 (`NewsCollectTarget`, `NewsCollectStatus`)
 - [ ] Controller/Service/Repository 기본 레이어 구축
 - [ ] 기타 (메서드 로직 설명 등)
 
-## 🛠 DB & Infrastructure (해당 시)
+## DB & Infrastructure (해당 시)
 - [ ] 엔티티 수정으로 인한 테이블 스키마 변경 여부
 - [ ] nGrinder 등 성능 테스트 결과 (필요 시 첨부)
 
-## ✅ Test Plan
+## Test Plan
 - 테스트 방법 및 결과를 체크리스트로 작성해 주세요.
 - [ ] 서버 실행 시 테이블 정상 생성 확인
 - [ ] 주요 API 엔드포인트 호출 및 응답 확인
 - [ ] 테스트 코드 통과 여부
 
-## 🔗 Issue
+## Issue
 - 관련 이슈 번호를 작성해 주세요.
 - Closes #

--- a/backend/src/main/java/com/example/nexus/domain/news/NewsService.java
+++ b/backend/src/main/java/com/example/nexus/domain/news/NewsService.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class NewsService {
-    private final NewsCollectRepository newsCollectRepository;
+    private final NewsRepository newsRepository;
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -1,13 +1,28 @@
 package com.example.nexus.domain.orders;
 
+import com.example.nexus.common.model.BaseResponse;
+import com.example.nexus.domain.orders.model.DangerDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
 
 @RequestMapping("/order")
 @RestController
 @RequiredArgsConstructor
 public class OrdersController {
     private final OrdersService orderService;
+
+    @GetMapping("/danger")
+    public ResponseEntity find() {
+        DangerDto.DangerRes result = orderService.find();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    @PutMapping("/danger")
+    public ResponseEntity save(@RequestBody DangerDto.DangerReq req) {
+        orderService.save(req);
+        return ResponseEntity.ok(BaseResponse.success("성공"));
+    }
 
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -1,10 +1,28 @@
 package com.example.nexus.domain.orders;
 
+import com.example.nexus.domain.orders.model.Danger;
+import com.example.nexus.domain.orders.model.DangerDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class OrdersService {
-    private final OrdersRepository orderRepository;
+    private final DangerRepository dangerRepository;
+
+    public DangerDto.DangerRes find() {
+        return dangerRepository.findById(1L)
+                .map(DangerDto.DangerRes::from)
+                .orElse(DangerDto.DangerRes.builder()
+                        .ratio(200)
+                        .period(3)
+                        .build());
+    }
+
+    public void save(DangerDto.DangerReq req) {
+        Danger danger = dangerRepository.findById(1L)
+                .orElse(Danger.builder().build());
+        danger.update(req.getRatio(), req.getPeriod());
+        dangerRepository.save(danger);
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Danger.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Danger.java
@@ -1,14 +1,11 @@
 package com.example.nexus.domain.orders.model;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Table(name = "danger")
-@Setter
+@Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Danger.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Danger.java
@@ -22,4 +22,8 @@ public class Danger {
     @Column(name = "period", nullable = false)
     private Integer period;
 
+    public void update(Integer ratio, Integer period) {
+        this.ratio = ratio;
+        this.period = period;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
@@ -12,6 +12,7 @@ public class DangerDto {
         private Integer period;
     }
 
+    @Getter
     @Builder
     public static class DangerRes {
         private Integer ratio;

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
@@ -1,0 +1,19 @@
+package com.example.nexus.domain.orders.model;
+
+import lombok.Builder;
+
+public class DangerDto {
+
+    @Builder
+    public static class DangerReq {
+        private Integer ratio;
+        private Integer period;
+
+        public Danger toEntity() {
+            return Danger.builder()
+                    .ratio(this.ratio)
+                    .period(this.period)
+                    .build();
+        }
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
@@ -1,18 +1,26 @@
 package com.example.nexus.domain.orders.model;
 
 import lombok.Builder;
+import lombok.Getter;
 
 public class DangerDto {
 
+    @Getter
     @Builder
     public static class DangerReq {
         private Integer ratio;
         private Integer period;
+    }
 
-        public Danger toEntity() {
-            return Danger.builder()
-                    .ratio(this.ratio)
-                    .period(this.period)
+    @Builder
+    public static class DangerRes {
+        private Integer ratio;
+        private Integer period;
+
+        public static DangerRes from(Danger entity) {
+            return DangerRes.builder()
+                    .ratio(entity.getRatio())
+                    .period(entity.getPeriod())
                     .build();
         }
     }


### PR DESCRIPTION
## Summary
- 이상 발주 기준 설정 조회 및 저장 API 구현

## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/model/Danger.java`
- `backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`
- `.github/PULL_REQUEST_TEMPLATE/pull_request_생성_템플릿.md`

## 주요 변경 사항
- [x] Danger 엔티티 update() 메서드 추가
- [x] DangerDto DangerReq @Getter 추가, DangerRes 및 from() 메서드 추가
- [x] OrdersService 이상 발주 기준 조회/저장 로직 구현
  - 데이터 없을 시 기본값 (ratio: 200, period: 3) 반환
  - 저장 시 데이터 없으면 insert, 있으면 update
- [x] GET /order/danger, PUT /order/danger 엔드포인트 추가
- [x] PR 템플릿 이모지 제거

## DB & Infrastructure (해당 시)
- [x] 엔티티 수정으로 인한 테이블 스키마 변경 여부

## Test Plan
- [x] 서버 실행 시 테이블 정상 생성 확인
- [x] GET /order/danger 응답 확인
- [x] PUT /order/danger 저장 후 응답 확인

## Issue
- Closes #76
