### PR TITLE
[Feat] #138 - 자동 발주서 품목 수정 기능 구현  

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -82,6 +82,12 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success("create success"));
     }
 
+    @PutMapping("/items/{ordersItemIdx}")
+    public ResponseEntity updateItemCount(@PathVariable Long ordersItemIdx, @RequestBody OrdersItemDto.OrdersItemReq req) {
+        orderService.updateItemCount(ordersItemIdx, req.getCount());
+        return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
     @GetMapping("/store/list")
     public ResponseEntity storeList(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
         if (authUserDetails == null) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -3,6 +3,7 @@ package com.example.nexus.domain.orders;
 import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.domain.orders.model.DangerDto;
 import com.example.nexus.domain.orders.model.OrdersDto;
+import com.example.nexus.domain.orders.model.OrdersItemDto;
 import com.example.nexus.domain.user.model.AuthUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -73,6 +74,12 @@ public class OrdersController {
     public ResponseEntity reject(@PathVariable Long ordersIdx) {
         orderService.reject(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
+    @PostMapping("/{ordersIdx}/items")
+    public ResponseEntity addItem(@PathVariable Long ordersIdx, @RequestBody OrdersItemDto.OrdersItemReq req) {
+        orderService.addItem(ordersIdx, req);
+        return ResponseEntity.ok(BaseResponse.success("create success"));
     }
 
     @GetMapping("/store/list")

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -88,6 +88,12 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
+    @DeleteMapping("/items/{ordersItemIdx}")
+    public ResponseEntity deleteItem(@PathVariable Long ordersItemIdx) {
+        orderService.deleteItem(ordersItemIdx);
+        return ResponseEntity.ok(BaseResponse.success("delete success"));
+    }
+
     @GetMapping("/store/list")
     public ResponseEntity storeList(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
         if (authUserDetails == null) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -63,14 +63,14 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
-    @PutMapping("/danger/{ordersIdx}/approve")
-    public ResponseEntity dangerApprove(@PathVariable Long ordersIdx) {
+    @PutMapping("/{ordersIdx}/approve")
+    public ResponseEntity approve(@PathVariable Long ordersIdx) {
         orderService.approve(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
-    @PutMapping("/danger/{ordersIdx}/reject")
-    public ResponseEntity dangerReject(@PathVariable Long ordersIdx) {
+    @PutMapping("/{ordersIdx}/reject")
+    public ResponseEntity reject(@PathVariable Long ordersIdx) {
         orderService.reject(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -134,6 +134,23 @@ public class OrdersService {
         orders.reject();
     }
 
+    @Transactional
+    public void addItem(Long ordersIdx, OrdersItemDto.OrdersItemReq req) {
+        Orders orders = ordersRepository.findById(ordersIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        Product product = productRepository.findById(req.getProductIdx())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        ordersItemRepository.save(OrdersItem.builder()
+                .count(req.getCount())
+                .product(product)
+                .orders(orders)
+                .build());
+
+        orders.updatePrice(orders.getPrice() + (long) product.getUnitPrice() * req.getCount());
+    }
+
     public List<OrdersDto.OrdersRes> findByUserIdx(Long userIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -118,14 +118,20 @@ public class OrdersService {
     public void approve(Long ordersIdx) {
         Orders orders = ordersRepository.findById(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-        orders.approveDangerOrder();
+        if (orders.isDanger()) {
+            orders.clearDanger();
+        }
+        orders.approve();
     }
 
     @Transactional
     public void reject(Long ordersIdx) {
         Orders orders = ordersRepository.findById(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-        orders.rejectDangerOrder();
+        if (orders.isDanger()) {
+            orders.clearDanger();
+        }
+        orders.reject();
     }
 
     public List<OrdersDto.OrdersRes> findByUserIdx(Long userIdx) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -162,6 +162,16 @@ public class OrdersService {
         orders.updatePrice(orders.getPrice() + priceDiff);
     }
 
+    @Transactional
+    public void deleteItem(Long ordersItemIdx) {
+        OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        Orders orders = item.getOrders();
+        orders.updatePrice(orders.getPrice() - (long) item.getProduct().getUnitPrice() * item.getCount());
+        ordersItemRepository.delete(item);
+    }
+
     public List<OrdersDto.OrdersRes> findByUserIdx(Long userIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -151,6 +151,17 @@ public class OrdersService {
         orders.updatePrice(orders.getPrice() + (long) product.getUnitPrice() * req.getCount());
     }
 
+    @Transactional
+    public void updateItemCount(Long ordersItemIdx, Integer count) {
+        OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        Orders orders = item.getOrders();
+        long priceDiff = (long) item.getProduct().getUnitPrice() * (count - item.getCount());
+        item.updateCount(count);
+        orders.updatePrice(orders.getPrice() + priceDiff);
+    }
+
     public List<OrdersDto.OrdersRes> findByUserIdx(Long userIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
@@ -61,4 +61,8 @@ public class Orders {
     public void clearDanger() {
         this.isDanger = false;
     }
+
+    public void updatePrice(Long price) {
+        this.price = price;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
@@ -50,13 +50,15 @@ public class Orders {
     @OneToOne(mappedBy = "orders", fetch = FetchType.LAZY)
     private Delivery delivery;
 
-    public void approveDangerOrder() {
-        this.isDanger = false;
+    public void approve() {
         this.ordersStatus = OrdersStatus.APPROVE;
     }
 
-    public void rejectDangerOrder() {
-        this.isDanger = false;
+    public void reject() {
         this.ordersStatus = OrdersStatus.REJECT;
+    }
+
+    public void clearDanger() {
+        this.isDanger = false;
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItem.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItem.java
@@ -28,4 +28,7 @@ public class OrdersItem {
     @JoinColumn(name = "product_idx", nullable = false)
     private Product product;
 
+    public void updateCount(Integer count) {
+        this.count = count;
+    }
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 가맹점에서 자동 발주서의 품목을 추가/수량 수정/삭제할 수 있는 API 구현                                                                                                                                                          
- 이상 발주와 자동 발주 추천의 승인/거절 엔드포인트를 공통 API로 통합                                                                                                                                                             
                                                                                                                                                                                                                                
## 변경 파일
- OrdersController.java
- OrdersService.java
- Orders.java
- OrdersItem.java

## 주요 변경 사항
-  발주서 품목 추가 API (`POST /orders/{ordersIdx}/items`)
-  발주서 품목 수량 수정 API (`PUT /orders/items/{ordersItemIdx}`)
-  발주서 품목 삭제 API (`DELETE /orders/items/{ordersItemIdx}`)
- 품목 변경 시 발주서 총 가격 자동 반영
- 승인/거절 엔드포인트 통합 (`PUT /orders/{ordersIdx}/approve|reject`)
- Orders 엔티티에 updatePrice, OrdersItem 엔티티에 updateCount 메서드 추가

## Test Plan
- [ ] 품목 추가 후 총 가격 정상 반영 확인
- [ ] 수량 수정 후 총 가격 차액 반영 확인
- [ ] 품목 삭제 후 총 가격 차감 확인
- [ ] 승인/거절 API 기존 기능 정상 동작 확인

## Issue
- Closes #138