### PR TITLE
[Feat] #69 - 수동 발주 목록 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -30,7 +30,7 @@ public class OrdersController {
 
     @GetMapping("/list/manual")
     public ResponseEntity manualList() {
-        List<OrdersDto.OrdersRes> result = orderService.findAllManual();
+        List<OrdersDto.OrderListRes> result = orderService.findAllManual();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -33,9 +33,9 @@ public class OrdersService {
                 .toList();
     }
 
-    public List<OrdersDto.OrdersRes> findAllManual() {
+    public List<OrdersDto.OrderListRes> findAllManual() {
         return ordersRepository.findAllByOrdersTypeAndOrdersStatus(OrdersType.MANUAL, OrdersStatus.WAITING).stream()
-                .map(OrdersDto.OrdersRes::from)
+                .map(OrdersDto.OrderListRes::from)
                 .toList();
     }
 

--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -1,5 +1,9 @@
 import api from '@/plugins/axiosinterceptor'
 
+const getManualOrders = () => {
+  return api.get('/orders/list/manual')
+}
+
 const getAutoOrders = () => {
   return api.get('/orders/list/auto')
 }
@@ -17,6 +21,7 @@ const updateDangerSettings = (data) => {
 }
 
 export default {
+  getManualOrders,
   getAutoOrders,
   getOrderDetail,
   getDangerSettings,

--- a/frontend/src/components/orders/HqManualOrderTable.vue
+++ b/frontend/src/components/orders/HqManualOrderTable.vue
@@ -27,7 +27,7 @@ defineEmits(['open-detail'])
               <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ o.id }}</td>
               <td class="px-5 py-3.5 font-semibold text-gray-900">{{ o.store }}</td>
               <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ o.date }}</td>
-              <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice((o.items ?? []).reduce((s, i) => s + i.unitPrice * i.qty, 0)) }}</td>
+              <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice(o.price) }}</td>
               <td class="px-5 py-3.5">
                 <span class="text-xs font-bold px-2 py-0.5 rounded" :class="statusClass(o.status)">{{ o.status }}</span>
               </td>

--- a/frontend/src/components/orders/HqManualOrderTable.vue
+++ b/frontend/src/components/orders/HqManualOrderTable.vue
@@ -25,7 +25,7 @@ defineEmits(['open-detail'])
           </thead>
           <tbody class="divide-y divide-gray-100">
             <tr v-for="o in orders" :key="o.id" class="hover:bg-gray-50/50 transition-colors cursor-pointer"
-              @click="$emit('open-detail', { id: o.id, type: '수동', store: o.store, status: o.status, date: o.date, items: o.items })">
+              @click="$emit('open-detail', o.id)">
               <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ o.id }}</td>
               <td class="px-5 py-3.5 font-semibold text-gray-900">{{ o.store }}</td>
               <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ o.date }}</td>

--- a/frontend/src/components/orders/HqManualOrderTable.vue
+++ b/frontend/src/components/orders/HqManualOrderTable.vue
@@ -9,10 +9,8 @@ defineEmits(['open-detail'])
 </script>
 
 <template>
-  <div class="space-y-5">
-    <div>
-      <h3 class="text-sm font-bold text-gray-700 mb-2">진행 중인 수동 발주</h3>
-      <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+  <div class="space-y-4">
+    <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
         <table class="w-full text-sm text-left">
           <thead>
             <tr class="border-b border-gray-200 bg-gray-50">
@@ -35,11 +33,10 @@ defineEmits(['open-detail'])
               </td>
             </tr>
             <tr v-if="orders.length === 0">
-              <td colspan="5" class="px-5 py-8 text-center text-sm text-gray-400">진행 중인 수동 발주가 없습니다.</td>
+              <td colspan="5" class="px-5 py-10 text-center text-sm text-gray-400">수동 발주 제안이 없습니다.</td>
             </tr>
           </tbody>
         </table>
-      </div>
     </div>
   </div>
 </template>

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -81,11 +81,6 @@ async function fetchManualOrders() {
       date: o.createdAt?.replace('T', ' ').slice(0, 16) ?? '-',
       price: o.price,
       status: o.ordersStatus === 'WAITING' ? '제안중' : o.ordersStatus === 'APPROVE' ? '확정' : '거절',
-      items: (o.ordersItemList ?? []).map(i => ({
-        product: i.productName,
-        qty: i.count,
-        unitPrice: i.unitPrice,
-      })),
     }))
   } catch (e) {
     console.error('수동 발주 목록 조회 실패', e)

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -103,6 +103,7 @@ function applyOrderRouteQuery() {
 onMounted(() => {
   applyOrderRouteQuery()
   fetchAutoOrders()
+  fetchManualOrders()
 })
 
 function setOrderViewTab(id) {

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -18,7 +18,7 @@ const abnormalCount = computed(() => abnormalOrders.value.filter(o => !o.process
 
 const tabs = computed(() => [
   { id: 'auto',     label: '자동 발주 제안', badge: autoOrders.value.length || null },
-  { id: 'manual',   label: '수동 발주 제안' },
+  { id: 'manual',   label: '수동 발주 제안', badge: manualOrders.value.length || null },
   { id: 'history',  label: '발주 이력' },
   { id: 'abnormal', label: '이상 발주', badge: abnormalCount.value || null },
 ])

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -70,12 +70,27 @@ const abnormalOrders = ref([
     ] },
 ])
 
-const pendingManualOrders = ref([
-  { id: 'MAN-20260420-001', store: '이탈리안 키친', date: '2026-04-20 09:10', status: '확정',
-    items: [{ product: '한우 등심', qty: 10, unitPrice: 85000 }, { product: '버터', qty: 5, unitPrice: 9000 }] },
-  { id: 'MAN-20260419-002', store: '일식 스시바',   date: '2026-04-19 14:30', status: '배송중',
-    items: [{ product: '올리브오일', qty: 8, unitPrice: 12000 }, { product: '간장', qty: 5, unitPrice: 4000 }, { product: '생수', qty: 10, unitPrice: 8000 }] },
-])
+const manualOrders = ref([])
+
+async function fetchManualOrders() {
+  try {
+    const res = await ordersApi.getManualOrders()
+    manualOrders.value = res.data.result.map(o => ({
+      id: o.idx,
+      store: o.storeName,
+      date: o.createdAt?.replace('T', ' ').slice(0, 16) ?? '-',
+      price: o.price,
+      status: o.ordersStatus === 'WAITING' ? '제안중' : o.ordersStatus === 'APPROVE' ? '확정' : '거절',
+      items: (o.ordersItemList ?? []).map(i => ({
+        product: i.productName,
+        qty: i.count,
+        unitPrice: i.unitPrice,
+      })),
+    }))
+  } catch (e) {
+    console.error('수동 발주 목록 조회 실패', e)
+  }
+}
 
 // Tab routing
 function applyOrderRouteQuery() {

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -221,7 +221,7 @@ function submitManualOrder({ store, items }) {
 
     <!-- Tab Contents -->
     <HqAutoOrderTable v-if="activeTab === 'auto'" :orders="autoOrders" @open-detail="openDetail" />
-    <HqManualOrderTable v-if="activeTab === 'manual'" :orders="pendingManualOrders" @open-detail="openDetail" />
+    <HqManualOrderTable v-if="activeTab === 'manual'" :orders="manualOrders" @open-detail="openDetail" />
     <HqOrderHistoryTable v-if="activeTab === 'history'" :orders="orderHistory" @open-detail="openDetail" />
     <HqAbnormalOrderTable v-if="activeTab === 'abnormal'" :orders="abnormalOrders"
       @open-detail="openDetail" @approve="approveAbnormal" @reject="rejectAbnormal" />


### PR DESCRIPTION
## Summary
- 수동 발주 목록 조회 API 연동 및 상세 조회 기능 구현

## 변경 파일
- `frontend/src/api/orders/index.js`
- `frontend/src/views/hq/HqOrderManageView.vue`
- `frontend/src/components/orders/HqManualOrderTable.vue`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`

## 주요 변경 사항
- 수동 발주 목록 조회 API 함수 추가 (getManualOrders)
- 목데이터 제거 및 API 데이터 바인딩
- 마운트 시 수동 발주 목록 자동 조회
- 수동 발주 탭 badge 건수 표시
- 목록 클릭 시 상세 조회 API 연동
- 백엔드 응답 DTO를 OrderListRes로 변경
- 총 금액 표시를 price 필드 직접 사용으로 수정
- 수동 발주 테이블 레이아웃을 자동 발주와 통일

## Test Plan
- [x] 수동 발주 목록 조회 시 데이터 정상 표시 확인
- [x] 목록 클릭 시 상세 모달 정상 표시 확인
- [ ] 데이터 없을 때 빈 상태 메시지 확인
- [x] 탭 badge 건수 정상 표시 확인

## Issue
- Closes #69