### PR TITLE
[Feat] #454 - 발주 이력 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -34,6 +34,12 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
+    @GetMapping("/list/history")
+    public ResponseEntity historyList() {
+        List<OrdersDto.OrderListRes> result = orderService.findOrderHistory();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
     @GetMapping("/{ordersIdx}")
     public ResponseEntity ordersDetail(@PathVariable Long ordersIdx) {
         OrdersDto.OrdersRes result = orderService.findById(ordersIdx);

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -11,4 +11,5 @@ public interface OrdersRepository extends JpaRepository<Orders, Long> {
     List<Orders> findAllByOrdersTypeAndOrdersStatus(OrdersType ordersType, OrdersStatus ordersStatus);
     List<Orders> findAllByStore_IdxAndOrdersStatus(Long storeIdx, OrdersStatus orderStatus);
     List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
+    List<Orders> findAllByOrdersStatusIn(List<OrdersStatus> ordersStatuses);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -105,6 +105,12 @@ public class OrdersService {
         }
     }
 
+    public List<OrdersDto.OrderListRes> findOrderHistory() {
+        return ordersRepository.findAllByOrdersStatusIn(List.of(OrdersStatus.APPROVE, OrdersStatus.REJECT, OrdersStatus.CANCELLED)).stream()
+                .map(OrdersDto.OrderListRes::from)
+                .toList();
+    }
+
     public List<OrdersDto.OrderListRes> findAllConfirmed() {
         return ordersRepository.findAllByOrdersStatus(OrdersStatus.CONFIRMED).stream()
                 .map(OrdersDto.OrderListRes::from)

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
@@ -52,6 +52,7 @@ public class OrdersDto {
     public static class OrderListRes {
         private Long idx;
         private Long price;
+        private OrdersType ordersType;
         private OrdersStatus ordersStatus;
         private LocalDateTime createdAt;
         private String storeName;
@@ -60,6 +61,7 @@ public class OrdersDto {
             return OrderListRes.builder()
                     .idx(entity.getIdx())
                     .price(entity.getPrice())
+                    .ordersType(entity.getOrdersType())
                     .ordersStatus(entity.getOrdersStatus())
                     .createdAt(entity.getCreatedAt())
                     .storeName(entity.getStore().getStoreName())


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 발주 이력(APPROVE, REJECT, CANCELLED) 목록 조회 API 구현

## 변경 파일
- `OrdersDto.java`
- `OrdersRepository.java`
- `OrdersService.java`
- `OrdersController.java`

## 주요 변경 사항
- OrderListRes에 ordersType 필드 추가
- OrdersRepository에 다중 상태 조회 메서드 추가 (findAllByOrdersStatusIn)
- OrdersService에 findOrderHistory() 메서드 추가
- OrdersController에 GET /orders/list/history 엔드포인트 추가

## Test Plan
- [ ] GET /orders/list/history 호출 시 APPROVE, REJECT, CANCELLED 상태의 발주 목록 반환 확인
- [ ] 응답에 ordersType(AUTO/MANUAL) 포함 확인

## Issue
- Closes #454