### PR TITLE
[Refactor] #130 - 점주 발주 이력 조회 시 전체 상태 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecificationExecutor<Orders> {
     List<Orders> findAllByStore_IdxAndOrdersStatus(Long storeIdx, OrdersStatus orderStatus);
+    List<Orders> findAllByStore_IdxAndOrdersStatusIn(Long storeIdx, List<OrdersStatus> ordersStatuses);
     List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
     List<Orders> findAllByIsDangerTrue();
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -276,9 +276,10 @@ public class OrdersService {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
-        return ordersRepository.findAllByStore_IdxAndOrdersStatus(store.getIdx(), OrdersStatus.APPROVE).stream()
-                .map(OrdersDto.OrdersRes::from)
-                .toList();
+        return ordersRepository.findAllByStore_IdxAndOrdersStatusIn(
+                store.getIdx(),
+                List.of(OrdersStatus.CONFIRMED, OrdersStatus.APPROVE, OrdersStatus.REJECT, OrdersStatus.CANCELLED)
+        ).stream().map(OrdersDto.OrdersRes::from).toList();
     }
 
     public List<OrdersDto.OrdersRes> findByUserIdxAndOrdersStatus(Long userIdx) {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 발주 이력 조회 API가 APPROVE 상태만 반환하던 것을 전체 상태로 확장

## 변경 파일
- backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
- backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java

## 주요 변경 사항
- OrdersRepository에 findAllByStore_IdxAndOrdersStatusIn 쿼리 메서드 추가
- findByUserIdx에서 APPROVE만 조회하던 것을 CONFIRMED, APPROVE, REJECT, CANCELLED 전체 조회로 변경

## Test Plan
- [ ] 점주 로그인 후 GET /orders/store/list 호출 시 전체 상태의 발주 이력 반환 확인

## Issue
- Closes #130