### PR TITLE
[Feat] #72 - 발주서 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -2,9 +2,12 @@ package com.example.nexus.domain.orders;
 
 import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.domain.orders.model.DangerDto;
+import com.example.nexus.domain.orders.model.OrdersDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RequestMapping("/orders")
@@ -15,7 +18,8 @@ public class OrdersController {
 
     @GetMapping("/list")
     public ResponseEntity list() {
-
+        List<OrdersDto.OrdersRes> result = orderService.findAll();
+        return ResponseEntity.ok(BaseResponse.success(result))
     }
 
     @GetMapping("/danger")

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -31,7 +31,7 @@ public class OrdersController {
     @PutMapping("/danger")
     public ResponseEntity save(@RequestBody DangerDto.DangerReq req) {
         orderService.save(req);
-        return ResponseEntity.ok(BaseResponse.success("성공"));
+        return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -7,11 +7,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
-@RequestMapping("/order")
+@RequestMapping("/orders")
 @RestController
 @RequiredArgsConstructor
 public class OrdersController {
     private final OrdersService orderService;
+
+    @GetMapping("/list")
+    public ResponseEntity list() {
+
+    }
 
     @GetMapping("/danger")
     public ResponseEntity find() {

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -19,7 +19,7 @@ public class OrdersController {
     @GetMapping("/list")
     public ResponseEntity list() {
         List<OrdersDto.OrdersRes> result = orderService.findAll();
-        return ResponseEntity.ok(BaseResponse.success(result))
+        return ResponseEntity.ok(BaseResponse.success(result));
     }
 
     @GetMapping("/danger")

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -2,13 +2,23 @@ package com.example.nexus.domain.orders;
 
 import com.example.nexus.domain.orders.model.Danger;
 import com.example.nexus.domain.orders.model.DangerDto;
+import com.example.nexus.domain.orders.model.OrdersDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class OrdersService {
     private final DangerRepository dangerRepository;
+    private final OrdersRepository ordersRepository;
+
+    public List<OrdersDto.OrdersRes> findAll() {
+        return ordersRepository.findAll().stream()
+                .map(OrdersDto.OrdersRes::from)
+                .toList();
+    }
 
     public DangerDto.DangerRes find() {
         return dangerRepository.findById(1L)

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
@@ -38,7 +38,7 @@ public class Orders {
     private OrdersStatus ordersStatus;
 
     @Column(name = "is_danger", nullable = false)
-    private Boolean isDanger;
+    private boolean isDanger;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
@@ -34,7 +34,7 @@ public class OrdersDto {
                     .storeIdx(entity.getStore().getIdx())
                     .ordersItemList(entity.getOrdersItemList().stream()
                             .map(OrdersItemDto.OrdersItemRes::from).toList())
-                    .deliveryIdx(entity.getDelivery().getIdx())
+                    .deliveryIdx(entity.getDelivery() != null ? entity.getDelivery().getIdx() : null)
                     .build();
         }
     }

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
@@ -1,0 +1,41 @@
+package com.example.nexus.domain.orders.model;
+
+import com.example.nexus.common.enums.OrdersStatus;
+import com.example.nexus.common.enums.OrdersType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class OrdersDto {
+
+    @Getter
+    @Builder
+    public static class OrdersRes {
+        private Long idx;
+        private Long price;
+        private OrdersType ordersType;
+        private OrdersStatus ordersStatus;
+        private boolean isDanger;
+        private LocalDateTime createdAt;
+        private Long storeIdx;
+        private List<OrdersItem> ordersItemList;
+        private Long deliveryIdx;
+
+        public static OrdersRes from(Orders entity) {
+            return OrdersRes.builder()
+                    .idx(entity.getIdx())
+                    .price(entity.getPrice())
+                    .ordersType(entity.getOrdersType())
+                    .ordersStatus(entity.getOrdersStatus())
+                    .isDanger(entity.isDanger())
+                    .createdAt(entity.getCreatedAt())
+                    .storeIdx(entity.getStore().getIdx())
+                    .ordersItemList(entity.getOrdersItemList().stream()
+                            .map(OrdersItemDto.OrdersItemRes::from).toList())
+                    .deliveryIdx(entity.getDelivery().getIdx())
+                    .build();
+        }
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
@@ -20,7 +20,7 @@ public class OrdersDto {
         private boolean isDanger;
         private LocalDateTime createdAt;
         private Long storeIdx;
-        private List<OrdersItem> ordersItemList;
+        private List<OrdersItemDto.OrdersItemRes> ordersItemList;
         private Long deliveryIdx;
 
         public static OrdersRes from(Orders entity) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItemDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItemDto.java
@@ -1,0 +1,26 @@
+package com.example.nexus.domain.orders.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class OrdersItemDto {
+
+    @Getter
+    @Builder
+    public static class OrdersItemRes {
+        private Long idx;
+        private Integer count;
+        private Long orderIdx;
+        private Long productIdx;
+
+        public static OrdersItemRes from(OrdersItem entity) {
+            return OrdersItemRes.builder()
+                    .idx(entity.getIdx())
+                    .count(entity.getCount())
+                    .orderIdx(entity.getOrders().getIdx())
+                    .productIdx(entity.getProduct().getIdx())
+                    .build();
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- 발주서 목록 조회 API 구현 (GET /orders/list)

## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java`
- `backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItemDto.java`

## 주요 변경 사항
- [x] OrdersDto.OrdersRes 응답 DTO 생성 및 from() 메서드 구현
- [x] OrdersItemDto.OrdersItemRes 응답 DTO 생성 및 from() 메서드 구현
- [x] OrdersService findAll() 메서드 구현
- [x] GET /orders/list 엔드포인트 추가
- [x] delivery null 체크 추가 (배송 정보 없는 발주서 NPE 수정)
- [x] RequestMapping /order → /orders 수정

## Test Plan
- [x] GET /orders/list API 호출 및 응답 확인
- [x] 배송 정보 없는 발주서 조회 시 정상 응답 확인

## Issue
- Close #72
