### PR TITLE
[Chore] K8s DB 및 백엔드 민감 설정 파일 gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 
 k8s/backend/secret.yaml
 k8s/backend/configmap.yaml
+k8s/db-statefulset.yaml
+k8s/db-service.yaml


### PR DESCRIPTION
## Summary
- K8s DB 관련 yaml 파일을 gitignore에 추가하여 민감 정보 노출 방지

## 변경 파일
- `.gitignore`

## 주요 변경 사항
-db-statefulset.yaml gitignore 추가 (DB 비밀번호 포함)
- db-service.yaml gitignore 추가

## Test Plan
- [ ] git status에서 db-statefulset.yaml, db-service.yaml이 추적되지 않는지 확인