### PR TITLE
[Fix] #394 - 본사 발주 이력 조회 시 APPROVE 상태 필터링 추가

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -11,4 +11,5 @@ import java.util.List;
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
     List<Orders> findAllByOrdersTypeAndOrdersStatus(OrdersType ordersType, OrdersStatus ordersStatus);
     List<Orders> findAllByStore_IdxAndOrdersStatus(Long storeIdx, OrdersStatus orderStatus);
+    List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -87,7 +87,7 @@ public class OrdersService {
     }
 
     public List<OrdersDto.OrdersRes> findAll() {
-        return ordersRepository.findAll().stream()
+        return ordersRepository.findAllByOrdersStatus(OrdersStatus.APPROVE).stream()
                 .map(OrdersDto.OrdersRes::from)
                 .toList();
     }


### PR DESCRIPTION
## Summary
- 본사 발주 이력 조회 시 모든 발주가 조회되던 문제를 APPROVE 상태만 조회되도록 수정

## 변경 파일
- `OrdersRepository.java`
- `OrdersService.java`

## 주요 변경 사항
- [x] OrdersRepository에 findAllByOrdersStatus 쿼리 메서드 추가
- [x] OrdersService.findAll()에서 OrdersStatus.APPROVE 필터링 적용

## Test Plan
- [x] 본사 발주 이력 조회 API 호출 시 APPROVE 상태 발주만 반환되는지 확인

## Issue
- Closes #394