### PR TITLE
[Feat] #68 - 수동 발주 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -16,6 +16,12 @@ import java.util.List;
 public class OrdersController {
     private final OrdersService orderService;
 
+    @GetMapping("/list/manual")
+    public ResponseEntity manualList() {
+        List<OrdersDto.OrdersRes> result = orderService.findAllManual();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
     @PostMapping
     public ResponseEntity create(@RequestBody OrdersDto.OrdersReq req) {
         orderService.create(req);

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -1,7 +1,11 @@
 package com.example.nexus.domain.orders;
 
+import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.orders.model.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
+    List<Orders> findAllByOrdersType(OrdersType ordersType);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -26,6 +26,13 @@ public class OrdersService {
     private final StoreRepository storeRepository;
     private final ProductRepository productRepository;
 
+
+    public List<OrdersDto.OrdersRes> findAllManual() {
+        return ordersRepository.findAllByOrdersType(OrdersType.MANUAL).stream()
+                .map(OrdersDto.OrdersRes::from)
+                .toList();
+    }
+
     @Transactional
     public void create(OrdersDto.OrdersReq req) {
         // 0. 주문 아이템 리스트 검증


### PR DESCRIPTION
## Summary                                                
- `ordersType`이 MANUAL인 발주 목록만 필터링하여 조회하는 API 구현

## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`

## 주요 변경 사항
- [x] OrdersRepository: `findAllByOrdersType()` 메서드 추가
- [x] OrdersService: `findAllManual()` - MANUAL 타입 필터링 조회 구현
- [x] OrdersController: `GET /orders/list/manual` 엔드포인트 추가

## DB & Infrastructure (해당 시)
- [x] 엔티티 수정으로 인한 테이블 스키마 변경 여부

## Test Plan
- [x] 서버 실행 후 `GET /orders/list/manual` 호출 시 MANUAL 타입 발주만 반환 확인
- [x] MANUAL 외 타입 데이터가 응답에 포함되지 않는지 확인

## Issue
- Closes #68