### PR TITLE
[Feat] #64 - 자동 발주 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -16,6 +16,12 @@ import java.util.List;
 public class OrdersController {
     private final OrdersService orderService;
 
+    @GetMapping("/list/auto")
+    public ResponseEntity autoList() {
+        List<OrdersDto.OrdersRes> result = orderService.findAllAuto();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
     @GetMapping("/list/manual")
     public ResponseEntity manualList() {
         List<OrdersDto.OrdersRes> result = orderService.findAllManual();

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -26,7 +26,7 @@ public class OrdersService {
     private final StoreRepository storeRepository;
     private final ProductRepository productRepository;
 
-    public List<OrdersDto.OrdersRes> finaAllAuto() {
+    public List<OrdersDto.OrdersRes> findAllAuto() {
         return ordersRepository.findAllByOrdersTypeAndOrdersStatus(OrdersType.AUTO, OrdersStatus.WAITING).stream()
                 .map(OrdersDto.OrdersRes::from)
                 .toList();

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -26,6 +26,11 @@ public class OrdersService {
     private final StoreRepository storeRepository;
     private final ProductRepository productRepository;
 
+    public List<OrdersDto.OrdersRes> finaAllAuto() {
+        return ordersRepository.findAllByOrdersTypeAndOrdersStatus(OrdersType.AUTO, OrdersStatus.WAITING).stream()
+                .map(OrdersDto.OrdersRes::from)
+                .toList();
+    }
 
     public List<OrdersDto.OrdersRes> findAllManual() {
         return ordersRepository.findAllByOrdersTypeAndOrdersStatus(OrdersType.MANUAL, OrdersStatus.WAITING).stream()


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- `ordersType`이 AUTO이고 `ordersStatus`가 WAITING인 발주 목록만 필터링하여 조회하는 API 구현

## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`

## 주요 변경 사항
- [x] OrdersService: `findAllAuto()` - AUTO & WAITING 조건 필터링 조회 구현
- [x] OrdersController: `GET /orders/list/auto` 엔드포인트 추가

## DB & Infrastructure (해당 시)
- [x] 엔티티 수정으로 인한 테이블 스키마 변경 여부

## Test Plan
- [x] `GET /orders/list/auto` 호출 시 AUTO + WAITING 상태 발주만 반환 확인
- [] 다른 타입/상태의 발주가 응답에 포함되지 않는지 확인

## Issue
- Closes #64