### PR TITLE
[Feat] 이상 발주 기준 변경 시 기존 데이터 재평가 및 이력 유지

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -13,6 +13,7 @@ import java.util.List;
 public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecificationExecutor<Orders> {
     List<Orders> findAllByStore_IdxAndOrdersStatus(Long storeIdx, OrdersStatus orderStatus);
     List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
+    List<Orders> findAllByIsDangerTrue();
 
     @Query("SELECT COALESCE(SUM(i.count), 0) / GREATEST(COUNT(DISTINCT o.idx), 1) " +
             "FROM Orders o JOIN o.ordersItemList i " +

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -192,20 +192,38 @@ public class OrdersService {
                         .build());
     }
 
+    @Transactional
     public void save(DangerDto.DangerReq req) {
         Danger danger = dangerRepository.findById(1L)
                 .orElse(Danger.builder().build());
+
         danger.update(req.getRatio(), req.getPeriod());
+
         dangerRepository.save(danger);
+
+        // 기존 이상 발주 재평가: 새 기준 미달 시 isDanger 해제
+        List<Orders> dangerOrders = ordersRepository.findAllByIsDangerTrue();
+
+        for (Orders orders : dangerOrders) {
+            int totalQty = orders.getOrdersItemList().stream().mapToInt(OrdersItem::getCount).sum();
+
+            LocalDateTime since = orders.getCreatedAt().minusMonths(req.getPeriod());
+
+            Integer avgQty = ordersRepository.findAvgQtyByStoreAndPeriod(orders.getStore().getIdx(), since);
+
+            int ratio = avgQty > 0 ? (totalQty - avgQty) * 100 / avgQty : 0;
+
+            if (ratio < req.getRatio()) {
+                orders.clearDanger();
+            }
+
+        }
     }
 
     @Transactional
     public void approve(Long ordersIdx) {
         Orders orders = ordersRepository.findById(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-        if (orders.isDanger()) {
-            orders.clearDanger();
-        }
         orders.approve();
     }
 
@@ -213,9 +231,6 @@ public class OrdersService {
     public void reject(Long ordersIdx) {
         Orders orders = ordersRepository.findById(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-        if (orders.isDanger()) {
-            orders.clearDanger();
-        }
         orders.reject();
     }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 이상 발주 기준(초과율, 기간) 변경 시 기존 isDanger=true 발주를 재평가하여 새 기준 미달 건은 자동 해제                                                                                                                           
- 승인/반려 시 isDanger를 유지하여 이상 발주 이력 보존

## 변경 파일
- `backend/src/main/java/.../orders/OrdersRepository.java`
- `backend/src/main/java/.../orders/OrdersService.java`

## 주요 변경 사항
- OrdersRepository에 findAllByIsDangerTrue 메서드 추가
- save()에서 기준 변경 시 isDanger=true인 모든 발주를 재평가하여 미달 건 clearDanger 처리
- approve()/reject()에서 clearDanger() 호출 제거하여 이상 발주 이력 유지

## Test Plan
- [ ] 이상 발주 기준 초과율을 높였을 때 기존 이상 발주 중 미달 건이 목록에서 제거되는지 확인
- [ ] 이상 발주 기준 기간을 변경했을 때 재평가가 정상 동작하는지 확인
- [ ] 승인/반려 후에도 이상 발주 목록에 이력이 유지되는지 확인