### PR TITLE
[Feat] #138 - 점주 제안 발주서 Backend API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -254,6 +254,28 @@ public class OrdersController {
     }
 
     /**
+     * 가맹점 발주 항목 추가
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @param ordersIdx 항목을 추가할 발주의 고유 ID
+     * @param req 추가할 발주 항목 요청 데이터
+     * @return ResponseEntity 추가 결과 메시지
+     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
+     */
+    @PostMapping("/store/{ordersIdx}/items")
+    public ResponseEntity addStoreItem(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @PathVariable Long ordersIdx,
+            @RequestBody OrdersItemDto.OrdersItemReq req
+    ) {
+        if (authUserDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        orderService.addStoreItem(authUserDetails.getIdx(), ordersIdx, req);
+        return ResponseEntity.ok(BaseResponse.success("create success"));
+    }
+
+    /**
      * 가맹점 발주 목록 조회
      *
      * @param authUserDetails 인증된 사용자 정보

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -254,7 +254,7 @@ public class OrdersController {
     }
 
     /**
-     * 가맹점 발주 항목 추가
+     * 가맹점 제안 발주서 항목 추가
      *
      * @param authUserDetails 인증된 사용자 정보
      * @param ordersIdx 항목을 추가할 발주의 고유 ID
@@ -276,7 +276,7 @@ public class OrdersController {
     }
 
     /**
-     * 가맹점 발주 항목 수량 수정
+     * 가맹점 제안 발주서 항목 수량 수정
      *
      * @param authUserDetails 인증된 사용자 정보
      * @param ordersItemIdx 수정할 발주 항목의 고유 ID
@@ -298,7 +298,27 @@ public class OrdersController {
     }
 
     /**
-     * 가맹점 발주 목록 조회
+     * 가맹점 제안 발주서 거절
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @param ordersIdx 거절할 발주의 고유 ID
+     * @return ResponseEntity 거절 결과 메시지
+     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
+     */
+    @PutMapping("/store/{ordersIdx}/reject")
+    public ResponseEntity rejectStoreOrder(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @PathVariable Long ordersIdx
+    ) {
+        if (authUserDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        orderService.rejectStoreOrder(authUserDetails.getIdx(), ordersIdx);
+        return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
+    /**
+     * 가맹점 발주 이력 조회
      *
      * @param authUserDetails 인증된 사용자 정보
      * @return ResponseEntity 가맹점 발주 목록
@@ -314,7 +334,7 @@ public class OrdersController {
     }
 
     /**
-     * 가맹점 진행 중인 발주 조회
+     * 가맹점 제안 발주서 조회
      *
      * @param authUserDetails 인증된 사용자 정보
      * @return ResponseEntity 가맹점 진행 중인 발주 목록

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -302,12 +302,20 @@ public class OrdersController {
     /**
      * 가맹점 발주 취소
      *
+     * @param authUserDetails 인증된 사용자 정보
      * @param ordersIdx 취소할 발주의 고유 ID
      * @return ResponseEntity 취소 결과 메시지
+     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
      */
-    @PutMapping("/{ordersIdx}/cancel")
-    public ResponseEntity cancel(@PathVariable Long ordersIdx) {
-        orderService.cancelOrder(ordersIdx);
+    @PutMapping("/store/{ordersIdx}/cancel")
+    public ResponseEntity cancel(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @PathVariable Long ordersIdx
+    ) {
+        if (authUserDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        orderService.cancelOrder(authUserDetails.getIdx(), ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -176,44 +176,6 @@ public class OrdersController {
     }
 
     /**
-     * 발주 항목 추가
-     *
-     * @param ordersIdx 항목을 추가할 발주의 고유 ID
-     * @param req 추가할 발주 항목 요청 데이터
-     * @return ResponseEntity 추가 결과 메시지
-     */
-    @PostMapping("/{ordersIdx}/items")
-    public ResponseEntity addItem(@PathVariable Long ordersIdx, @RequestBody OrdersItemDto.OrdersItemReq req) {
-        orderService.addItem(ordersIdx, req);
-        return ResponseEntity.ok(BaseResponse.success("create success"));
-    }
-
-    /**
-     * 발주 항목 수량 수정
-     *
-     * @param ordersItemIdx 수정할 발주 항목의 고유 ID
-     * @param req 수정할 수량 요청 데이터
-     * @return ResponseEntity 수정 결과 메시지
-     */
-    @PutMapping("/items/{ordersItemIdx}")
-    public ResponseEntity updateItemCount(@PathVariable Long ordersItemIdx, @RequestBody OrdersItemDto.OrdersItemReq req) {
-        orderService.updateItemCount(ordersItemIdx, req.getCount());
-        return ResponseEntity.ok(BaseResponse.success("update success"));
-    }
-
-    /**
-     * 발주 항목 삭제
-     *
-     * @param ordersItemIdx 삭제할 발주 항목의 고유 ID
-     * @return ResponseEntity 삭제 결과 메시지
-     */
-    @DeleteMapping("/items/{ordersItemIdx}")
-    public ResponseEntity deleteItem(@PathVariable Long ordersItemIdx) {
-        orderService.deleteItem(ordersItemIdx);
-        return ResponseEntity.ok(BaseResponse.success("delete success"));
-    }
-
-    /**
      * 확정 발주 일괄 승인
      *
      * @return ResponseEntity 일괄 승인 결과 메시지
@@ -221,18 +183,6 @@ public class OrdersController {
     @PutMapping("/confirmed/approve")
     public ResponseEntity approveAll() {
         orderService.approveAllConfirmed();
-        return ResponseEntity.ok(BaseResponse.success("update success"));
-    }
-
-    /**
-     * 발주 취소
-     *
-     * @param ordersIdx 취소할 발주의 고유 ID
-     * @return ResponseEntity 취소 결과 메시지
-     */
-    @PutMapping("/{ordersIdx}/cancel")
-    public ResponseEntity cancel(@PathVariable Long ordersIdx) {
-        orderService.cancelOrder(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
@@ -251,6 +201,22 @@ public class OrdersController {
         }
         orderService.createStoreManualOrder(authUserDetails.getIdx(), req);
         return ResponseEntity.ok(BaseResponse.success("create success"));
+    }
+
+    /**
+     * 가맹점 제안 발주서 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity 가맹점 진행 중인 발주 목록
+     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
+     */
+    @GetMapping("/store/find")
+    public ResponseEntity storeFind(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        if (authUserDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        List<OrdersDto.OrdersRes> result = orderService.findByUserIdxAndOrdersStatus(authUserDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success(result));
     }
 
     /**
@@ -334,19 +300,15 @@ public class OrdersController {
     }
 
     /**
-     * 가맹점 제안 발주서 조회
+     * 가맹점 발주 취소
      *
-     * @param authUserDetails 인증된 사용자 정보
-     * @return ResponseEntity 가맹점 진행 중인 발주 목록
-     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
+     * @param ordersIdx 취소할 발주의 고유 ID
+     * @return ResponseEntity 취소 결과 메시지
      */
-    @GetMapping("/store/find")
-    public ResponseEntity storeFind(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
-        if (authUserDetails == null) {
-            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
-        }
-        List<OrdersDto.OrdersRes> result = orderService.findByUserIdxAndOrdersStatus(authUserDetails.getIdx());
-        return ResponseEntity.ok(BaseResponse.success(result));
+    @PutMapping("/{ordersIdx}/cancel")
+    public ResponseEntity cancel(@PathVariable Long ordersIdx) {
+        orderService.cancelOrder(ordersIdx);
+        return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -276,6 +276,28 @@ public class OrdersController {
     }
 
     /**
+     * 가맹점 발주 항목 수량 수정
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @param ordersItemIdx 수정할 발주 항목의 고유 ID
+     * @param req 수정할 수량 요청 데이터
+     * @return ResponseEntity 수정 결과 메시지
+     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
+     */
+    @PutMapping("/store/{ordersItemIdx}/items")
+    public ResponseEntity updateStoreItemCount(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @PathVariable Long ordersItemIdx,
+            @RequestBody OrdersItemDto.OrdersItemReq req
+    ) {
+        if (authUserDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        orderService.updateStoreItemCount(authUserDetails.getIdx(), ordersItemIdx, req.getCount());
+        return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
+    /**
      * 가맹점 발주 목록 조회
      *
      * @param authUserDetails 인증된 사용자 정보

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -264,6 +264,26 @@ public class OrdersController {
     }
 
     /**
+     * 가맹점 제안 발주서 항목 삭제
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @param ordersItemIdx 삭제할 발주 항목의 고유 ID
+     * @return ResponseEntity 삭제 결과 메시지
+     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
+     */
+    @DeleteMapping("/store/{ordersItemIdx}/items")
+    public ResponseEntity deleteStoreItem(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @PathVariable Long ordersItemIdx
+    ) {
+        if (authUserDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        orderService.deleteStoreItem(authUserDetails.getIdx(), ordersItemIdx);
+        return ResponseEntity.ok(BaseResponse.success("delete success"));
+    }
+
+    /**
      * 가맹점 제안 발주서 거절
      *
      * @param authUserDetails 인증된 사용자 정보

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -314,6 +314,25 @@ public class OrdersService {
         orders.updatePrice(orders.getPrice() + (long) product.getUnitPrice() * req.getCount());
     }
 
+    @Transactional
+    public void rejectStoreOrder(Long userIdx, Long ordersIdx) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        Orders orders = ordersRepository.findById(ordersIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        if (!orders.getStore().getIdx().equals(store.getIdx())) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        if (orders.getOrdersStatus() != OrdersStatus.WAITING) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        orders.reject();
+    }
+
     public List<OrdersDto.OrdersRes> findByUserIdx(Long userIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -162,62 +162,6 @@ public class OrdersService {
     }
 
     @Transactional
-    public void addItem(Long ordersIdx, OrdersItemDto.OrdersItemReq req) {
-        Orders orders = ordersRepository.findById(ordersIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-
-        Product product = productRepository.findById(req.getProductIdx())
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-
-        ordersItemRepository.save(OrdersItem.builder()
-                .count(req.getCount())
-                .product(product)
-                .orders(orders)
-                .build());
-
-        orders.updatePrice(orders.getPrice() + (long) product.getUnitPrice() * req.getCount());
-    }
-
-    @Transactional
-    public void updateItemCount(Long ordersItemIdx, Integer count) {
-        OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-
-        Orders orders = item.getOrders();
-        long priceDiff = (long) item.getProduct().getUnitPrice() * (count - item.getCount());
-        item.updateCount(count);
-        orders.updatePrice(orders.getPrice() + priceDiff);
-    }
-
-    @Transactional
-    public void updateStoreItemCount(Long userIdx, Long ordersItemIdx, Integer count) {
-        Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-
-        OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-
-        if (!item.getOrders().getStore().getIdx().equals(store.getIdx())) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
-        }
-
-        Orders orders = item.getOrders();
-        long priceDiff = (long) item.getProduct().getUnitPrice() * (count - item.getCount());
-        item.updateCount(count);
-        orders.updatePrice(orders.getPrice() + priceDiff);
-    }
-
-    @Transactional
-    public void deleteItem(Long ordersItemIdx) {
-        OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-
-        Orders orders = item.getOrders();
-        orders.updatePrice(orders.getPrice() - (long) item.getProduct().getUnitPrice() * item.getCount());
-        ordersItemRepository.delete(item);
-    }
-
-    @Transactional
     public void approveAllConfirmed() {
         // 1. CONFIRMED 상태의 모든 발주 조회
         List<Orders> confirmedOrders = ordersRepository.findAllByOrdersStatus(OrdersStatus.CONFIRMED);
@@ -226,21 +170,6 @@ public class OrdersService {
         for (Orders orders : confirmedOrders) {
             orders.approve();
         }
-    }
-
-    @Transactional
-    public void cancelOrder(Long ordersIdx) {
-        // 1. 발주 조회
-        Orders orders = ordersRepository.findById(ordersIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-
-        // 2. CONFIRMED 상태인 경우에만 취소 가능
-        if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
-        }
-
-        // 3. 상태를 CANCELLED로 변경
-        orders.cancel();
     }
 
     @Transactional
@@ -290,6 +219,15 @@ public class OrdersService {
         }
     }
 
+    public List<OrdersDto.OrdersRes> findByUserIdxAndOrdersStatus(Long userIdx) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        return ordersRepository.findAllByStore_IdxAndOrdersStatus(store.getIdx(), OrdersStatus.WAITING).stream()
+                .map(OrdersDto.OrdersRes::from)
+                .toList();
+    }
+
     @Transactional
     public void addStoreItem(Long userIdx, Long ordersIdx, OrdersItemDto.OrdersItemReq req) {
         Store store = storeRepository.findByUserIdx(userIdx)
@@ -312,6 +250,24 @@ public class OrdersService {
                 .build());
 
         orders.updatePrice(orders.getPrice() + (long) product.getUnitPrice() * req.getCount());
+    }
+
+    @Transactional
+    public void updateStoreItemCount(Long userIdx, Long ordersItemIdx, Integer count) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        if (!item.getOrders().getStore().getIdx().equals(store.getIdx())) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        Orders orders = item.getOrders();
+        long priceDiff = (long) item.getProduct().getUnitPrice() * (count - item.getCount());
+        item.updateCount(count);
+        orders.updatePrice(orders.getPrice() + priceDiff);
     }
 
     @Transactional
@@ -343,12 +299,18 @@ public class OrdersService {
         ).stream().map(OrdersDto.OrdersRes::from).toList();
     }
 
-    public List<OrdersDto.OrdersRes> findByUserIdxAndOrdersStatus(Long userIdx) {
-        Store store = storeRepository.findByUserIdx(userIdx)
+    @Transactional
+    public void cancelOrder(Long ordersIdx) {
+        // 1. 발주 조회
+        Orders orders = ordersRepository.findById(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
-        return ordersRepository.findAllByStore_IdxAndOrdersStatus(store.getIdx(), OrdersStatus.WAITING).stream()
-                .map(OrdersDto.OrdersRes::from)
-                .toList();
+        // 2. CONFIRMED 상태인 경우에만 취소 가능
+        if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        // 3. 상태를 CANCELLED로 변경
+        orders.cancel();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -271,6 +271,23 @@ public class OrdersService {
     }
 
     @Transactional
+    public void deleteStoreItem(Long userIdx, Long ordersItemIdx) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        if (!item.getOrders().getStore().getIdx().equals(store.getIdx())) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        Orders orders = item.getOrders();
+        orders.updatePrice(orders.getPrice() - (long) item.getProduct().getUnitPrice() * item.getCount());
+        ordersItemRepository.delete(item);
+    }
+
+    @Transactional
     public void rejectStoreOrder(Long userIdx, Long ordersIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -190,6 +190,24 @@ public class OrdersService {
     }
 
     @Transactional
+    public void updateStoreItemCount(Long userIdx, Long ordersItemIdx, Integer count) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        if (!item.getOrders().getStore().getIdx().equals(store.getIdx())) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        Orders orders = item.getOrders();
+        long priceDiff = (long) item.getProduct().getUnitPrice() * (count - item.getCount());
+        item.updateCount(count);
+        orders.updatePrice(orders.getPrice() + priceDiff);
+    }
+
+    @Transactional
     public void deleteItem(Long ordersItemIdx) {
         OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -300,17 +300,21 @@ public class OrdersService {
     }
 
     @Transactional
-    public void cancelOrder(Long ordersIdx) {
-        // 1. 발주 조회
+    public void cancelOrder(Long userIdx, Long ordersIdx) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
         Orders orders = ordersRepository.findById(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
-        // 2. CONFIRMED 상태인 경우에만 취소 가능
+        if (!orders.getStore().getIdx().equals(store.getIdx())) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
         if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
             throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
         }
 
-        // 3. 상태를 CANCELLED로 변경
         orders.cancel();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -272,6 +272,30 @@ public class OrdersService {
         }
     }
 
+    @Transactional
+    public void addStoreItem(Long userIdx, Long ordersIdx, OrdersItemDto.OrdersItemReq req) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        Orders orders = ordersRepository.findById(ordersIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        if (!orders.getStore().getIdx().equals(store.getIdx())) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        Product product = productRepository.findById(req.getProductIdx())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        ordersItemRepository.save(OrdersItem.builder()
+                .count(req.getCount())
+                .product(product)
+                .orders(orders)
+                .build());
+
+        orders.updatePrice(orders.getPrice() + (long) product.getUnitPrice() * req.getCount());
+    }
+
     public List<OrdersDto.OrdersRes> findByUserIdx(Long userIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));


### PR DESCRIPTION
## Summary
- 점주 제안 발주서 관리에 필요한 Backend API 구현 및 기존 발주 API 정리

## 변경 파일
- `backend/.../orders/OrdersController.java`
- `backend/.../orders/OrdersService.java`

## 주요 변경 사항
- 점주 발주 품목 추가 API 구현 (`POST /orders/store/{ordersIdx}/items`)
- 점주 발주 품목 수량 수정 API 구현 (`PUT /orders/store/{ordersItemIdx}/items`)
- 점주 발주 품목 삭제 API 구현 (`DELETE /orders/store/{ordersItemIdx}/items`)
- 점주 제안 발주서 거절 API 구현 (`PUT /orders/store/{ordersIdx}/reject`)
- 발주 취소 API에 점주 인증 및 매장 소유자 검증 추가 (`PUT /orders/store/{ordersIdx}/cancel`)
- 미사용 본사 발주 품목 CRUD API 삭제 (addItem, updateItemCount, deleteItem)
- Service 메서드 순서를 Controller 호출 순서에 맞춰 정렬

## Test Plan
- [ ] 점주 로그인 후 품목 추가/수량 수정/삭제/거절/취소 API 정상 동작 확인
- [ ] 다른 매장의 발주에 대해 요청 시 권한 오류 반환 확인

## Issue
- Closes #138