### PR TITLE
[Docs] OrdersController Javadoc 추가 및 Service 메서드 순서 정렬

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -29,6 +29,14 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 public class OrdersController {
     private final OrdersService orderService;
 
+    /**
+     * 자동 발주 목록 조회
+     *
+     * @param keyword 검색 키워드 (선택)
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return ResponseEntity 자동 발주 목록 (페이징)
+     */
     @GetMapping("/list/auto")
     public ResponseEntity autoList(
             @RequestParam(required = false) String keyword,
@@ -39,6 +47,14 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
 
+    /**
+     * 확정 발주 목록 조회
+     *
+     * @param keyword 검색 키워드 (선택)
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return ResponseEntity 확정 발주 목록 (페이징)
+     */
     @GetMapping("/list/confirmed")
     public ResponseEntity confirmedList(
             @RequestParam(required = false) String keyword,
@@ -50,6 +66,17 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
 
+    /**
+     * 발주 이력 목록 조회
+     *
+     * @param ordersType 발주 유형 필터 (선택)
+     * @param startDate 조회 시작일 (선택)
+     * @param endDate 조회 종료일 (선택)
+     * @param keyword 검색 키워드 (선택)
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return ResponseEntity 발주 이력 목록 (페이징)
+     */
     @GetMapping("/list/history")
     public ResponseEntity historyList(
             @RequestParam(required = false) OrdersType ordersType,
@@ -65,6 +92,16 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
 
+    /**
+     * 위험 발주 목록 조회
+     *
+     * @param startDate 조회 시작일 (선택)
+     * @param endDate 조회 종료일 (선택)
+     * @param keyword 검색 키워드 (선택)
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return ResponseEntity 위험 발주 목록 (페이징)
+     */
     @GetMapping("/list/danger")
     public ResponseEntity dangerList(
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -79,66 +116,134 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
 
+    /**
+     * 발주 상세 정보 조회
+     *
+     * @param ordersIdx 조회할 발주의 고유 ID
+     * @return ResponseEntity 발주 상세 정보
+     */
     @GetMapping("/{ordersIdx}")
     public ResponseEntity ordersDetail(@PathVariable Long ordersIdx) {
         OrdersDto.OrdersRes result = orderService.findById(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
+    /**
+     * 위험 발주 기준 설정 조회
+     *
+     * @return ResponseEntity 위험 발주 기준 설정 정보
+     */
     @GetMapping("/danger")
     public ResponseEntity find() {
         DangerDto.DangerRes result = orderService.find();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
+    /**
+     * 위험 발주 기준 설정 수정
+     *
+     * @param req 위험 발주 기준 설정 요청 데이터
+     * @return ResponseEntity 수정 결과 메시지
+     */
     @PutMapping("/danger")
     public ResponseEntity save(@RequestBody DangerDto.DangerReq req) {
         orderService.save(req);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
+    /**
+     * 발주 승인
+     *
+     * @param ordersIdx 승인할 발주의 고유 ID
+     * @return ResponseEntity 승인 결과 메시지
+     */
     @PutMapping("/{ordersIdx}/approve")
     public ResponseEntity approve(@PathVariable Long ordersIdx) {
         orderService.approve(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
+    /**
+     * 발주 반려
+     *
+     * @param ordersIdx 반려할 발주의 고유 ID
+     * @return ResponseEntity 반려 결과 메시지
+     */
     @PutMapping("/{ordersIdx}/reject")
     public ResponseEntity reject(@PathVariable Long ordersIdx) {
         orderService.reject(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
+    /**
+     * 발주 항목 추가
+     *
+     * @param ordersIdx 항목을 추가할 발주의 고유 ID
+     * @param req 추가할 발주 항목 요청 데이터
+     * @return ResponseEntity 추가 결과 메시지
+     */
     @PostMapping("/{ordersIdx}/items")
     public ResponseEntity addItem(@PathVariable Long ordersIdx, @RequestBody OrdersItemDto.OrdersItemReq req) {
         orderService.addItem(ordersIdx, req);
         return ResponseEntity.ok(BaseResponse.success("create success"));
     }
 
+    /**
+     * 발주 항목 수량 수정
+     *
+     * @param ordersItemIdx 수정할 발주 항목의 고유 ID
+     * @param req 수정할 수량 요청 데이터
+     * @return ResponseEntity 수정 결과 메시지
+     */
     @PutMapping("/items/{ordersItemIdx}")
     public ResponseEntity updateItemCount(@PathVariable Long ordersItemIdx, @RequestBody OrdersItemDto.OrdersItemReq req) {
         orderService.updateItemCount(ordersItemIdx, req.getCount());
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
+    /**
+     * 발주 항목 삭제
+     *
+     * @param ordersItemIdx 삭제할 발주 항목의 고유 ID
+     * @return ResponseEntity 삭제 결과 메시지
+     */
     @DeleteMapping("/items/{ordersItemIdx}")
     public ResponseEntity deleteItem(@PathVariable Long ordersItemIdx) {
         orderService.deleteItem(ordersItemIdx);
         return ResponseEntity.ok(BaseResponse.success("delete success"));
     }
 
+    /**
+     * 확정 발주 일괄 승인
+     *
+     * @return ResponseEntity 일괄 승인 결과 메시지
+     */
     @PutMapping("/confirmed/approve")
     public ResponseEntity approveAll() {
         orderService.approveAllConfirmed();
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
+    /**
+     * 발주 취소
+     *
+     * @param ordersIdx 취소할 발주의 고유 ID
+     * @return ResponseEntity 취소 결과 메시지
+     */
     @PutMapping("/{ordersIdx}/cancel")
     public ResponseEntity cancel(@PathVariable Long ordersIdx) {
         orderService.cancelOrder(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
+    /**
+     * 가맹점 수동 발주 생성
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @param req 수동 발주 요청 데이터
+     * @return ResponseEntity 생성 결과 메시지
+     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
+     */
     @PostMapping("/store/reg/manual")
     public ResponseEntity createStoreManualOrder(@AuthenticationPrincipal AuthUserDetails authUserDetails, @RequestBody OrdersDto.OrdersReq req) {
         if (authUserDetails == null) {
@@ -148,6 +253,13 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success("create success"));
     }
 
+    /**
+     * 가맹점 발주 목록 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity 가맹점 발주 목록
+     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
+     */
     @GetMapping("/store/list")
     public ResponseEntity storeList(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
         if (authUserDetails == null) {
@@ -157,6 +269,13 @@ public class OrdersController {
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
+    /**
+     * 가맹점 진행 중인 발주 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity 가맹점 진행 중인 발주 목록
+     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
+     */
     @GetMapping("/store/find")
     public ResponseEntity storeFind(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
         if (authUserDetails == null) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -43,77 +43,16 @@ public class OrdersService {
         return ordersRepository.findAll(spec, pageable).map(OrdersDto.OrderListRes::from);
     }
 
-    @Transactional
-    public void createStoreManualOrder(Long userIdx, OrdersDto.OrdersReq req) {
-        // 1. 주문 아이템 리스트 검증
-        if (req.getOrdersItemList() == null || req.getOrdersItemList().isEmpty()) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+    // 확정 발주 검색 조회 (CONFIRMED 상태 대상)
+    // 매장명 키워드 검색 + 페이징 처리
+    public Page<OrdersDto.OrderListRes> findAllConfirmed(String keyword, Pageable pageable) {
+        Specification<Orders> spec = OrdersSpecification.statusIn(List.of(OrdersStatus.CONFIRMED));
+
+        if (keyword != null && !keyword.isBlank()) {
+            spec = spec.and(OrdersSpecification.keywordLike(keyword));
         }
 
-        // 2. 인증 정보로 매장 조회
-        Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-
-        // 3. Product 조회 및 총 가격 계산
-        long totalprice = 0;
-        List<OrdersItem> itemList = new ArrayList<>();
-
-        for (OrdersItemDto.OrdersItemReq itemReq : req.getOrdersItemList()) {
-            Product product = productRepository.findById(itemReq.getProductIdx())
-                    .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-
-            totalprice += (long) product.getUnitPrice() * itemReq.getCount();
-
-            itemList.add(OrdersItem.builder()
-                    .count(itemReq.getCount())
-                    .product(product)
-                    .build());
-        }
-
-        // 4. Orders 저장
-        Orders orders = ordersRepository.save(Orders.builder()
-                .price(totalprice)
-                .ordersType(OrdersType.MANUAL)
-                .ordersStatus(OrdersStatus.CONFIRMED)
-                .isDanger(false)
-                .createdAt(LocalDateTime.now())
-                .store(store)
-                .build());
-
-        // 5. OrdersItem 저장
-        for (OrdersItem item : itemList) {
-            ordersItemRepository.save(OrdersItem.builder()
-                    .count(item.getCount())
-                    .product(item.getProduct())
-                    .orders(orders)
-                    .build());
-        }
-    }
-
-    @Transactional
-    public void cancelOrder(Long ordersIdx) {
-        // 1. 발주 조회
-        Orders orders = ordersRepository.findById(ordersIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-
-        // 2. CONFIRMED 상태인 경우에만 취소 가능
-        if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
-        }
-
-        // 3. 상태를 CANCELLED로 변경
-        orders.cancel();
-    }
-
-    @Transactional
-    public void approveAllConfirmed() {
-        // 1. CONFIRMED 상태의 모든 발주 조회
-        List<Orders> confirmedOrders = ordersRepository.findAllByOrdersStatus(OrdersStatus.CONFIRMED);
-
-        // 2. 각 발주를 APPROVE 상태로 변경
-        for (Orders orders : confirmedOrders) {
-            orders.approve();
-        }
+        return ordersRepository.findAll(spec, pageable).map(OrdersDto.OrderListRes::from);
     }
 
     // 발주 이력 검색 조회 (APPROVE, REJECT, CANCELLED 상태 대상)
@@ -131,18 +70,6 @@ public class OrdersService {
         if (endDate != null) {
             spec = spec.and(OrdersSpecification.createdBefore(endDate));
         }
-        if (keyword != null && !keyword.isBlank()) {
-            spec = spec.and(OrdersSpecification.keywordLike(keyword));
-        }
-
-        return ordersRepository.findAll(spec, pageable).map(OrdersDto.OrderListRes::from);
-    }
-
-    // 확정 발주 검색 조회 (CONFIRMED 상태 대상)
-    // 매장명 키워드 검색 + 페이징 처리
-    public Page<OrdersDto.OrderListRes> findAllConfirmed(String keyword, Pageable pageable) {
-        Specification<Orders> spec = OrdersSpecification.statusIn(List.of(OrdersStatus.CONFIRMED));
-
         if (keyword != null && !keyword.isBlank()) {
             spec = spec.and(OrdersSpecification.keywordLike(keyword));
         }
@@ -270,6 +197,79 @@ public class OrdersService {
         Orders orders = item.getOrders();
         orders.updatePrice(orders.getPrice() - (long) item.getProduct().getUnitPrice() * item.getCount());
         ordersItemRepository.delete(item);
+    }
+
+    @Transactional
+    public void approveAllConfirmed() {
+        // 1. CONFIRMED 상태의 모든 발주 조회
+        List<Orders> confirmedOrders = ordersRepository.findAllByOrdersStatus(OrdersStatus.CONFIRMED);
+
+        // 2. 각 발주를 APPROVE 상태로 변경
+        for (Orders orders : confirmedOrders) {
+            orders.approve();
+        }
+    }
+
+    @Transactional
+    public void cancelOrder(Long ordersIdx) {
+        // 1. 발주 조회
+        Orders orders = ordersRepository.findById(ordersIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // 2. CONFIRMED 상태인 경우에만 취소 가능
+        if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        // 3. 상태를 CANCELLED로 변경
+        orders.cancel();
+    }
+
+    @Transactional
+    public void createStoreManualOrder(Long userIdx, OrdersDto.OrdersReq req) {
+        // 1. 주문 아이템 리스트 검증
+        if (req.getOrdersItemList() == null || req.getOrdersItemList().isEmpty()) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        // 2. 인증 정보로 매장 조회
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // 3. Product 조회 및 총 가격 계산
+        long totalprice = 0;
+        List<OrdersItem> itemList = new ArrayList<>();
+
+        for (OrdersItemDto.OrdersItemReq itemReq : req.getOrdersItemList()) {
+            Product product = productRepository.findById(itemReq.getProductIdx())
+                    .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+            totalprice += (long) product.getUnitPrice() * itemReq.getCount();
+
+            itemList.add(OrdersItem.builder()
+                    .count(itemReq.getCount())
+                    .product(product)
+                    .build());
+        }
+
+        // 4. Orders 저장
+        Orders orders = ordersRepository.save(Orders.builder()
+                .price(totalprice)
+                .ordersType(OrdersType.MANUAL)
+                .ordersStatus(OrdersStatus.CONFIRMED)
+                .isDanger(false)
+                .createdAt(LocalDateTime.now())
+                .store(store)
+                .build());
+
+        // 5. OrdersItem 저장
+        for (OrdersItem item : itemList) {
+            ordersItemRepository.save(OrdersItem.builder()
+                    .count(item.getCount())
+                    .product(item.getProduct())
+                    .orders(orders)
+                    .build());
+        }
     }
 
     public List<OrdersDto.OrdersRes> findByUserIdx(Long userIdx) {


### PR DESCRIPTION
## Summary
- OrdersController 전체 엔드포인트에 Javadoc 주석 추가
- OrdersService 메서드 순서를 Controller 호출 순서에 맞춰 정렬

## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`

## 주요 변경 사항
- OrdersController 17개 엔드포인트에 `@param`, `@return`, `@throws` Javadoc 추가
- OrdersService 메서드 순서를 Controller 메서드 호출 순서와 동일하게 재배치
- 목록 조회(auto → confirmed → history → danger) → 상세 조회 → 설정 → 승인/반려 → 항목 CRUD → 일괄 승인 → 취소 → 가맹점

## Test Plan
- [x] 로직 변경 없이 주석 추가 및 메서드 순서 변경만 수행하여 기존 동작에 영향 없음