### PR TITLE
[Feat] #73 - 발주 이력 프론트엔드 API 연동

### DIFF
--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -24,6 +24,10 @@ const cancelOrder = (ordersIdx) => {
   return api.put(`/orders/${ordersIdx}/cancel`)
 }
 
+const getOrderHistory = () => {
+  return api.get('/orders/list/history')
+}
+
 const getConfirmedOrders = () => {
   return api.get('/orders/list/confirmed')
 }
@@ -35,6 +39,7 @@ const approveAllConfirmed = () => {
 export default {
   getAutoOrders,
   getOrderDetail,
+  getOrderHistory,
   getDangerSettings,
   updateDangerSettings,
   createStoreManualOrder,

--- a/frontend/src/components/orders/HqOrderHistoryTable.vue
+++ b/frontend/src/components/orders/HqOrderHistoryTable.vue
@@ -82,7 +82,7 @@ const filteredHistory = computed(() =>
             </td>
             <td class="px-5 py-3.5 font-semibold text-gray-900">{{ h.store }}</td>
             <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ h.date }}</td>
-            <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice((h.items ?? []).reduce((s, i) => s + i.unitPrice * i.qty, 0)) }}</td>
+            <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice(h.price) }}</td>
             <td class="px-5 py-3.5">
               <span class="text-xs font-bold px-2 py-0.5 rounded" :class="statusClass(h.status)">{{ h.status }}</span>
             </td>

--- a/frontend/src/components/orders/HqOrderHistoryTable.vue
+++ b/frontend/src/components/orders/HqOrderHistoryTable.vue
@@ -72,7 +72,7 @@ const filteredHistory = computed(() =>
         </thead>
         <tbody class="divide-y divide-gray-100">
           <tr v-for="h in filteredHistory" :key="h.id" class="hover:bg-gray-50/50 transition-colors cursor-pointer"
-            @click="$emit('open-detail', { id: h.id, type: h.type, store: h.store, status: h.status, date: h.date, items: h.items })">
+            @click="$emit('open-detail', h.id)">
             <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ h.id }}</td>
             <td class="px-5 py-3.5">
               <span class="text-xs font-bold px-2 py-0.5 rounded"

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -40,16 +40,23 @@ async function fetchAutoOrders() {
   }
 }
 
-const orderHistory = ref([
-  { id: 'ORD-20260413-001', type: '자동', store: '차이나 가든',    date: '2026-04-12 22:00', status: '배송중',
-    items: [{ product: '양파', qty: 20, unitPrice: 1500 }, { product: '생수', qty: 10, unitPrice: 8000 }] },
-  { id: 'ORD-20260413-002', type: '수동', store: '한우 오마카세',  date: '2026-04-11 10:30', status: '입고완료',
-    items: [{ product: '한우 등심', qty: 15, unitPrice: 85000 }, { product: '올리브오일', qty: 5, unitPrice: 12000 }] },
-  { id: 'ORD-20260412-003', type: '자동', store: '이탈리안 키친',  date: '2026-04-11 22:00', status: '입고완료',
-    items: [{ product: '버터', qty: 10, unitPrice: 9000 }, { product: '생크림', qty: 8, unitPrice: 7000 }, { product: '간장', qty: 5, unitPrice: 4000 }] },
-  { id: 'ORD-20260411-004', type: '수동', store: '일식 스시바',    date: '2026-04-10 14:15', status: '입고완료',
-    items: [{ product: '연어', qty: 10, unitPrice: 32000 }, { product: '마늘', qty: 5, unitPrice: 8000 }] },
-])
+const orderHistory = ref([])
+
+async function fetchOrderHistory() {
+  try {
+    const res = await ordersApi.getOrderHistory()
+    orderHistory.value = res.data.result.map(o => ({
+      id: o.idx,
+      type: o.ordersType === 'AUTO' ? '자동' : '수동',
+      store: o.storeName,
+      date: o.createdAt?.replace('T', ' ').slice(0, 16) ?? '-',
+      price: o.price,
+      status: o.ordersStatus === 'APPROVE' ? '승인' : o.ordersStatus === 'REJECT' ? '거절' : '취소',
+    }))
+  } catch (e) {
+    console.error('발주 이력 조회 실패', e)
+  }
+}
 
 const abnormalOrders = ref([
   { id: 'ORD-20260414-ABN1', store: '이탈리안 키친', qty: 85, avgQty: 15, ratio: 567, date: '2026-04-14 11:22', processed: false,
@@ -114,6 +121,7 @@ onMounted(() => {
   applyOrderRouteQuery()
   fetchAutoOrders()
   fetchConfirmedOrders()
+  fetchOrderHistory()
 })
 
 function setOrderViewTab(id) {
@@ -121,6 +129,7 @@ function setOrderViewTab(id) {
   router.replace({ path: '/order', query: { tab: id } })
   if (id === 'confirmed') fetchConfirmedOrders()
   if (id === 'auto') fetchAutoOrders()
+  if (id === 'history') fetchOrderHistory()
 }
 
 // Detail modal


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 발주 이력 탭의 하드코딩된 더미 데이터를 백엔드 API 연동으로 교체                                                                                                                                                                
                                                        
## 변경 파일
- `frontend/src/api/orders/index.js`
- `frontend/src/views/hq/HqOrderManageView.vue`

## 주요 변경 사항
- orders API에 getOrderHistory() 함수 추가 (GET /orders/list/history)
- HqOrderManageView에서 orderHistory 더미 데이터 제거 및 fetchOrderHistory() API 호출로 교체
- 페이지 진입 시(onMounted) 및 발주 이력 탭 전환 시 데이터 갱신

## Test Plan
- [ ] 발주 이력 탭 클릭 시 APPROVE, REJECT, CANCELLED 상태의 발주 목록 표시 확인
- [ ] 발주 유형(자동/수동) 정상 표시 확인
- [ ] 탭 전환 시 데이터 갱신 확인

## Issue
- Closes #73