### PR TITLE
[Feat] #462 - 자동 발주 제안 검색 및 페이징 API 구현 (BACKEND)

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -30,9 +30,13 @@ public class OrdersController {
     private final OrdersService orderService;
 
     @GetMapping("/list/auto")
-    public ResponseEntity autoList() {
-        List<OrdersDto.OrderListRes> result = orderService.findAllAuto();
-        return ResponseEntity.ok(BaseResponse.success(result));
+    public ResponseEntity autoList(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<OrdersDto.OrderListRes> result = orderService.findAllAuto(keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+        return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
 
     @GetMapping("/list/confirmed")

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -1,7 +1,6 @@
 package com.example.nexus.domain.orders;
 
 import com.example.nexus.common.enums.OrdersStatus;
-import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.orders.model.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -9,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import java.util.List;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecificationExecutor<Orders> {
-    List<Orders> findAllByOrdersTypeAndOrdersStatus(OrdersType ordersType, OrdersStatus ordersStatus);
     List<Orders> findAllByStore_IdxAndOrdersStatus(Long storeIdx, OrdersStatus orderStatus);
     List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -30,10 +30,17 @@ public class OrdersService {
     private final StoreRepository storeRepository;
     private final ProductRepository productRepository;
 
-    public List<OrdersDto.OrderListRes> findAllAuto() {
-        return ordersRepository.findAllByOrdersTypeAndOrdersStatus(OrdersType.AUTO, OrdersStatus.WAITING).stream()
-                .map(OrdersDto.OrderListRes::from)
-                .toList();
+    // 자동 발주 제안 검색 조회 (AUTO + WAITING 상태 대상)
+    // 매장명 키워드 검색 + 페이징 처리
+    public Page<OrdersDto.OrderListRes> findAllAuto(String keyword, Pageable pageable) {
+        Specification<Orders> spec = OrdersSpecification.ordersTypeEquals(OrdersType.AUTO)
+                .and(OrdersSpecification.statusIn(List.of(OrdersStatus.WAITING)));
+
+        if (keyword != null && !keyword.isBlank()) {
+            spec = spec.and(OrdersSpecification.keywordLike(keyword));
+        }
+
+        return ordersRepository.findAll(spec, pageable).map(OrdersDto.OrderListRes::from);
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- 자동 발주 제안 목록의 매장명 검색 및 페이징 API 구현                                                                                                                                                                            
                                                        
## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java`

## 주요 변경 사항
- findAllAuto에 keyword, Pageable 파라미터 추가 및 Specification 적용
- GET /orders/list/auto에 keyword, page, size 쿼리 파라미터 지원
- 최신순 정렬, PageResponse로 안정적인 JSON 반환
- 미사용 findAllByOrdersTypeAndOrdersStatus 메서드 및 OrdersType import 제거

## Test Plan
- [ ] GET /orders/list/auto 파라미터 없이 호출 시 전체 목록 페이징 반환 확인
- [ ] keyword로 매장명 검색 확인
- [ ] page, size 파라미터로 페이징 동작 확인

## Issue
- Closes #462