### PR TITLE
[Feat] #130 - 가맹점주 본인 가게 발주 이력 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -3,11 +3,16 @@ package com.example.nexus.domain.orders;
 import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.domain.orders.model.DangerDto;
 import com.example.nexus.domain.orders.model.OrdersDto;
+import com.example.nexus.domain.user.model.AuthUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 
 @RequestMapping("/orders")
@@ -56,6 +61,15 @@ public class OrdersController {
     public ResponseEntity save(@RequestBody DangerDto.DangerReq req) {
         orderService.save(req);
         return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
+    @GetMapping("/store/list")
+    public ResponseEntity storeList(@AuthenticationPrincipal AuthUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        List<OrdersDto.OrdersRes> result = orderService.findByUserIdx(userDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success(result));
     }
 
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -3,10 +3,12 @@ package com.example.nexus.domain.orders;
 import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.orders.model.Orders;
+import com.example.nexus.domain.store.model.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
     List<Orders> findAllByOrdersTypeAndOrdersStatus(OrdersType ordersType, OrdersStatus ordersStatus);
+    List<Orders> findAllByStore_IdxAndOrdersStatus(Long storeIdx, OrdersStatus orderStatus);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -9,6 +9,7 @@ import com.example.nexus.domain.product.ProductRepository;
 import com.example.nexus.domain.product.model.Product;
 import com.example.nexus.domain.store.StoreRepository;
 import com.example.nexus.domain.store.model.Store;
+import com.example.nexus.domain.user.model.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -92,7 +93,7 @@ public class OrdersService {
     }
 
     public OrdersDto.OrdersRes findById(Long ordersIdx) {
-        Orders orders =  ordersRepository.findById(ordersIdx).orElseThrow(
+        Orders orders = ordersRepository.findById(ordersIdx).orElseThrow(
                 () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
         return OrdersDto.OrdersRes.from(orders);
     }
@@ -111,5 +112,14 @@ public class OrdersService {
                 .orElse(Danger.builder().build());
         danger.update(req.getRatio(), req.getPeriod());
         dangerRepository.save(danger);
+    }
+
+    public List<OrdersDto.OrdersRes> findByUserIdx(Long userIdx) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        return ordersRepository.findAllByStore_IdxAndOrdersStatus(store.getIdx(), OrdersStatus.APPROVE).stream()
+                .map(OrdersDto.OrdersRes::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java
@@ -1,10 +1,13 @@
 package com.example.nexus.domain.store;
 
 import com.example.nexus.domain.store.model.Store;
+import com.example.nexus.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store,Long> {
     Optional<Store> findByUserIdx(Long userIdx);
+
+    Long user(User user);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 가맹점주가 JWT 인증을 통해 본인 가게의 승인된 발주 이력을 조회하는 기능 구현                                                                                                                                                    
              
## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java`
- `backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java`

## 주요 변경 사항
- [x] `GET /orders/store/list` 엔드포인트 추가
- [x] `userIdx`로 가맹점 조회 후 승인된 발주 이력 반환 (`OrdersService.findByUserIdx`)
- [x] `OrdersRepository`에 `store_idx` + `OrdersStatus` 조건 쿼리 추가
- [x] `StoreRepository`에 `findByUserIdx` 추가

## DB & Infrastructure (해당 시)
- [ ] 엔티티 수정으로 인한 테이블 스키마 변경 없음

## Test Plan
- [ ] 가맹점주 계정으로 로그인 후 `GET /orders/store/list` 호출 및 본인 가게 발주 이력만 반환되는지 확인
- [ ] 미인증 상태에서 401 응답 확인

## Issue
- Closes #130