### PR TITLE
[Feat] #463 - 자동 발주 제안 검색 및 페이징 프론트엔드 연동

### DIFF
--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -1,7 +1,7 @@
 import api from '@/plugins/axiosinterceptor'
 
-const getAutoOrders = () => {
-  return api.get('/orders/list/auto')
+const getAutoOrders = (params = {}) => {
+  return api.get('/orders/list/auto', { params })
 }
 
 const getOrderDetail = (ordersIdx) => {

--- a/frontend/src/components/orders/HqAutoOrderTable.vue
+++ b/frontend/src/components/orders/HqAutoOrderTable.vue
@@ -1,15 +1,52 @@
 <script setup>
+import { ref } from 'vue'
+import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { statusClass, formatPrice } from './orderUtils'
 
-defineProps({
+const props = defineProps({
   orders: { type: Array, required: true },
+  currentPage: { type: Number, default: 0 },
+  totalPages: { type: Number, default: 1 },
 })
 
-defineEmits(['open-detail'])
+const emit = defineEmits(['open-detail', 'search', 'page-change'])
+
+const search = ref('')
+
+function emitSearch() {
+  emit('search', {
+    keyword: search.value.trim() || null,
+  })
+}
+
+function resetSearch() {
+  search.value = ''
+  emitSearch()
+}
 </script>
 
 <template>
-  <div class="space-y-4">
+  <div class="space-y-3">
+    <div class="bg-white border border-gray-200 rounded-lg px-5 py-4 flex flex-wrap gap-5 items-end">
+      <div class="flex flex-col gap-2 flex-1 min-w-40">
+        <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">매장명 검색</span>
+        <div class="flex gap-2 items-center">
+          <input v-model="search" type="search" placeholder="매장명을 입력하세요"
+            class="flex-1 px-3 py-2 rounded border border-gray-200 text-sm outline-none focus:border-[#F37321]"
+            @keyup.enter="emitSearch" />
+          <button type="button"
+            class="text-xs font-semibold text-white bg-[#F37321] px-4 py-2 rounded hover:bg-[#e0661d] shrink-0 cursor-pointer"
+            @click="emitSearch">
+            검색
+          </button>
+          <button type="button"
+            class="text-xs font-semibold text-gray-500 border border-gray-200 px-4 py-2 rounded hover:bg-gray-50 shrink-0 cursor-pointer"
+            @click="resetSearch">
+            초기화
+          </button>
+        </div>
+      </div>
+    </div>
     <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
       <table class="w-full text-sm text-left">
         <thead>
@@ -22,12 +59,9 @@ defineEmits(['open-detail'])
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
-          <tr
-            v-for="o in orders"
-            :key="o.id"
+          <tr v-for="o in orders" :key="o.id"
             class="hover:bg-gray-50/50 transition-colors cursor-pointer"
-            @click="$emit('open-detail', o.id)"
-          >
+            @click="$emit('open-detail', o.id)">
             <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ o.id }}</td>
             <td class="px-5 py-3.5 font-semibold text-gray-900">{{ o.store }}</td>
             <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ o.date ?? '-' }}</td>
@@ -41,6 +75,30 @@ defineEmits(['open-detail'])
           </tr>
         </tbody>
       </table>
+    </div>
+
+    <!-- Pagination -->
+    <div v-if="totalPages > 1" class="flex justify-center items-center gap-2 pt-2">
+      <button
+        class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+        :disabled="currentPage === 0"
+        @click="$emit('page-change', currentPage - 1)">
+        <ChevronLeft class="w-4 h-4" />
+      </button>
+      <button v-for="page in totalPages" :key="page"
+        class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
+        :class="currentPage === page - 1
+          ? 'bg-[#F37321] text-white'
+          : 'text-gray-500 hover:bg-gray-50'"
+        @click="$emit('page-change', page - 1)">
+        {{ page }}
+      </button>
+      <button
+        class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+        :disabled="currentPage === totalPages - 1"
+        @click="$emit('page-change', currentPage + 1)">
+        <ChevronRight class="w-4 h-4" />
+      </button>
     </div>
   </div>
 </template>

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -16,28 +16,43 @@ const router = useRouter()
 const abnormalCount = computed(() => abnormalOrders.value.filter(o => !o.processed).length)
 
 const tabs = computed(() => [
-  { id: 'auto',      label: '자동 발주 제안', badge: autoOrders.value.length || null },
-  { id: 'confirmed', label: '확정 발주',      badge: confirmedOrders.value.length || null },
+  { id: 'auto',      label: '자동 발주 제안' },
+  { id: 'confirmed', label: '확정 발주' },
   { id: 'history',   label: '발주 이력' },
-  { id: 'abnormal',  label: '이상 발주',      badge: abnormalCount.value || null },
+  { id: 'abnormal',  label: '이상 발주', badge: abnormalCount.value || null },
 ])
 const activeTab = ref('auto')
 
 const autoOrders = ref([])
+const autoPage = ref(0)
+const autoTotalPages = ref(1)
+const autoSearchParams = ref({})
 
-async function fetchAutoOrders() {
+async function fetchAutoOrders(params = autoSearchParams.value, page = autoPage.value) {
   try {
-    const res = await ordersApi.getAutoOrders()
-    autoOrders.value = res.data.result.map(o => ({
+    const res = await ordersApi.getAutoOrders({ ...params, page, size: 10 })
+    const data = res.data.result
+    autoOrders.value = data.content.map(o => ({
       id: o.idx,
       store: o.storeName,
       date: o.createdAt?.replace('T', ' ').slice(0, 16) ?? '-',
       price: o.price,
       status: '제안중',
     }))
+    autoPage.value = data.number
+    autoTotalPages.value = data.totalPages
   } catch (e) {
     console.error('자동 발주 목록 조회 실패', e)
   }
+}
+
+function onAutoSearch(params) {
+  autoSearchParams.value = params
+  fetchAutoOrders(params, 0)
+}
+
+function onAutoPageChange(page) {
+  fetchAutoOrders(autoSearchParams.value, page)
 }
 
 const orderHistory = ref([])
@@ -233,7 +248,9 @@ function rejectAbnormal(o)  { o.processed = true; alert(`${o.store} 발주 반�
     </div>
 
     <!-- Tab Contents -->
-    <HqAutoOrderTable v-if="activeTab === 'auto'" :orders="autoOrders" @open-detail="openDetail" />
+    <HqAutoOrderTable v-if="activeTab === 'auto'" :orders="autoOrders"
+      :current-page="autoPage" :total-pages="autoTotalPages"
+      @open-detail="openDetail" @search="onAutoSearch" @page-change="onAutoPageChange" />
     <div v-if="activeTab === 'confirmed'" class="space-y-4">
       <div class="flex justify-end">
         <button @click="approveAllConfirmed"


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 자동 발주 제안 탭에 매장명 검색 및 페이지네이션 UI 추가                                                                                                                                                                         
                                                        
## 변경 파일
- `frontend/src/api/orders/index.js`
- `frontend/src/components/orders/HqAutoOrderTable.vue`
- `frontend/src/views/hq/HqOrderManageView.vue`

## 주요 변경 사항
- getAutoOrders API 함수에 검색/페이징 파라미터 지원 추가
- HqAutoOrderTable에 매장명 검색 UI 및 페이지네이션 추가
- HqOrderManageView에서 검색/페이지 파라미터 관리 및 API 전달
- Spring Page 응답 구조(content, number, totalPages) 처리
- 자동 발주/확정 발주 탭 badge 제거 (페이징 도입으로 무의미)

## Test Plan
- [ ] 매장명 검색 시 해당 매장 자동 발주만 표시 확인
- [ ] Enter 키 및 검색 버튼 동작 확인
- [ ] 초기화 버튼 클릭 시 전체 목록 표시 확인
- [ ] 페이지네이션 동작 확인 (10건 단위)
- [ ] 검색 후 페이지 이동 시 검색 조건 유지 확인

## Issue
- Closes #463