### PR TITLE
[Fix] - 발주 관리 탭 전환 시 목록 데이터 갱신 추가

### DIFF
--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -119,6 +119,8 @@ onMounted(() => {
 function setOrderViewTab(id) {
   activeTab.value = id
   router.replace({ path: '/order', query: { tab: id } })
+  if (id === 'confirmed') fetchConfirmedOrders()
+  if (id === 'auto') fetchAutoOrders()
 }
 
 // Detail modal


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                      
- 본사 발주 관리 페이지에서 탭 전환 시 최신 목록 데이터를 다시 조회하도록 수정

## 변경 파일
- `frontend/src/views/hq/HqOrderManageView.vue`

## 주요 변경 사항
- 자동 발주, 확정 발주 탭 클릭 시 각 목록 API를 재호출하여 최신 데이터 반영

## Test Plan
- [ ] 자동 발주 탭 클릭 시 목록이 최신 데이터로 갱신되는지 확인
- [ ] 확정 발주 탭 클릭 시 목록이 최신 데이터로 갱신되는지 확인
- [ ] 다른 탭(이력, 이상 발주) 전환 시 오류 없는지 확인

## Issue
- N/A
