### PR TITLE
[Feat] #445 - 확정 발주 전체 승인 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/NexusApplication.java
+++ b/backend/src/main/java/com/example/nexus/NexusApplication.java
@@ -2,7 +2,9 @@ package com.example.nexus;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class NexusApplication {
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -82,7 +82,7 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success("delete success"));
     }
 
-    @PutMapping("/comfirmed/approve")
+    @PutMapping("/confirmed/approve")
     public ResponseEntity approveAll() {
         orderService.approveAllConfirmed();
         return ResponseEntity.ok(BaseResponse.success("update success"));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -82,6 +82,12 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success("delete success"));
     }
 
+    @PutMapping("/comfirmed/approve")
+    public ResponseEntity approveAll() {
+        orderService.approveAllConfirmed();
+        return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
     @PutMapping("/{ordersIdx}/cancel")
     public ResponseEntity cancel(@PathVariable Long ordersIdx) {
         orderService.cancelOrder(ordersIdx);

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersScheduler.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersScheduler.java
@@ -1,0 +1,21 @@
+package com.example.nexus.domain.orders;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrdersScheduler {
+    private final OrdersService ordersService;
+
+    // 매일 자정에 확정 발주 전체 승인
+    @Scheduled(cron = "0 0 0 * * *")
+    public void autoApproveConfirmedOrders() {
+        log.info("확정 발주 자동 전체 승인 스케줄러 실행");
+        ordersService.approveAllConfirmed();
+        log.info("확정 발주 자동 전체 승인 완료");
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -94,6 +94,17 @@ public class OrdersService {
         orders.cancel();
     }
 
+    @Transactional
+    public void approveAllConfirmed() {
+        // 1. CONFIRMED 상태의 모든 발주 조회
+        List<Orders> confirmedOrders = ordersRepository.findAllByOrdersStatus(OrdersStatus.CONFIRMED);
+
+        // 2. 각 발주를 APPROVE 상태로 변경
+        for (Orders orders : confirmedOrders) {
+            orders.approve();
+        }
+    }
+
     public List<OrdersDto.OrderListRes> findAllConfirmed() {
         return ordersRepository.findAllByOrdersStatus(OrdersStatus.CONFIRMED).stream()
                 .map(OrdersDto.OrderListRes::from)

--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -29,7 +29,7 @@ const getConfirmedOrders = () => {
 }
 
 const approveAllConfirmed = () => {
-  return api.put('/orders/approve-all')
+  return api.put('/orders/confirmed/approve')
 }
 
 export default {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                      
- 확정 발주를 전체 승인하는 API와 매일 자정 자동 전체 승인 스케줄러 구현

## 변경 파일
- `OrdersService.java`
- `OrdersController.java`
- `OrdersScheduler.java` (신규)
- `NexusApplication.java`
- `orders/index.js` (프론트엔드 API 경로 수정)

## 주요 변경 사항
- CONFIRMED 상태의 발주를 일괄 APPROVE로 변경하는 서비스 메서드 추가
- 확정 발주 전체 승인 API 엔드포인트 추가 (`PUT /orders/confirmed/approve`)
- 매일 자정 자동 전체 승인 스케줄러 추가 (`OrdersScheduler`)
- `@EnableScheduling` 활성화
- 프론트엔드 API 호출 경로를 백엔드와 일치하도록 수정

## Test Plan
- [ ] `PUT /orders/confirmed/approve` 호출 시 CONFIRMED 상태 발주가 모두 APPROVE로 변경되는지 확인
- [ ] CONFIRMED 상태가 아닌 발주는 영향받지 않는지 확인
- [ ] 스케줄러가 자정에 정상 실행되는지 로그 확인

## Issue
- Closes #445