### PR TITLE
[Feat] #466 - 이상 발주 검색 및 페이징 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -43,7 +43,8 @@ public class OrdersController {
     public ResponseEntity confirmedList(
             @RequestParam(required = false) String keyword,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(defaultValue = "10") int size
+    ) {
         Page<OrdersDto.OrderListRes> result = orderService.findAllConfirmed(
                 keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
@@ -56,9 +57,24 @@ public class OrdersController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @RequestParam(required = false) String keyword,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(defaultValue = "10") int size
+    ) {
         Page<OrdersDto.OrderListRes> result = orderService.findOrderHistory(
                 ordersType, startDate, endDate, keyword,
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+        return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
+    }
+
+    @GetMapping("/list/danger")
+    public ResponseEntity dangerList(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<OrdersDto.OrderListRes> result = orderService.findDangerOrders(
+                startDate, endDate, keyword,
                 PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -150,6 +150,24 @@ public class OrdersService {
         return ordersRepository.findAll(spec, pageable).map(OrdersDto.OrderListRes::from);
     }
 
+    // 이상 발주 검색 조회 (isDanger=true 대상)
+    // 기간, 키워드 조건으로 필터링 + 페이징 처리
+    public Page<OrdersDto.OrderListRes> findAbnormalOrders(LocalDate startDate, LocalDate endDate, String keyword, Pageable pageable) {
+        Specification<Orders> spec = OrdersSpecification.isDangerTrue();
+
+        if (startDate != null) {
+            spec = spec.and(OrdersSpecification.createdAfter(startDate));
+        }
+        if (endDate != null) {
+            spec = spec.and(OrdersSpecification.createdBefore(endDate));
+        }
+        if (keyword != null && !keyword.isBlank()) {
+            spec = spec.and(OrdersSpecification.keywordLike(keyword));
+        }
+
+        return ordersRepository.findAll(spec, pageable).map(OrdersDto.OrderListRes::from);
+    }
+
     public OrdersDto.OrdersRes findById(Long ordersIdx) {
         Orders orders = ordersRepository.findById(ordersIdx).orElseThrow(
                 () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -152,7 +152,7 @@ public class OrdersService {
 
     // 이상 발주 검색 조회 (isDanger=true 대상)
     // 기간, 키워드 조건으로 필터링 + 페이징 처리
-    public Page<OrdersDto.OrderListRes> findAbnormalOrders(LocalDate startDate, LocalDate endDate, String keyword, Pageable pageable) {
+    public Page<OrdersDto.OrderListRes> findDangerOrders(LocalDate startDate, LocalDate endDate, String keyword, Pageable pageable) {
         Specification<Orders> spec = OrdersSpecification.isDangerTrue();
 
         if (startDate != null) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersSpecification.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersSpecification.java
@@ -26,6 +26,10 @@ public class OrdersSpecification {
         return (root, query, cb) -> cb.lessThan(root.get("createdAt"), endDate.plusDays(1).atStartOfDay());
     }
 
+    public static Specification<Orders> isDangerTrue() {
+        return (root, query, cb) -> cb.isTrue(root.get("isDanger"));
+    }
+
     public static Specification<Orders> keywordLike(String keyword) {
         return (root, query, cb) -> {
             String pattern = "%" + keyword + "%";


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 이상 발주(isDanger=true) 목록의 검색 및 페이징 API 구현                                                                                                                                                                         
                                                                                                                                                                                                                              
## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersSpecification.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`

## 주요 변경 사항
- OrdersSpecification에 isDangerTrue 조건 추가
- findDangerOrders 메서드 추가 (기간, 키워드 검색 + 페이징)
- GET /orders/list/danger 엔드포인트 추가
- startDate, endDate, keyword, page, size 파라미터 지원

## Test Plan
- [ ] GET /orders/list/danger 파라미터 없이 호출 시 이상 발주 목록 페이징 반환 확인
- [ ] startDate, endDate 기간 검색 확인
- [ ] keyword로 발주번호/가맹점명 검색 확인
- [ ] page, size 파라미터로 페이징 동작 확인

## Issue
- Closes #466