### PR TITLE
[Fix] 더미데이터 비밀번호 해시 수정 및 로그인 디버깅 개선

### DIFF
--- a/backend/src/main/java/com/example/nexus/config/LoginFilter.java
+++ b/backend/src/main/java/com/example/nexus/config/LoginFilter.java
@@ -35,7 +35,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
-        response.getWriter().write("login failed: " + failed.getMessage());
+        response.getWriter().write("login failed");
     }
 
     @Override

--- a/backend/src/main/java/com/example/nexus/config/LoginFilter.java
+++ b/backend/src/main/java/com/example/nexus/config/LoginFilter.java
@@ -35,7 +35,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
-        response.getWriter().write("login failed");
+        response.getWriter().write("login failed: " + failed.getMessage());
     }
 
     @Override

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -13,3 +13,7 @@ spring:
 
 server:
   port: 8080
+
+logging:
+  level:
+    org.springframework.security: DEBUG

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -37,13 +37,13 @@ SET FOREIGN_KEY_CHECKS = 1;
 -- ============================================================
 -- 비밀번호: 모두 'password123' BCrypt 인코딩
 INSERT INTO user (email, password, user_name, tel, role, is_deleted) VALUES
-('admin@theventi.co.kr', '{bcrypt}$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '김본사', '010-1234-5678', 'ADMIN', false),
-('manager01@theventi.co.kr', '{bcrypt}$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '이정우', '010-2345-6789', 'MANAGER', false),
-('store01@theventi.co.kr', '{bcrypt}$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '박민수', '010-3456-7890', 'STORE', false),
-('store02@theventi.co.kr', '{bcrypt}$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '최유진', '010-4567-8901', 'STORE', false),
-('store03@theventi.co.kr', '{bcrypt}$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '정수아', '010-5678-9012', 'STORE', false),
-('store04@theventi.co.kr', '{bcrypt}$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '한지민', '010-6789-0123', 'STORE', false),
-('store05@theventi.co.kr', '{bcrypt}$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '윤서준', '010-7890-1234', 'STORE', false);
+('admin@theventi.co.kr', '{bcrypt}$2b$10$lvGJMgshX87086lRcSRGT.NXXzXyKXIXc2PgpAgAeK10LKeWfW2MS', '김본사', '010-1234-5678', 'ADMIN', false),
+('manager01@theventi.co.kr', '{bcrypt}$2b$10$lvGJMgshX87086lRcSRGT.NXXzXyKXIXc2PgpAgAeK10LKeWfW2MS', '이정우', '010-2345-6789', 'MANAGER', false),
+('store01@theventi.co.kr', '{bcrypt}$2b$10$lvGJMgshX87086lRcSRGT.NXXzXyKXIXc2PgpAgAeK10LKeWfW2MS', '박민수', '010-3456-7890', 'STORE', false),
+('store02@theventi.co.kr', '{bcrypt}$2b$10$lvGJMgshX87086lRcSRGT.NXXzXyKXIXc2PgpAgAeK10LKeWfW2MS', '최유진', '010-4567-8901', 'STORE', false),
+('store03@theventi.co.kr', '{bcrypt}$2b$10$lvGJMgshX87086lRcSRGT.NXXzXyKXIXc2PgpAgAeK10LKeWfW2MS', '정수아', '010-5678-9012', 'STORE', false),
+('store04@theventi.co.kr', '{bcrypt}$2b$10$lvGJMgshX87086lRcSRGT.NXXzXyKXIXc2PgpAgAeK10LKeWfW2MS', '한지민', '010-6789-0123', 'STORE', false),
+('store05@theventi.co.kr', '{bcrypt}$2b$10$lvGJMgshX87086lRcSRGT.NXXzXyKXIXc2PgpAgAeK10LKeWfW2MS', '윤서준', '010-7890-1234', 'STORE', false);
 
 -- ============================================================
 -- 2. Store (가맹점 5개)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 더미데이터 비밀번호 해시가 실제 password123과 불일치하여 로그인 실패하던 문제 수정
- 로그인 실패 시 원인 파악을 위한 디버깅 로그 추가

## 변경 파일
- `data.sql`
- `LoginFilter.java`
- `application-dev.yaml`

## 주요 변경 사항
- data.sql의 BCrypt 해시를 password123에 맞는 해시로 교체
- LoginFilter에 로그인 실패 원인 메시지 출력 추가
- application-dev.yaml에 Spring Security DEBUG 로깅 추가

## Test Plan
- [x] password123으로 로그인 성공 확인
- [x] 잘못된 비밀번호로 로그인 시 실패 원인 메시지 출력 확인