### PR TITLE
[Fix] - 발주 상세 모달 상태 매핑 수정

### DIFF
--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -135,7 +135,7 @@ async function openDetail(ordersIdx) {
       type: o.ordersType === 'AUTO' ? '자동' : '수동',
       store: o.storeName,
       date: o.createdAt?.replace('T', ' ').slice(0, 16) ?? '-',
-      status: o.ordersStatus === 'WAITING' ? '제안중' : o.ordersStatus === 'APPROVE' ? '확정' : '거절',
+      status: o.ordersStatus === 'WAITING' ? '제안중' : o.ordersStatus === 'APPROVE' ? '승인' : o.ordersStatus === 'CONFIRMED' ? '확정' : o.ordersStatus === 'CANCELLED' ? '취소' : '거절',
       items: o.ordersItemList.map(i => ({
         product: i.productName,
         qty: i.count,


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 확정 발주 상세 조회 시 상태가 '거절'로 표시되던 문제 수정                                                                                                                                                                       
                                                                                                                                                                                                                                
## 변경 파일                                                                                                                                                                                                                      
- `frontend/src/views/hq/HqOrderManageView.vue`

## 주요 변경 사항
- 발주 상세 모달 상태 매핑에 CONFIRMED('확정'), CANCELLED('취소') 추가
- 기존에는 WAITING, APPROVE만 처리하고 나머지를 '거절'로 표시하던 문제 해결

## Test Plan
- [ ] 확정 발주 클릭 시 상세 모달에서 상태가 '확정'으로 표시되는지 확인
- [ ] 취소된 발주 상세 조회 시 '취소'로 표시되는지 확인
- [ ] 기존 상태(제안중, 승인, 거절)가 정상 표시되는지 확인

## Issue
- N/A