### PR TITLE
[Feat] #405 - 이상 발주 거절 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -69,6 +69,12 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
+    @PutMapping("/danger/{ordersIdx}/reject")
+    public ResponseEntity dangerReject(@PathVariable Long ordersIdx) {
+        orderService.reject(ordersIdx);
+        return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
     @GetMapping("/store/list")
     public ResponseEntity storeList(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
         if (authUserDetails == null) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -121,6 +121,13 @@ public class OrdersService {
         orders.approveDangerOrder();
     }
 
+
+    public void reject(Long ordersIdx) {
+        Orders orders = ordersRepository.findById(ordersIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+        orders.rejectDangerOrder();
+    }
+
     public List<OrdersDto.OrdersRes> findByUserIdx(Long userIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -121,7 +121,7 @@ public class OrdersService {
         orders.approveDangerOrder();
     }
 
-
+    @Transactional
     public void reject(Long ordersIdx) {
         Orders orders = ordersRepository.findById(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
@@ -54,4 +54,9 @@ public class Orders {
         this.isDanger = false;
         this.ordersStatus = OrdersStatus.APPROVE;
     }
+
+    public void rejectDangerOrder() {
+        this.isDanger = false;
+        this.ordersStatus = OrdersStatus.REJECT;
+    }
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 이상 발주 목록에서 발주서를 거절할 수 있는 API 구현

## 변경 파일
- `Orders.java`
- `OrdersService.java`
- `OrdersController.java`

## 주요 변경 사항
- Orders 엔티티에 rejectDangerOrder 메서드 추가 (isDanger → false, ordersStatus → REJECT)
- OrdersService에 reject 로직 구현 (@Transactional 적용)
- OrdersController에 PUT /danger/{ordersIdx}/reject 엔드포인트 추가

## Test Plan
- [ ] 이상 발주 거절 API 호출 시 isDanger가 false로 변경되는지 확인
- [ ] 거절 후 ordersStatus가 REJECT로 변경되는지 확인
- [ ] 존재하지 않는 ordersIdx로 요청 시 에러 응답 확인

## Issue
- Closes #405