### PR TITLE
[Feat] #465 - 확정 발주 검색 및 페이징 프론트엔드 연동

### DIFF
--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -28,8 +28,8 @@ const getOrderHistory = (params = {}) => {
   return api.get('/orders/list/history', { params })
 }
 
-const getConfirmedOrders = () => {
-  return api.get('/orders/list/confirmed')
+const getConfirmedOrders = (params = {}) => {
+  return api.get('/orders/list/confirmed', { params })
 }
 
 const approveAllConfirmed = () => {

--- a/frontend/src/components/orders/HqConfirmedOrderTable.vue
+++ b/frontend/src/components/orders/HqConfirmedOrderTable.vue
@@ -1,42 +1,104 @@
 <script setup>
+import { ref } from 'vue'
+import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { statusClass, formatPrice } from './orderUtils'
 
-defineProps({
+const props = defineProps({
   orders: { type: Array, required: true },
+  currentPage: { type: Number, default: 0 },
+  totalPages: { type: Number, default: 1 },
 })
 
-defineEmits(['open-detail'])
+const emit = defineEmits(['open-detail', 'search', 'page-change'])
+
+const search = ref('')
+
+function emitSearch() {
+  emit('search', {
+    keyword: search.value.trim() || null,
+  })
+}
+
+function resetSearch() {
+  search.value = ''
+  emitSearch()
+}
 </script>
 
 <template>
-  <div class="space-y-4">
+  <div class="space-y-3">
+    <div class="bg-white border border-gray-200 rounded-lg px-5 py-4 flex flex-wrap gap-5 items-end">
+      <div class="flex flex-col gap-2 flex-1 min-w-40">
+        <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">매장명 검색</span>
+        <div class="flex gap-2 items-center">
+          <input v-model="search" type="search" placeholder="매장명을 입력하세요"
+            class="flex-1 px-3 py-2 rounded border border-gray-200 text-sm outline-none focus:border-[#F37321]"
+            @keyup.enter="emitSearch" />
+          <button type="button"
+            class="text-xs font-semibold text-white bg-[#F37321] px-4 py-2 rounded hover:bg-[#e0661d] shrink-0 cursor-pointer"
+            @click="emitSearch">
+            검색
+          </button>
+          <button type="button"
+            class="text-xs font-semibold text-gray-500 border border-gray-200 px-4 py-2 rounded hover:bg-gray-50 shrink-0 cursor-pointer"
+            @click="resetSearch">
+            초기화
+          </button>
+        </div>
+      </div>
+    </div>
     <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
-        <table class="w-full text-sm text-left">
-          <thead>
-            <tr class="border-b border-gray-200 bg-gray-50">
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주번호</th>
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">가맹점</th>
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주일시</th>
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">총 금액</th>
-              <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-100">
-            <tr v-for="o in orders" :key="o.id" class="hover:bg-gray-50/50 transition-colors cursor-pointer"
-              @click="$emit('open-detail', o.id)">
-              <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ o.id }}</td>
-              <td class="px-5 py-3.5 font-semibold text-gray-900">{{ o.store }}</td>
-              <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ o.date }}</td>
-              <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice(o.price) }}</td>
-              <td class="px-5 py-3.5">
-                <span class="text-xs font-bold px-2 py-0.5 rounded" :class="statusClass(o.status)">{{ o.status }}</span>
-              </td>
-            </tr>
-            <tr v-if="orders.length === 0">
-              <td colspan="5" class="px-5 py-10 text-center text-sm text-gray-400">확정된 발주가 없습니다.</td>
-            </tr>
-          </tbody>
-        </table>
+      <table class="w-full text-sm text-left">
+        <thead>
+          <tr class="border-b border-gray-200 bg-gray-50">
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주번호</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">가맹점</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주일시</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">총 금액</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100">
+          <tr v-for="o in orders" :key="o.id"
+            class="hover:bg-gray-50/50 transition-colors cursor-pointer"
+            @click="$emit('open-detail', o.id)">
+            <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ o.id }}</td>
+            <td class="px-5 py-3.5 font-semibold text-gray-900">{{ o.store }}</td>
+            <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ o.date }}</td>
+            <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice(o.price) }}</td>
+            <td class="px-5 py-3.5">
+              <span class="text-xs font-bold px-2 py-0.5 rounded" :class="statusClass(o.status)">{{ o.status }}</span>
+            </td>
+          </tr>
+          <tr v-if="orders.length === 0">
+            <td colspan="5" class="px-5 py-10 text-center text-sm text-gray-400">확정된 발주가 없습니다.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div v-if="totalPages > 1" class="flex justify-center items-center gap-2 pt-2">
+      <button
+        class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+        :disabled="currentPage === 0"
+        @click="$emit('page-change', currentPage - 1)">
+        <ChevronLeft class="w-4 h-4" />
+      </button>
+      <button v-for="page in totalPages" :key="page"
+        class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
+        :class="currentPage === page - 1
+          ? 'bg-[#F37321] text-white'
+          : 'text-gray-500 hover:bg-gray-50'"
+        @click="$emit('page-change', page - 1)">
+        {{ page }}
+      </button>
+      <button
+        class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+        :disabled="currentPage === totalPages - 1"
+        @click="$emit('page-change', currentPage + 1)">
+        <ChevronRight class="w-4 h-4" />
+      </button>
     </div>
   </div>
 </template>

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -107,20 +107,35 @@ const abnormalOrders = ref([
 ])
 
 const confirmedOrders = ref([])
+const confirmedPage = ref(0)
+const confirmedTotalPages = ref(1)
+const confirmedSearchParams = ref({})
 
-async function fetchConfirmedOrders() {
+async function fetchConfirmedOrders(params = confirmedSearchParams.value, page = confirmedPage.value) {
   try {
-    const res = await ordersApi.getConfirmedOrders()
-    confirmedOrders.value = res.data.result.map(o => ({
+    const res = await ordersApi.getConfirmedOrders({ ...params, page, size: 10 })
+    const data = res.data.result
+    confirmedOrders.value = data.content.map(o => ({
       id: o.idx,
       store: o.storeName,
       date: o.createdAt?.replace('T', ' ').slice(0, 16) ?? '-',
       price: o.price,
       status: '확정',
     }))
+    confirmedPage.value = data.number
+    confirmedTotalPages.value = data.totalPages
   } catch (e) {
     console.error('확정 발주 목록 조회 실패', e)
   }
+}
+
+function onConfirmedSearch(params) {
+  confirmedSearchParams.value = params
+  fetchConfirmedOrders(params, 0)
+}
+
+function onConfirmedPageChange(page) {
+  fetchConfirmedOrders(confirmedSearchParams.value, page)
 }
 
 async function approveAllConfirmed() {
@@ -258,7 +273,9 @@ function rejectAbnormal(o)  { o.processed = true; alert(`${o.store} 발주 반�
           <CheckCheck class="w-4 h-4" /> 전체 승인
         </button>
       </div>
-      <HqConfirmedOrderTable :orders="confirmedOrders" @open-detail="openDetail" />
+      <HqConfirmedOrderTable :orders="confirmedOrders"
+        :current-page="confirmedPage" :total-pages="confirmedTotalPages"
+        @open-detail="openDetail" @search="onConfirmedSearch" @page-change="onConfirmedPageChange" />
     </div>
     <HqOrderHistoryTable v-if="activeTab === 'history'" :orders="orderHistory"
       :current-page="historyPage" :total-pages="historyTotalPages"


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 확정 발주 탭에 매장명 검색 및 페이지네이션 UI 추가                                                                                                                                                                              
                                                                                                                                                                                                                              
## 변경 파일
- `frontend/src/api/orders/index.js`
- `frontend/src/components/orders/HqConfirmedOrderTable.vue`
- `frontend/src/views/hq/HqOrderManageView.vue`

## 주요 변경 사항
- getConfirmedOrders API 함수에 검색/페이징 파라미터 지원 추가
- HqConfirmedOrderTable에 매장명 검색 UI 및 페이지네이션 추가
- HqOrderManageView에서 검색/페이지 파라미터 관리 및 API 전달
- Spring Page 응답 구조(content, number, totalPages) 처리

## Test Plan
- [ ] 매장명 검색 시 해당 매장 확정 발주만 표시 확인
- [ ] Enter 키 및 검색 버튼 동작 확인
- [ ] 초기화 버튼 클릭 시 전체 목록 표시 확인
- [ ] 페이지네이션 동작 확인 (10건 단위)
- [ ] 전체 승인 버튼 정상 동작 확인

## Issue
- Closes #465