### PR TITLE
[Chore] K8s 백엔드 환경변수 ConfigMap/Secret 분리 적용     

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 **/.DS_Store
 
 node_modules
+
+k8s/backend/secret.yaml
+k8s/backend/configmap.yaml

--- a/k8s/backend/deployment.yaml
+++ b/k8s/backend/deployment.yaml
@@ -19,6 +19,11 @@ spec:
           image: deatytim/nexusback:latest
           ports:
             - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: nexus-backend-config
+            - secretRef:
+                name: nexus-backend-secret
           readinessProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- K8s 백엔드 배포 시 환경변수를 ConfigMap/Secret으로 분리하여 주입하도록 설정                                                                                                                                                     
                                                                                                                                                                                                                                
## 변경 파일                                                                                                                                                                                                                    
- `.gitignore`
- `k8s/backend/deployment.yaml`

## 주요 변경 사항
- ConfigMap, Secret yaml 파일 생성 (gitignore 처리)
- deployment.yaml에 envFrom으로 ConfigMap/Secret 참조 추가
- .gitignore에 secret.yaml, configmap.yaml 추가

## DB & Infrastructure
- DB 접속 정보(DB_URL, DB_USER, DB_PASS)를 Secret으로 관리
- AWS 관련 설정을 ConfigMap으로 관리
- DB_URL을 k8s 내부 서비스명(db-service)으로 설정

## Test Plan
- [x] kubectl apply 후 backend pod에서 환경변수 주입 확인
- [ ] Spring Boot 정상 기동 및 DB 연결 확인