### PR TITLE
[Feat] #67 - 수동 발주 생성 프론트엔드-백엔드 API 연동

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -34,9 +34,9 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
-    @PostMapping
-    public ResponseEntity create(@RequestBody OrdersDto.OrdersReq req) {
-        orderService.create(req);
+    @PostMapping("/manual")
+    public ResponseEntity createManualOrder(@RequestBody OrdersDto.OrdersReq req) {
+        orderService.createManualOrder(req);
         return ResponseEntity.ok(BaseResponse.success("create success"));
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -34,7 +34,7 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
-    @PostMapping("/manual")
+    @PostMapping("/reg/manual")
     public ResponseEntity createManualOrder(@RequestBody OrdersDto.OrdersReq req) {
         orderService.createManualOrder(req);
         return ResponseEntity.ok(BaseResponse.success("create success"));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -40,7 +40,7 @@ public class OrdersService {
     }
 
     @Transactional
-    public void create(OrdersDto.OrdersReq req) {
+    public void createManualOrder(OrdersDto.OrdersReq req) {
         // 0. 주문 아이템 리스트 검증
         if (req.getOrdersItemList() == null || req.getOrdersItemList().isEmpty()) {
             throw new BaseException(BaseResponseStatus.REQUEST_ERROR);

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItemDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItemDto.java
@@ -26,7 +26,7 @@ public class OrdersItemDto {
                     .idx(entity.getIdx())
                     .count(entity.getCount())
                     .orderIdx(entity.getOrders().getIdx())
-                    .productName(entity.getProduct().getName())
+                    .productName(entity.getProduct().getProductName())
                     .unitPrice(entity.getProduct().getUnitPrice())
                     .build();
         }

--- a/backend/src/main/java/com/example/nexus/domain/pos/model/PosStoreInventoryDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/model/PosStoreInventoryDto.java
@@ -32,7 +32,7 @@ public class PosStoreInventoryDto {
                     .storeIdx(entity.getStore().getIdx())
                     .storeName(entity.getStore().getStoreName())
                     .productIdx(entity.getProduct().getIdx())
-                    .productName(entity.getProduct().getName())
+                    .productName(entity.getProduct().getProductName())
                     .minStock(entity.getProduct().getMinStock())
                     .build();
         }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreController.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreController.java
@@ -26,12 +26,12 @@ public class StoreController {
 
     // [본사] keyword로 가맹점 검색
     @GetMapping("/search")
-    public ResponseEntity<List<StoreDto.StoreSearchRes>> searchStore(@RequestParam(value = "keyword", required = false, defaultValue = "") String keyword) {
+    public ResponseEntity searchStore(@RequestParam(value = "keyword", required = false, defaultValue = "") String keyword) {
         StoreDto.StoreSearchReq reqDto = new StoreDto.StoreSearchReq(keyword);
 
         List<StoreDto.StoreSearchRes> result = storeService.searchByStoreName(reqDto);
 
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(BaseResponse.success(result));
     }
 
     @GetMapping("/list")

--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -20,10 +20,15 @@ const updateDangerSettings = (data) => {
   return api.put('/orders/danger', data)
 }
 
+const createManualOrder = (data) => {
+  return api.post('/orders/manual', data)
+}
+
 export default {
   getManualOrders,
   getAutoOrders,
   getOrderDetail,
   getDangerSettings,
   updateDangerSettings,
+  createManualOrder,
 }

--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -21,7 +21,7 @@ const updateDangerSettings = (data) => {
 }
 
 const createManualOrder = (data) => {
-  return api.post('/orders/manual', data)
+  return api.post('/orders/reg/manual', data)
 }
 
 export default {

--- a/frontend/src/api/product/index.js
+++ b/frontend/src/api/product/index.js
@@ -1,0 +1,3 @@
+import api from '@/plugins/axiosinterceptor'
+
+export const getProductList = () => api.get('/product/list')

--- a/frontend/src/components/orders/HqManualOrderModal.vue
+++ b/frontend/src/components/orders/HqManualOrderModal.vue
@@ -93,11 +93,13 @@ function submit() {
     return
   }
   emit('submit', {
-    store: form.store,
-    items: validItems.map(i => ({ product: i.product, qty: i.qty, unitPrice: productPrices[i.product] ?? 0 })),
+    storeIdx: form.store,
+    ordersItemList: validItems.map(i => ({ productIdx: i.product, count: i.qty })),
   })
   form.store = ''
   form.items = []
+  selectedStore.value = null
+  storeKeyword.value = ''
 }
 </script>
 

--- a/frontend/src/components/orders/HqManualOrderModal.vue
+++ b/frontend/src/components/orders/HqManualOrderModal.vue
@@ -2,7 +2,7 @@
 import { reactive, ref, onMounted } from 'vue'
 import { Plus } from 'lucide-vue-next'
 import { formatPrice } from './orderUtils'
-import { getStoreList } from '@/api/store'
+import { searchStoreList } from '@/api/store'
 import { getProductList } from '@/api/product'
 
 defineProps({
@@ -12,16 +12,47 @@ defineProps({
 const emit = defineEmits(['close', 'submit'])
 
 const stores = ref([])
+const storeKeyword = ref('')
+const selectedStore = ref(null)
+const showStoreDropdown = ref(false)
 const products = ref([])
 const form = reactive({ store: '', items: [] })
 
+async function searchStore() {
+  if (storeKeyword.value.trim().length === 0) {
+    stores.value = []
+    showStoreDropdown.value = false
+    return
+  }
+  try {
+    const res = await searchStoreList(storeKeyword.value)
+    stores.value = res.data.result
+    showStoreDropdown.value = stores.value.length > 0
+  } catch (e) {
+    console.error('매장 검색 실패', e)
+  }
+}
+
+function selectStore(store) {
+  selectedStore.value = store
+  form.store = store.idx
+  storeKeyword.value = store.storeName
+  showStoreDropdown.value = false
+}
+
+function clearStore() {
+  selectedStore.value = null
+  form.store = ''
+  storeKeyword.value = ''
+  stores.value = []
+}
+
 onMounted(async () => {
   try {
-    const [storeRes, productRes] = await Promise.all([getStoreList(), getProductList()])
-    stores.value = storeRes.data.result
+    const productRes = await getProductList()
     products.value = productRes.data
   } catch (e) {
-    console.error('매장/상품 목록 조회 실패', e)
+    console.error('상품 목록 조회 실패', e)
   }
 })
 
@@ -59,14 +90,20 @@ function submit() {
       <div class="p-6 space-y-4">
         <div class="space-y-1.5">
           <label class="text-xs font-bold text-gray-500 uppercase tracking-wider">대상 매장</label>
-          <select v-model="form.store"
-            class="w-full px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none">
-            <option value="">선택</option>
-            <option>한우 오마카세</option>
-            <option>이탈리안 키친</option>
-            <option>일식 스시바</option>
-            <option>차이나 가든</option>
-          </select>
+          <div class="relative">
+            <div v-if="selectedStore" class="flex items-center justify-between w-full px-3 py-2 rounded border border-[#F37321] bg-orange-50 text-sm">
+              <span class="font-medium text-gray-900">{{ selectedStore.storeName }}</span>
+              <button @click="clearStore" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
+            </div>
+            <input v-else v-model="storeKeyword" @input="searchStore" placeholder="매장명을 검색하세요"
+              class="w-full px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none" />
+            <ul v-if="showStoreDropdown" class="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded shadow-lg max-h-40 overflow-y-auto">
+              <li v-for="store in stores" :key="store.idx" @click="selectStore(store)"
+                class="px-3 py-2 text-sm hover:bg-orange-50 cursor-pointer">
+                {{ store.storeName }} <span class="text-gray-400 text-xs">{{ store.address }}</span>
+              </li>
+            </ul>
+          </div>
         </div>
         <div class="space-y-2">
           <div class="flex justify-between items-center">

--- a/frontend/src/components/orders/HqManualOrderModal.vue
+++ b/frontend/src/components/orders/HqManualOrderModal.vue
@@ -57,7 +57,29 @@ onMounted(async () => {
 })
 
 function addItem() {
-  form.items.push({ product: '', qty: 1, unitPrice: 0 })
+  form.items.push({ product: null, productKeyword: '', showDropdown: false, qty: 1, unitPrice: 0 })
+}
+
+function filterProducts(item) {
+  if (item.productKeyword.trim().length === 0) {
+    item.showDropdown = false
+    return []
+  }
+  item.showDropdown = true
+  return products.value.filter(p => p.productName.includes(item.productKeyword))
+}
+
+function selectProduct(item, product) {
+  item.product = product.idx
+  item.productKeyword = product.productName
+  item.unitPrice = product.unitPrice
+  item.showDropdown = false
+}
+
+function clearProduct(item) {
+  item.product = null
+  item.productKeyword = ''
+  item.unitPrice = 0
 }
 
 function submit() {
@@ -113,24 +135,28 @@ function submit() {
             </button>
           </div>
           <div v-for="(item, idx) in form.items" :key="idx" class="flex gap-2 items-center">
-            <select v-model="item.product" @change="item.unitPrice = productPrices[item.product] ?? 0"
-              class="flex-1 px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none">
-              <option value="">품목 선택</option>
-              <option>한우 등심</option>
-              <option>올리브오일</option>
-              <option>버터</option>
-              <option>생크림</option>
-              <option>간장</option>
-              <option>양파</option>
-              <option>생수</option>
-            </select>
+            <div class="flex-1 relative">
+              <div v-if="item.product" class="flex items-center justify-between px-3 py-2 rounded border border-[#F37321] bg-orange-50 text-sm">
+                <span class="font-medium text-gray-900">{{ item.productKeyword }}</span>
+                <button @click="clearProduct(item)" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
+              </div>
+              <input v-else v-model="item.productKeyword" @input="filterProducts(item)" placeholder="상품명 검색"
+                class="w-full px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none" />
+              <ul v-if="item.showDropdown && filterProducts(item).length > 0"
+                class="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded shadow-lg max-h-32 overflow-y-auto">
+                <li v-for="p in filterProducts(item)" :key="p.idx" @click="selectProduct(item, p)"
+                  class="px-3 py-2 text-sm hover:bg-orange-50 cursor-pointer">
+                  {{ p.productName }} <span class="text-gray-400 text-xs">{{ p.productUnit }}</span>
+                </li>
+              </ul>
+            </div>
             <div class="flex items-center gap-1.5">
               <input v-model.number="item.qty" type="number" min="1" placeholder="수량"
                 class="w-20 px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none" />
-              <span class="text-xs text-gray-400 font-medium w-6">{{ PRODUCT_UNIT[item.product] ?? '' }}</span>
+              <span class="text-xs text-gray-400 font-medium w-6">{{ item.product ? products.find(p => p.idx === item.product)?.productUnit : '' }}</span>
             </div>
             <div class="w-28 px-3 py-2 rounded border border-gray-100 bg-gray-50 text-sm text-gray-500 text-right shrink-0">
-              {{ item.product ? formatPrice(productPrices[item.product] ?? 0) : '-' }}
+              {{ item.product ? formatPrice(item.unitPrice) : '-' }}
             </div>
             <button @click="form.items.splice(idx, 1)"
               class="px-3 py-2 text-xs font-semibold rounded border border-red-200 text-red-500 bg-red-50 hover:bg-red-500 hover:text-white hover:cursor-pointer transition-colors shrink-0">

--- a/frontend/src/components/orders/HqManualOrderModal.vue
+++ b/frontend/src/components/orders/HqManualOrderModal.vue
@@ -155,7 +155,7 @@ function submit() {
             <div class="flex items-center gap-1.5">
               <input v-model.number="item.qty" type="number" min="1" placeholder="수량"
                 class="w-20 px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none" />
-              <span class="text-xs text-gray-400 font-medium w-6">{{ item.product ? products.find(p => p.idx === item.product)?.productUnit : '' }}</span>
+              <span class="text-xs text-gray-400 font-medium w-auto shrink-0">{{ item.product ? products.find(p => p.idx === item.product)?.productUnit : '' }}</span>
             </div>
             <div class="w-28 px-3 py-2 rounded border border-gray-100 bg-gray-50 text-sm text-gray-500 text-right shrink-0">
               {{ item.product ? formatPrice(item.unitPrice) : '-' }}

--- a/frontend/src/components/orders/HqManualOrderModal.vue
+++ b/frontend/src/components/orders/HqManualOrderModal.vue
@@ -1,7 +1,9 @@
 <script setup>
-import { reactive } from 'vue'
+import { reactive, ref, onMounted } from 'vue'
 import { Plus } from 'lucide-vue-next'
-import { formatPrice, PRODUCT_UNIT, productPrices } from './orderUtils'
+import { formatPrice } from './orderUtils'
+import { getStoreList } from '@/api/store'
+import { getProductList } from '@/api/product'
 
 defineProps({
   visible: { type: Boolean, required: true },
@@ -9,7 +11,19 @@ defineProps({
 
 const emit = defineEmits(['close', 'submit'])
 
+const stores = ref([])
+const products = ref([])
 const form = reactive({ store: '', items: [] })
+
+onMounted(async () => {
+  try {
+    const [storeRes, productRes] = await Promise.all([getStoreList(), getProductList()])
+    stores.value = storeRes.data.result
+    products.value = productRes.data
+  } catch (e) {
+    console.error('매장/상품 목록 조회 실패', e)
+  }
+})
 
 function addItem() {
   form.items.push({ product: '', qty: 1, unitPrice: 0 })

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -162,19 +162,17 @@ function rejectAbnormal(o)  { o.processed = true; alert(`${o.store} 발주 반�
 // Manual order modal
 const showManualForm = ref(false)
 
-function submitManualOrder({ store, items }) {
-  const now = new Date().toISOString().slice(0, 16).replace('T', ' ')
-  orderHistory.value.unshift({
-    id: `ORD-${Date.now()}`,
-    type: '수동',
-    store,
-    date: now,
-    status: '확정',
-    items,
-  })
-  alert('발주가 생성되었습니다.')
-  showManualForm.value = false
-  setOrderViewTab('history')
+async function submitManualOrder(data) {
+  try {
+    await ordersApi.createManualOrder(data)
+    alert('발주가 생성되었습니다.')
+    showManualForm.value = false
+    await fetchManualOrders()
+    setOrderViewTab('manual')
+  } catch (e) {
+    console.error('수동 발주 생성 실패', e)
+    alert('발주 생성에 실패했습니다.')
+  }
 }
 </script>
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 수동 발주 생성 모달에서 백엔드 API를 연동하여 실제 발주 생성이 동작하도록 구현

## 변경 파일
- `frontend/src/api/product/index.js` (신규)
- `frontend/src/api/orders/index.js`
- `frontend/src/components/orders/HqManualOrderModal.vue`
- `frontend/src/views/hq/HqOrderManageView.vue`
- `backend/src/main/java/.../orders/OrdersController.java`
- `backend/src/main/java/.../orders/OrdersService.java`
- `backend/src/main/java/.../orders/model/OrdersItemDto.java`
- `backend/src/main/java/.../store/StoreController.java`
- `backend/src/main/java/.../pos/model/PosStoreInventoryDto.java`

## 주요 변경 사항
- 수동 발주 생성 API 엔드포인트 및 메서드명 변경 (POST /orders/reg/manual)
- 상품 목록 조회 API 함수 추가 (GET /product/list)
- 수동 발주 생성 API 함수 추가 (POST /orders/reg/manual)
- 매장 선택을 검색 방식으로 변경 (GET /store/search 연동)
- 상품 선택을 검색 필터링 방식으로 변경
- submit 데이터를 백엔드 형식(storeIdx, ordersItemList)에 맞게 변환
- 발주 생성 시 실제 API 호출 및 목록 갱신 처리
- 매장 검색 API 응답을 BaseResponse 형식으로 통일
- Product 엔티티 필드명 변경에 따른 getter 수정

## Test Plan
- [ ] 매장 검색 후 선택하여 발주 생성 확인
- [ ] 상품 검색 후 선택 및 수량 입력 확인
- [ ] 발주 생성 후 수동 발주 목록에 반영 확인

## Issue
- Closes #67