### PR TITLE
[Feat] #443 - 가맹점 발주 취소 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/common/enums/OrdersStatus.java
+++ b/backend/src/main/java/com/example/nexus/common/enums/OrdersStatus.java
@@ -3,5 +3,7 @@ package com.example.nexus.common.enums;
 public enum OrdersStatus {
     REJECT,
     WAITING,
-    APPROVE
+    CONFIRMED,
+    APPROVE,
+    CANCELLED
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -82,6 +82,12 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success("delete success"));
     }
 
+    @PutMapping("/{ordersIdx}/cancel")
+    public ResponseEntity cancel(@PathVariable Long ordersIdx) {
+        orderService.cancelOrder(ordersIdx);
+        return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
     @PostMapping("/store/reg/manual")
     public ResponseEntity createStoreManualOrder(@AuthenticationPrincipal AuthUserDetails authUserDetails, @RequestBody OrdersDto.OrdersReq req) {
         if (authUserDetails == null) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -63,7 +63,7 @@ public class OrdersService {
         Orders orders = ordersRepository.save(Orders.builder()
                 .price(totalprice)
                 .ordersType(OrdersType.MANUAL)
-                .ordersStatus(OrdersStatus.WAITING)
+                .ordersStatus(OrdersStatus.CONFIRMED)
                 .isDanger(false)
                 .createdAt(LocalDateTime.now())
                 .store(store)
@@ -77,6 +77,21 @@ public class OrdersService {
                     .orders(orders)
                     .build());
         }
+    }
+
+    @Transactional
+    public void cancelOrder(Long ordersIdx) {
+        // 1. 발주 조회
+        Orders orders = ordersRepository.findById(ordersIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // 2. CONFIRMED 상태인 경우에만 취소 가능
+        if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        // 3. 상태를 CANCELLED로 변경
+        orders.cancel();
     }
 
     public List<OrdersDto.OrdersRes> findAll() {

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
@@ -50,6 +50,14 @@ public class Orders {
     @OneToOne(mappedBy = "orders", fetch = FetchType.LAZY)
     private Delivery delivery;
 
+    public void confirm() {
+        this.ordersStatus = OrdersStatus.CONFIRMED;
+    }
+
+    public void cancel() {
+        this.ordersStatus = OrdersStatus.CANCELLED;
+    }
+
     public void approve() {
         this.ordersStatus = OrdersStatus.APPROVE;
     }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 발주 상태에 CONFIRMED, CANCELLED 추가 및 가맹점 발주 취소 API 구현                                                                                                                                                              
                                                                                                                                                                                                                                  
## 변경 파일                                              
- `backend/src/main/java/com/example/nexus/common/enums/OrdersStatus.java`
- `backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`

## 주요 변경 사항
- OrdersStatus에 CONFIRMED, CANCELLED 상태 추가
- Orders 엔티티에 confirm(), cancel() 메서드 추가
- 발주 취소 서비스 로직 추가 (CONFIRMED 상태만 취소 가능)
- `PUT /orders/{ordersIdx}/cancel` 엔드포인트 추가
- createStoreManualOrder 초기 상태를 WAITING → CONFIRMED로 변경

## Test Plan
- [ ] CONFIRMED 상태인 발주에 취소 API 호출 시 CANCELLED로 변경 확인
- [ ] CONFIRMED 외 상태(WAITING, APPROVE 등)에서 취소 호출 시 에러 응답 확인
- [ ] 가맹점 수동 발주 생성 시 초기 상태가 CONFIRMED인지 확인

## Issue
- Closes #443