### PR TITLE
[Refactor] #140 #134 - 발주 승인/거절 API 통합         

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -63,14 +63,14 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
-    @PutMapping("/danger/{ordersIdx}/approve")
-    public ResponseEntity dangerApprove(@PathVariable Long ordersIdx) {
+    @PutMapping("/{ordersIdx}/approve")
+    public ResponseEntity approve(@PathVariable Long ordersIdx) {
         orderService.approve(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
-    @PutMapping("/danger/{ordersIdx}/reject")
-    public ResponseEntity dangerReject(@PathVariable Long ordersIdx) {
+    @PutMapping("/{ordersIdx}/reject")
+    public ResponseEntity reject(@PathVariable Long ordersIdx) {
         orderService.reject(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -118,14 +118,20 @@ public class OrdersService {
     public void approve(Long ordersIdx) {
         Orders orders = ordersRepository.findById(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-        orders.approveDangerOrder();
+        if (orders.isDanger()) {
+            orders.clearDanger();
+        }
+        orders.approve();
     }
 
     @Transactional
     public void reject(Long ordersIdx) {
         Orders orders = ordersRepository.findById(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-        orders.rejectDangerOrder();
+        if (orders.isDanger()) {
+            orders.clearDanger();
+        }
+        orders.reject();
     }
 
     public List<OrdersDto.OrdersRes> findByUserIdx(Long userIdx) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
@@ -50,13 +50,15 @@ public class Orders {
     @OneToOne(mappedBy = "orders", fetch = FetchType.LAZY)
     private Delivery delivery;
 
-    public void approveDangerOrder() {
-        this.isDanger = false;
+    public void approve() {
         this.ordersStatus = OrdersStatus.APPROVE;
     }
 
-    public void rejectDangerOrder() {
-        this.isDanger = false;
+    public void reject() {
         this.ordersStatus = OrdersStatus.REJECT;
+    }
+
+    public void clearDanger() {
+        this.isDanger = false;
     }
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 이상 발주와 자동 발주 추천의 승인/거절 로직을 공통 메서드로 통합                                                                                                                                                                
- `/danger/`, `/store/` 엔드포인트를 `/{ordersIdx}/approve`, `/{ordersIdx}/reject`로 단일화                                                                                                                                       
                                                                                                                                                                                                                                  
## 변경 파일                                                                                                                                                                                                                      
- OrdersController.java                                                                                                                                                                                                           
- OrdersService.java
- Orders.java

## 주요 변경 사항
- Orders 엔티티: approveDangerOrder()/rejectDangerOrder() → 범용 approve()/reject() + clearDanger() 분리
- OrdersService: isDanger 여부에 따라 clearDanger() 조건 호출
- OrdersController: 4개 엔드포인트 → 2개로 통합

## Test Plan
- [ ] 이상 발주 승인/거절 시 isDanger 플래그 초기화 확인
- [ ] 일반 자동 발주 승인/거절 정상 동작 확인

## Issue
- Closes #140
- Closes #134
