### PR TITLE
[Feat] #444 - 확정 발주 목록 조회 API 구현 

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -28,6 +28,12 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
+    @GetMapping("/list/confirmed")
+    public ResponseEntity confirmedList() {
+        List<OrdersDto.OrderListRes> result = orderService.findAllConfirmed();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
     @GetMapping("/list")
     public ResponseEntity list() {
         List<OrdersDto.OrdersRes> result = orderService.findAll();

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -34,12 +34,6 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
-    @GetMapping("/list")
-    public ResponseEntity list() {
-        List<OrdersDto.OrdersRes> result = orderService.findAll();
-        return ResponseEntity.ok(BaseResponse.success(result));
-    }
-
     @GetMapping("/{ordersIdx}")
     public ResponseEntity ordersDetail(@PathVariable Long ordersIdx) {
         OrdersDto.OrdersRes result = orderService.findById(ordersIdx);

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -3,7 +3,6 @@ package com.example.nexus.domain.orders;
 import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.orders.model.Orders;
-import com.example.nexus.domain.store.model.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -100,12 +100,6 @@ public class OrdersService {
                 .toList();
     }
 
-    public List<OrdersDto.OrdersRes> findAll() {
-        return ordersRepository.findAllByOrdersStatus(OrdersStatus.APPROVE).stream()
-                .map(OrdersDto.OrdersRes::from)
-                .toList();
-    }
-
     public OrdersDto.OrdersRes findById(Long ordersIdx) {
         Orders orders = ordersRepository.findById(ordersIdx).orElseThrow(
                 () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -94,6 +94,12 @@ public class OrdersService {
         orders.cancel();
     }
 
+    public List<OrdersDto.OrderListRes> findAllConfirmed() {
+        return ordersRepository.findAllByOrdersStatus(OrdersStatus.CONFIRMED).stream()
+                .map(OrdersDto.OrderListRes::from)
+                .toList();
+    }
+
     public List<OrdersDto.OrdersRes> findAll() {
         return ordersRepository.findAllByOrdersStatus(OrdersStatus.APPROVE).stream()
                 .map(OrdersDto.OrdersRes::from)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사에서 점주가 확정한 발주 목록을 조회할 수 있는 API 구현                                                                                                                                                                      
                                                                                                                                                                                                                                
## 변경 파일                                                                                                                                                                                                                    
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java`

## 주요 변경 사항
- `GET /orders/list/confirmed` 엔드포인트 추가
- findAllConfirmed 서비스 메서드 추가 (CONFIRMED 상태 발주 조회)
- OrdersRepository 미사용 Store import 제거

## Test Plan
- [ ] `GET /orders/list/confirmed` 호출 시 CONFIRMED 상태 발주만 조회되는지 확인
- [ ] 확정 발주가 없을 때 빈 배열 반환 확인

## Issue
- Closes #444