### PR TITLE
[Feat] - 수동 발주 목록 조회 기능 추가 설정

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -1,5 +1,6 @@
 package com.example.nexus.domain.orders;
 
+import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.orders.model.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
-    List<Orders> findAllByOrdersType(OrdersType ordersType);
+    List<Orders> findAllByOrdersTypeAndOrdersStatus(OrdersType ordersType, OrdersStatus ordersStatus);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -28,7 +28,7 @@ public class OrdersService {
 
 
     public List<OrdersDto.OrdersRes> findAllManual() {
-        return ordersRepository.findAllByOrdersType(OrdersType.MANUAL).stream()
+        return ordersRepository.findAllByOrdersTypeAndOrdersStatus(OrdersType.MANUAL, OrdersStatus.WAITING).stream()
                 .map(OrdersDto.OrdersRes::from)
                 .toList();
     }


### PR DESCRIPTION
## Summary
- `ordersType`이 MANUAL이고 `ordersStatus`가 WAITING인 발주 목록만 필터링하여 조회하는 API 구현

## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`

## 주요 변경 사항
- [x] OrdersRepository: `findAllByOrdersTypeAndOrdersStatus()` 메서드 추가
- [x] OrdersService: `findAllManual()` - MANUAL & WAITING 조건 필터링 조회 구현
- [x] OrdersController: `GET /orders/list/manual` 엔드포인트 추가

## DB & Infrastructure (해당 시)
- [ ] 엔티티 수정으로 인한 테이블 스키마 변경 여부

## Test Plan
- [ ] `GET /orders/list/manual` 호출 시 MANUAL + WAITING 상태 발주만 반환 확인
- [ ] 다른 타입/상태의 발주가 응답에 포함되지 않는지 확인