### PR TITLE
[Feat] #132 - 발주서 상세 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -22,7 +22,7 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
-    @GetMapping("/detail/{ordersIdx}")
+    @GetMapping("/{ordersIdx}")
     public ResponseEntity ordersDetail(@PathVariable Long ordersIdx) {
         OrdersDto.OrdersRes result = orderService.findById(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success(result));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -22,6 +22,12 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
+    @GetMapping("/detail/{ordersIdx}")
+    public ResponseEntity ordersDetail(@PathVariable Long ordersIdx) {
+        OrdersDto.OrdersRes result = orderService.findId(ordersIdx);
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
     @GetMapping("/danger")
     public ResponseEntity find() {
         DangerDto.DangerRes result = orderService.find();

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -24,7 +24,7 @@ public class OrdersController {
 
     @GetMapping("/detail/{ordersIdx}")
     public ResponseEntity ordersDetail(@PathVariable Long ordersIdx) {
-        OrdersDto.OrdersRes result = orderService.findId(ordersIdx);
+        OrdersDto.OrdersRes result = orderService.findById(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -1,7 +1,10 @@
 package com.example.nexus.domain.orders;
 
+import com.example.nexus.common.exception.BaseException;
+import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.domain.orders.model.Danger;
 import com.example.nexus.domain.orders.model.DangerDto;
+import com.example.nexus.domain.orders.model.Orders;
 import com.example.nexus.domain.orders.model.OrdersDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,12 @@ public class OrdersService {
         return ordersRepository.findAll().stream()
                 .map(OrdersDto.OrdersRes::from)
                 .toList();
+    }
+
+    public OrdersDto.OrdersRes findById(Long ordersIdx) {
+        Orders orders =  ordersRepository.findById(ordersIdx).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+        return OrdersDto.OrdersRes.from(orders);
     }
 
     public DangerDto.DangerRes find() {


### PR DESCRIPTION
## Summary
- 발주서 상세 조회 API 구현 (GET /orders/{ordersIdx})

## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`

## 주요 변경 사항
- [x] OrdersService findById() 메서드 구현 (단건 조회, 없을 시 예외 처리)
- [x] GET /orders/{ordersIdx} 엔드포인트 추가

## Test Plan
- [x] GET /orders/{ordersIdx} API 호출 및 응답 확인
- [x] 존재하지 않는 발주서 조회 시 예외 응답 확인

## Issue
- Close #132
