### PR TITLE
[Feat] #397 - 가맹점 제안 발주서 조회 기능 구현        

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -64,11 +64,20 @@ public class OrdersController {
     }
 
     @GetMapping("/store/list")
-    public ResponseEntity storeList(@AuthenticationPrincipal AuthUserDetails userDetails) {
-        if (userDetails == null) {
+    public ResponseEntity storeList(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        if (authUserDetails == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
         }
-        List<OrdersDto.OrdersRes> result = orderService.findByUserIdx(userDetails.getIdx());
+        List<OrdersDto.OrdersRes> result = orderService.findByUserIdx(authUserDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    @GetMapping("/store/find")
+    public ResponseEntity storeFind(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        if (authUserDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        List<OrdersDto.OrdersRes> result = orderService.findByUserIdxAndOrdersStatus(authUserDetails.getIdx());
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -122,4 +122,13 @@ public class OrdersService {
                 .map(OrdersDto.OrdersRes::from)
                 .toList();
     }
+
+    public List<OrdersDto.OrdersRes> findByUserIdxAndOrdersStatus(Long userIdx) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        return ordersRepository.findAllByStore_IdxAndOrdersStatus(store.getIdx(), OrdersStatus.WAITING).stream()
+                .map(OrdersDto.OrdersRes::from)
+                .toList();
+    }
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 가맹점주가 본사에서 제안한 발주서(WAITING 상태)를 조회할 수 있는 API 추가

## 변경 파일
- `OrdersController.java`
- `OrdersService.java`

## 주요 변경 사항
-  OrdersController에 GET /store/find 엔드포인트 추가
-  OrdersService에 findByUserIdxAndOrdersStatus 메서드 추가
-  storeList 메서드 파라미터명 authUserDetails로 통일

## Test Plan
- [ ] GET /store/find 호출 시 로그인한 점주 매장의 WAITING 상태 발주서만 반환되는지 확인
- [ ] 미인증 상태에서 401 응답 확인

## Issue
- Closes #397