### PR TITLE
[Feat] #464 - 확정 발주 검색 및 페이징 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -40,9 +40,13 @@ public class OrdersController {
     }
 
     @GetMapping("/list/confirmed")
-    public ResponseEntity confirmedList() {
-        List<OrdersDto.OrderListRes> result = orderService.findAllConfirmed();
-        return ResponseEntity.ok(BaseResponse.success(result));
+    public ResponseEntity confirmedList(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<OrdersDto.OrderListRes> result = orderService.findAllConfirmed(
+                keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+        return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
 
     @GetMapping("/list/history")

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -138,10 +138,16 @@ public class OrdersService {
         return ordersRepository.findAll(spec, pageable).map(OrdersDto.OrderListRes::from);
     }
 
-    public List<OrdersDto.OrderListRes> findAllConfirmed() {
-        return ordersRepository.findAllByOrdersStatus(OrdersStatus.CONFIRMED).stream()
-                .map(OrdersDto.OrderListRes::from)
-                .toList();
+    // 확정 발주 검색 조회 (CONFIRMED 상태 대상)
+    // 매장명 키워드 검색 + 페이징 처리
+    public Page<OrdersDto.OrderListRes> findAllConfirmed(String keyword, Pageable pageable) {
+        Specification<Orders> spec = OrdersSpecification.statusIn(List.of(OrdersStatus.CONFIRMED));
+
+        if (keyword != null && !keyword.isBlank()) {
+            spec = spec.and(OrdersSpecification.keywordLike(keyword));
+        }
+
+        return ordersRepository.findAll(spec, pageable).map(OrdersDto.OrderListRes::from);
     }
 
     public OrdersDto.OrdersRes findById(Long ordersIdx) {


### PR DESCRIPTION
## Summary
- 확정 발주 목록의 매장명 검색 및 페이징 API 구현                                                                                                                                                                                 
                                                        
## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`

## 주요 변경 사항
- findAllConfirmed에 keyword, Pageable 파라미터 추가 및 Specification 적용
- GET /orders/list/confirmed에 keyword, page, size 쿼리 파라미터 지원
- 최신순 정렬, PageResponse로 안정적인 JSON 반환

## Test Plan
- [ ] GET /orders/list/confirmed 파라미터 없이 호출 시 전체 목록 페이징 반환 확인
- [ ] keyword로 매장명 검색 확인
- [ ] page, size 파라미터로 페이징 동작 확인

## Issue
- Closes #464