### PR TITLE
[Feat] #435 - 가맹점 발주 취소 기능 추가

### DIFF
--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -24,6 +24,10 @@ const createStoreManualOrder = (data) => {
   return api.post('/orders/store/reg/manual', data)
 }
 
+const cancelOrder = (ordersIdx) => {
+  return api.put(`/orders/${ordersIdx}/cancel`)
+}
+
 export default {
   getManualOrders,
   getAutoOrders,
@@ -31,4 +35,5 @@ export default {
   getDangerSettings,
   updateDangerSettings,
   createStoreManualOrder,
+  cancelOrder,
 }

--- a/frontend/src/components/orders/orderUtils.js
+++ b/frontend/src/components/orders/orderUtils.js
@@ -8,6 +8,7 @@ export function statusClass(status) {
     '검토필요': 'bg-rose-50 text-rose-700 border border-rose-200',
     '확정':     'bg-green-50 text-green-700 border border-green-200',
     '거절':     'bg-gray-100 text-gray-400 border border-gray-200',
+    '취소':     'bg-red-50 text-red-500 border border-red-200',
     '배송중':   'bg-orange-50 text-orange-600 border border-orange-200',
     '입고완료': 'bg-emerald-50 text-emerald-700 border border-emerald-200',
   }

--- a/frontend/src/views/store/StoreOrderManageView.vue
+++ b/frontend/src/views/store/StoreOrderManageView.vue
@@ -193,6 +193,7 @@
               <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">총 금액</th>
               <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주일시</th>
               <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
+              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">처리</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-100">
@@ -218,6 +219,13 @@
                 <span class="text-xs font-bold px-2 py-0.5 rounded" :class="historyStatusCls(h.status)">
                   {{ h.status }}
                 </span>
+              </td>
+              <td class="px-5 py-3.5">
+                <button v-if="h.status === '확정'"
+                  @click.stop="cancelOrder(h)"
+                  class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-red-200 text-red-500 bg-red-50 hover:bg-red-500 hover:text-white hover:cursor-pointer transition-colors">
+                  취소
+                </button>
               </td>
             </tr>
             <tr v-if="orderHistory.length === 0">
@@ -466,10 +474,12 @@ function openHistoryDetail(h) {
 }
 
 const HISTORY_STATUS_CLS = {
+  '확정':     'bg-green-50 text-green-700 border border-green-200',
   '승인대기': 'bg-gray-100 text-gray-500 border border-gray-200',
   '배송중':   'bg-blue-50 text-blue-600 border border-blue-200',
   '입고완료': 'bg-green-50 text-green-700 border border-green-200',
   '거절':     'bg-red-50 text-red-600 border border-red-200',
+  '취소':     'bg-red-50 text-red-500 border border-red-200',
 }
 const historyStatusCls = s => HISTORY_STATUS_CLS[s] ?? 'bg-gray-100 text-gray-500 border border-gray-200'
 
@@ -543,6 +553,18 @@ function rejectOrder(order) {
   if (confirm('발주서를 거절하시겠습니까?')) {
     const idx = pendingOrders.value.indexOf(order)
     pendingOrders.value.splice(idx, 1)
+  }
+}
+
+async function cancelOrder(order) {
+  if (!confirm('발주를 취소하시겠습니까?')) return
+  try {
+    await ordersApi.cancelOrder(order.id)
+    order.status = '취소'
+    alert('발주가 취소되었습니다.')
+  } catch (e) {
+    console.error('발주 취소 실패', e)
+    alert('발주 취소에 실패했습니다.')
   }
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 가맹점 발주 이력에서 본사 승인 전(확정 상태)인 발주를 취소할 수 있는 기능 추가                                                                                                                                                  
                                                                                                                                                                                                                                
## 변경 파일                                              
- `frontend/src/components/orders/orderUtils.js`
- `frontend/src/views/store/StoreOrderManageView.vue`
- `frontend/src/api/orders/index.js`

## 주요 변경 사항
- `orderUtils.js`에 `취소` 상태 스타일 추가
- 발주 이력 테이블에 처리 컬럼 추가 및 확정 상태일 때 취소 버튼 노출
- 취소 확인 후 상태를 CANCELLED로 변경하는 로직 추가
- 발주 취소 API 엔드포인트 추가 (`PUT /orders/{ordersIdx}/cancel`)

## Test Plan
- [ ] 발주 이력에서 확정 상태인 발주에 취소 버튼이 노출되는지 확인
- [ ] 취소 버튼 클릭 시 확인 모달 표시 후 상태가 취소로 변경되는지 확인
- [ ] 확정 상태가 아닌 발주(배송중, 입고완료 등)에는 취소 버튼이 노출되지 않는지 확인

## Issue
- Closes #435