### PR TITLE
[Design] #71 - 발주 상세 모달 합계 영역 개선

### DIFF
--- a/frontend/src/components/orders/HqOrderDetailModal.vue
+++ b/frontend/src/components/orders/HqOrderDetailModal.vue
@@ -86,7 +86,11 @@ defineEmits(['close'])
               </tbody>
               <tfoot v-if="order.type !== '이상'" class="bg-gray-50 border-t border-gray-200">
                 <tr>
-                  <td colspan="3" class="px-4 py-2.5 text-right text-xs font-bold text-gray-500">합계</td>
+                  <td class="px-4 py-2.5 text-left text-xs font-bold text-gray-500">합계</td>
+                  <td class="px-4 py-2.5 text-right font-bold text-gray-900">
+                    {{ (order.items ?? []).reduce((s, i) => s + i.qty, 0).toLocaleString() }}
+                  </td>
+                  <td class="px-4 py-2.5"></td>
                   <td class="px-4 py-2.5 text-right font-black text-[#F37321]">
                     {{ formatPrice((order.items ?? []).reduce((s, i) => s + (i.unitPrice ? i.unitPrice * i.qty : 0), 0)) }}
                   </td>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 발주 상세 모달의 합계 행 레이아웃 개선

## 변경 파일
- `frontend/src/components/orders/HqOrderDetailModal.vue`

## 주요 변경 사항
- 합계 레이블을 우측 정렬에서 좌측(맨 왼쪽 칸)으로 이동
- 수량 합계 컬럼 추가하여 총 수량과 총 금액을 함께 표시

## Test Plan
- [ ] 자동 발주 상세 모달에서 합계 행에 수량 합계와 금액 합계가 정상 표시되는지 확인
- [ ] 이상 발주 상세 모달에서는 합계 행이 표시되지 않는지 확인

## Issue
- Closes #71                                                                                                                                                             
- 발주 상세 모달의 합계 행 레이아웃 개선

## 변경 파일
- `frontend/src/components/orders/HqOrderDetailModal.vue`

## 주요 변경 사항
- 합계 레이블을 우측 정렬에서 좌측(맨 왼쪽 칸)으로 이동
- 수량 합계 컬럼 추가하여 총 수량과 총 금액을 함께 표시

## Test Plan
- [x] 자동 발주 상세 모달에서 합계 행에 수량 합계와 금액 합계가 정상 표시되는지 확인
- [ ] 이상 발주 상세 모달에서는 합계 행이 표시되지 않는지 확인

## Issue
- Closes #71