### PR TITLE
[Feat] #467, #75 - 이상 발주 검색/페이징 및 평균수량·초과율 계산 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -73,7 +73,7 @@ public class OrdersController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        Page<OrdersDto.OrderListRes> result = orderService.findDangerOrders(
+        Page<DangerDto.DangerListRes> result = orderService.findDangerOrders(
                 startDate, endDate, keyword,
                 PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -4,10 +4,18 @@ import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.domain.orders.model.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecificationExecutor<Orders> {
     List<Orders> findAllByStore_IdxAndOrdersStatus(Long storeIdx, OrdersStatus orderStatus);
     List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
+
+    @Query("SELECT COALESCE(SUM(i.count), 0) / GREATEST(COUNT(DISTINCT o.idx), 1) " +
+            "FROM Orders o JOIN o.ordersItemList i " +
+            "WHERE o.store.idx = :storeIdx AND o.createdAt >= :since")
+    Integer findAvgQtyByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("since") LocalDateTime since);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -152,7 +152,8 @@ public class OrdersService {
 
     // 이상 발주 검색 조회 (isDanger=true 대상)
     // 기간, 키워드 조건으로 필터링 + 페이징 처리
-    public Page<OrdersDto.OrderListRes> findDangerOrders(LocalDate startDate, LocalDate endDate, String keyword, Pageable pageable) {
+    // 각 발주에 대해 같은 매장의 최근 N개월 평균 수량 계산
+    public Page<DangerDto.DangerListRes> findDangerOrders(LocalDate startDate, LocalDate endDate, String keyword, Pageable pageable) {
         Specification<Orders> spec = OrdersSpecification.isDangerTrue();
 
         if (startDate != null) {
@@ -165,7 +166,15 @@ public class OrdersService {
             spec = spec.and(OrdersSpecification.keywordLike(keyword));
         }
 
-        return ordersRepository.findAll(spec, pageable).map(OrdersDto.OrderListRes::from);
+        Danger danger = dangerRepository.findById(1L).orElse(null);
+        int period = danger != null ? danger.getPeriod() : 3;
+
+        return ordersRepository.findAll(spec, pageable).map(orders -> {
+            LocalDateTime since = orders.getCreatedAt().minusMonths(period);
+            Integer avgQty = ordersRepository.findAvgQtyByStoreAndPeriod(
+                    orders.getStore().getIdx(), since);
+            return DangerDto.DangerListRes.from(orders, avgQty);
+        });
     }
 
     public OrdersDto.OrdersRes findById(Long ordersIdx) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
@@ -1,7 +1,10 @@
 package com.example.nexus.domain.orders.model;
 
+import com.example.nexus.common.enums.OrdersStatus;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 public class DangerDto {
 
@@ -22,6 +25,37 @@ public class DangerDto {
             return DangerRes.builder()
                     .ratio(entity.getRatio())
                     .period(entity.getPeriod())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class DangerListRes {
+        private Long idx;
+        private String storeName;
+        private LocalDateTime createdAt;
+        private Long price;
+        private OrdersStatus ordersStatus;
+        private Integer totalQty;
+        private Integer avgQty;
+        private Integer ratio;
+
+        public static DangerListRes from(Orders entity, Integer avgQty) {
+            int totalQty = entity.getOrdersItemList().stream()
+                    .mapToInt(OrdersItem::getCount)
+                    .sum();
+            int ratioValue = avgQty > 0 ? (totalQty - avgQty) * 100 / avgQty : 0;
+
+            return DangerListRes.builder()
+                    .idx(entity.getIdx())
+                    .storeName(entity.getStore().getStoreName())
+                    .createdAt(entity.getCreatedAt())
+                    .price(entity.getPrice())
+                    .ordersStatus(entity.getOrdersStatus())
+                    .totalQty(totalQty)
+                    .avgQty(avgQty)
+                    .ratio(ratioValue)
                     .build();
         }
     }

--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -32,6 +32,10 @@ const getConfirmedOrders = (params = {}) => {
   return api.get('/orders/list/confirmed', { params })
 }
 
+const getDangerOrders = (params = {}) => {
+  return api.get('/orders/list/danger', { params })
+}
+
 const approveAllConfirmed = () => {
   return api.put('/orders/confirmed/approve')
 }
@@ -45,5 +49,6 @@ export default {
   createStoreManualOrder,
   cancelOrder,
   getConfirmedOrders,
+  getDangerOrders,
   approveAllConfirmed,
 }

--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -40,6 +40,14 @@ const approveAllConfirmed = () => {
   return api.put('/orders/confirmed/approve')
 }
 
+const approveDangerOrder = (ordersIdx) => {
+  return api.put(`/orders/${ordersIdx}/approve`)
+}
+
+const rejectDangerOrder = (ordersIdx) => {
+  return api.put(`/orders/${ordersIdx}/reject`)
+}
+
 export default {
   getAutoOrders,
   getOrderDetail,
@@ -51,4 +59,6 @@ export default {
   getConfirmedOrders,
   getDangerOrders,
   approveAllConfirmed,
+  approveDangerOrder,
+  rejectDangerOrder,
 }

--- a/frontend/src/components/orders/HqAbnormalOrderTable.vue
+++ b/frontend/src/components/orders/HqAbnormalOrderTable.vue
@@ -79,30 +79,29 @@ function resetFilters() {
         <tbody class="divide-y divide-gray-100">
           <tr v-for="o in orders" :key="o.id"
             class="hover:bg-gray-50/50 transition-colors cursor-pointer"
-            :class="o.processed ? 'opacity-50' : ''"
-            @click="$emit('open-detail', { id: o.id, type: '이상', store: o.store, status: o.processed ? '처리완료' : 'DANGER', date: o.date, items: o.items, avgQty: o.avgQty, ratio: o.ratio })"
+            @click="$emit('open-detail', o.id)"
           >
             <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ o.id }}</td>
             <td class="px-5 py-3.5 font-semibold text-gray-900">{{ o.store }}</td>
-            <td class="px-5 py-3.5 font-bold text-red-600">{{ o.qty.toLocaleString() }}</td>
-            <td class="px-5 py-3.5 text-gray-500">{{ o.avgQty.toLocaleString() }}</td>
+            <td class="px-5 py-3.5 font-bold text-red-600">{{ (o.qty ?? 0).toLocaleString() }}</td>
+            <td class="px-5 py-3.5 text-gray-500">{{ (o.avgQty ?? 0).toLocaleString() }}</td>
             <td class="px-5 py-3.5">
               <span class="text-xs font-black px-2 py-0.5 rounded bg-red-50 text-red-600 border border-red-200">
                 +{{ o.ratio }}%
               </span>
             </td>
-            <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice((o.items ?? []).reduce((s, i) => s + i.unitPrice * i.qty, 0)) }}</td>
+            <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice(o.price) }}</td>
             <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ o.date }}</td>
             <td class="px-5 py-3.5">
               <span class="text-xs font-bold px-2 py-0.5 rounded"
-                :class="o.processed
+                :class="o.status === 'APPROVE' || o.status === 'REJECT'
                   ? 'bg-gray-100 text-gray-400 border border-gray-200'
                   : 'bg-red-50 text-red-600 border border-red-200'">
-                {{ o.processed ? '처리완료' : 'DANGER' }}
+                {{ o.status === 'APPROVE' || o.status === 'REJECT' ? '처리완료' : 'DANGER' }}
               </span>
             </td>
             <td class="px-5 py-3.5">
-              <div v-if="!o.processed" class="flex justify-center gap-1.5">
+              <div v-if="o.status !== 'APPROVE' && o.status !== 'REJECT'" class="flex justify-center gap-1.5">
                 <button @click.stop="$emit('approve', o)"
                   class="px-2.5 py-1 bg-[#F37321] text-white text-xs font-semibold hover:bg-[#e0661d] rounded cursor-pointer">승인</button>
                 <button @click.stop="$emit('reject', o)"

--- a/frontend/src/components/orders/HqAbnormalOrderTable.vue
+++ b/frontend/src/components/orders/HqAbnormalOrderTable.vue
@@ -1,15 +1,66 @@
 <script setup>
+import { ref } from 'vue'
+import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { formatPrice } from './orderUtils'
 
-defineProps({
+const props = defineProps({
   orders: { type: Array, required: true },
+  currentPage: { type: Number, default: 0 },
+  totalPages: { type: Number, default: 1 },
 })
 
-defineEmits(['open-detail', 'approve', 'reject'])
+const emit = defineEmits(['open-detail', 'approve', 'reject', 'search', 'page-change'])
+
+const dateFrom = ref('')
+const dateTo = ref('')
+const search = ref('')
+
+function emitSearch() {
+  emit('search', {
+    startDate: dateFrom.value || null,
+    endDate: dateTo.value || null,
+    keyword: search.value.trim() || null,
+  })
+}
+
+function resetFilters() {
+  dateFrom.value = ''
+  dateTo.value = ''
+  search.value = ''
+  emitSearch()
+}
 </script>
 
 <template>
-  <div class="space-y-4">
+  <div class="space-y-3">
+    <div class="bg-white border border-gray-200 rounded-lg px-5 py-4 flex flex-wrap gap-5 items-end">
+      <label class="flex flex-col gap-2">
+        <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">기간 시작</span>
+        <input v-model="dateFrom" type="date" class="px-3 py-2 rounded border border-gray-200 text-sm outline-none focus:border-[#F37321]" />
+      </label>
+      <label class="flex flex-col gap-2">
+        <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">기간 종료</span>
+        <input v-model="dateTo" type="date" class="px-3 py-2 rounded border border-gray-200 text-sm outline-none focus:border-[#F37321]" />
+      </label>
+      <div class="flex flex-col gap-2 flex-1 min-w-40">
+        <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">검색</span>
+        <div class="flex gap-2 items-center">
+          <input v-model="search" type="search" placeholder="발주번호·가맹점"
+            class="flex-1 px-3 py-2 rounded border border-gray-200 text-sm outline-none focus:border-[#F37321]"
+            @keyup.enter="emitSearch" />
+          <button type="button"
+            class="text-xs font-semibold text-white bg-[#F37321] px-4 py-2 rounded hover:bg-[#e0661d] shrink-0 cursor-pointer"
+            @click="emitSearch">
+            검색
+          </button>
+          <button type="button"
+            class="text-xs font-semibold text-gray-500 border border-gray-200 px-4 py-2 rounded hover:bg-gray-50 shrink-0 cursor-pointer"
+            @click="resetFilters">
+            초기화
+          </button>
+        </div>
+      </div>
+    </div>
     <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
       <table class="w-full text-sm text-left">
         <thead>
@@ -60,8 +111,35 @@ defineEmits(['open-detail', 'approve', 'reject'])
               <span v-else class="text-xs text-gray-400 block text-center">—</span>
             </td>
           </tr>
+          <tr v-if="orders.length === 0">
+            <td colspan="9" class="px-5 py-10 text-center text-sm text-gray-400">이상 발주가 없습니다.</td>
+          </tr>
         </tbody>
       </table>
+    </div>
+
+    <!-- Pagination -->
+    <div v-if="totalPages > 1" class="flex justify-center items-center gap-2 pt-2">
+      <button
+        class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+        :disabled="currentPage === 0"
+        @click="$emit('page-change', currentPage - 1)">
+        <ChevronLeft class="w-4 h-4" />
+      </button>
+      <button v-for="page in totalPages" :key="page"
+        class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
+        :class="currentPage === page - 1
+          ? 'bg-[#F37321] text-white'
+          : 'text-gray-500 hover:bg-gray-50'"
+        @click="$emit('page-change', page - 1)">
+        {{ page }}
+      </button>
+      <button
+        class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+        :disabled="currentPage === totalPages - 1"
+        @click="$emit('page-change', currentPage + 1)">
+        <ChevronRight class="w-4 h-4" />
+      </button>
     </div>
   </div>
 </template>

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -13,7 +13,7 @@ import HqDangerSettingsModal from '@/components/orders/HqDangerSettingsModal.vue
 const route = useRoute()
 const router = useRouter()
 
-const abnormalCount = computed(() => abnormalOrders.value.length)
+const abnormalCount = computed(() => abnormalOrders.value.filter(o => o.status !== 'APPROVE' && o.status !== 'REJECT').length)
 
 const tabs = computed(() => [
   { id: 'auto',      label: '자동 발주 제안' },
@@ -103,6 +103,9 @@ async function fetchAbnormalOrders(params = abnormalSearchParams.value, page = a
       date: o.createdAt?.replace('T', ' ').slice(0, 16) ?? '-',
       price: o.price,
       status: o.ordersStatus,
+      qty: o.totalQty,
+      avgQty: o.avgQty,
+      ratio: o.ratio,
     }))
     abnormalPage.value = data.number
     abnormalTotalPages.value = data.totalPages

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -13,7 +13,7 @@ import HqDangerSettingsModal from '@/components/orders/HqDangerSettingsModal.vue
 const route = useRoute()
 const router = useRouter()
 
-const abnormalCount = computed(() => abnormalOrders.value.filter(o => !o.processed).length)
+const abnormalCount = computed(() => abnormalOrders.value.length)
 
 const tabs = computed(() => [
   { id: 'auto',      label: '자동 발주 제안' },
@@ -88,23 +88,37 @@ function onHistoryPageChange(page) {
   fetchOrderHistory(historySearchParams.value, page)
 }
 
-const abnormalOrders = ref([
-  { id: 'ORD-20260414-ABN1', store: '이탈리안 키친', qty: 85, avgQty: 15, ratio: 567, date: '2026-04-14 11:22', processed: false,
-    items: [
-      { product: '한우 등심',  qty: 85, unitPrice: 85000, avgQty: 15, ratio: 567, isAbnormal: true  },
-      { product: '올리브오일', qty: 6,  unitPrice: 12000, avgQty: 5,  ratio: 20,  isAbnormal: false },
-    ] },
-  { id: 'ORD-20260413-ABN2', store: '일식 스시바',   qty: 60, avgQty: 10, ratio: 500, date: '2026-04-13 09:15', processed: false,
-    items: [
-      { product: '버터',   qty: 60, unitPrice: 9000, avgQty: 10, ratio: 500, isAbnormal: true  },
-      { product: '생크림', qty: 12, unitPrice: 7000, avgQty: 11, ratio: 9,   isAbnormal: false },
-    ] },
-  { id: 'ORD-20260412-ABN3', store: '차이나 가든',   qty: 500, avgQty: 50, ratio: 900, date: '2026-04-12 16:40', processed: true,
-    items: [
-      { product: '양파', qty: 500, unitPrice: 1500, avgQty: 50, ratio: 900, isAbnormal: true  },
-      { product: '생수', qty: 40,  unitPrice: 8000, avgQty: 38, ratio: 5,   isAbnormal: false },
-    ] },
-])
+const abnormalOrders = ref([])
+const abnormalPage = ref(0)
+const abnormalTotalPages = ref(1)
+const abnormalSearchParams = ref({})
+
+async function fetchAbnormalOrders(params = abnormalSearchParams.value, page = abnormalPage.value) {
+  try {
+    const res = await ordersApi.getDangerOrders({ ...params, page, size: 10 })
+    const data = res.data.result
+    abnormalOrders.value = data.content.map(o => ({
+      id: o.idx,
+      store: o.storeName,
+      date: o.createdAt?.replace('T', ' ').slice(0, 16) ?? '-',
+      price: o.price,
+      status: o.ordersStatus,
+    }))
+    abnormalPage.value = data.number
+    abnormalTotalPages.value = data.totalPages
+  } catch (e) {
+    console.error('이상 발주 목록 조회 실패', e)
+  }
+}
+
+function onAbnormalSearch(params) {
+  abnormalSearchParams.value = params
+  fetchAbnormalOrders(params, 0)
+}
+
+function onAbnormalPageChange(page) {
+  fetchAbnormalOrders(abnormalSearchParams.value, page)
+}
 
 const confirmedOrders = ref([])
 const confirmedPage = ref(0)
@@ -167,6 +181,7 @@ onMounted(() => {
   fetchAutoOrders()
   fetchConfirmedOrders()
   fetchOrderHistory()
+  fetchAbnormalOrders()
 })
 
 function setOrderViewTab(id) {
@@ -175,6 +190,7 @@ function setOrderViewTab(id) {
   if (id === 'confirmed') fetchConfirmedOrders()
   if (id === 'auto') fetchAutoOrders()
   if (id === 'history') fetchOrderHistory()
+  if (id === 'abnormal') fetchAbnormalOrders()
 }
 
 // Detail modal
@@ -227,8 +243,28 @@ async function saveDangerSettings({ threshold, months }) {
 }
 
 // Abnormal order actions
-function approveAbnormal(o) { o.processed = true; alert(`${o.store} 발주 승인 처리되었습니다.`) }
-function rejectAbnormal(o)  { o.processed = true; alert(`${o.store} 발주 반려 처리되었습니다.`) }
+async function approveAbnormal(o) {
+  if (!confirm(`${o.store} 발주를 승인하시겠습니까?`)) return
+  try {
+    await ordersApi.approveDangerOrder(o.id)
+    alert(`${o.store} 발주 승인 처리되었습니다.`)
+    await fetchAbnormalOrders()
+  } catch (e) {
+    console.error('이상 발주 승인 실패', e)
+    alert('승인 처리에 실패했습니다.')
+  }
+}
+async function rejectAbnormal(o) {
+  if (!confirm(`${o.store} 발주를 반려하시겠습니까?`)) return
+  try {
+    await ordersApi.rejectDangerOrder(o.id)
+    alert(`${o.store} 발주 반려 처리되었습니다.`)
+    await fetchAbnormalOrders()
+  } catch (e) {
+    console.error('이상 발주 반려 실패', e)
+    alert('반려 처리에 실패했습니다.')
+  }
+}
 
 </script>
 
@@ -281,7 +317,9 @@ function rejectAbnormal(o)  { o.processed = true; alert(`${o.store} 발주 반�
       :current-page="historyPage" :total-pages="historyTotalPages"
       @open-detail="openDetail" @search="onHistorySearch" @page-change="onHistoryPageChange" />
     <HqAbnormalOrderTable v-if="activeTab === 'abnormal'" :orders="abnormalOrders"
-      @open-detail="openDetail" @approve="approveAbnormal" @reject="rejectAbnormal" />
+      :current-page="abnormalPage" :total-pages="abnormalTotalPages"
+      @open-detail="openDetail" @approve="approveAbnormal" @reject="rejectAbnormal"
+      @search="onAbnormalSearch" @page-change="onAbnormalPageChange" />
 
     <!-- Modals -->
     <HqOrderDetailModal :order="selectedOrder" @close="selectedOrder = null" />


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 이상 발주 목록에 검색/페이징 기능 추가 및 매장별 평균 수량·초과율 계산 로직 구현                                                                                                                                                
- 본사 관리자가 이상 발주를 승인/반려할 수 있도록 API 연동

## 변경 파일
- `backend/src/main/java/.../orders/model/DangerDto.java`
- `backend/src/main/java/.../orders/OrdersRepository.java`
- `backend/src/main/java/.../orders/OrdersService.java`
- `backend/src/main/java/.../orders/OrdersController.java`
- `frontend/src/api/orders/index.js`
- `frontend/src/components/orders/HqAbnormalOrderTable.vue`
- `frontend/src/views/hq/HqOrderManageView.vue`

## 주요 변경 사항
- DangerListRes DTO 추가 (totalQty, avgQty, ratio 필드 포함)
- OrdersRepository에 매장별 최근 N개월 평균 발주 수량 조회 JPQL 쿼리 추가
- OrdersService.findDangerOrders에서 Danger 설정 기반 평균수량 계산 및 DangerListRes 반환
- OrdersController의 danger 엔드포인트 반환 타입을 DangerListRes로 변경
- 이상 발주 테이블에 기간/키워드 검색 UI 및 페이지네이션 추가
- 프론트엔드에서 승인/반려 API 호출 연동 (approveDangerOrder, rejectDangerOrder)
- o.processed 기반 처리 판단을 ordersStatus 기반으로 변경

## Test Plan
- [ ] 이상 발주 목록 조회 시 발주수량, 평균수량, 초과율이 정상 표시되는지 확인
- [ ] 기간 필터 및 키워드 검색이 정상 동작하는지 확인
- [ ] 페이지네이션이 정상 동작하는지 확인
- [ ] 승인/반려 버튼 클릭 시 상태가 정상 변경되는지 확인
- [ ] 처리완료된 발주는 승인/반려 버튼이 숨겨지는지 확인

## Issue
- Closes #467
- Closes #75