### PR TITLE
[Feat] #134 - 점주 제안 발주서 확정 API 구현 

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -220,6 +220,26 @@ public class OrdersController {
     }
 
     /**
+     * 가맹점 제안 발주서 확정
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @param ordersIdx 확정할 발주의 고유 ID
+     * @return ResponseEntity 확정 결과 메시지
+     * @throws ResponseStatusException 로그인하지 않은 경우 (401)
+     */
+    @PutMapping("/store/{ordersIdx}/confirm")
+    public ResponseEntity confirmStoreOrder(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @PathVariable Long ordersIdx
+    ) {
+        if (authUserDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        orderService.confirmStoreOrder(authUserDetails.getIdx(), ordersIdx);
+        return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
+    /**
      * 가맹점 제안 발주서 항목 추가
      *
      * @param authUserDetails 인증된 사용자 정보

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -229,6 +229,25 @@ public class OrdersService {
     }
 
     @Transactional
+    public void confirmStoreOrder(Long userIdx, Long ordersIdx) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        Orders orders = ordersRepository.findById(ordersIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        if (!orders.getStore().getIdx().equals(store.getIdx())) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        if (orders.getOrdersStatus() != OrdersStatus.WAITING) {
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+
+        orders.confirm();
+    }
+
+    @Transactional
     public void addStoreItem(Long userIdx, Long ordersIdx, OrdersItemDto.OrdersItemReq req) {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));


### PR DESCRIPTION
## Summary
- 점주가 제안 발주서를 확정할 수 있는 API 구현

## 변경 파일
- `backend/.../orders/OrdersController.java`
- `backend/.../orders/OrdersService.java`

## 주요 변경 사항
- 점주 제안 발주서 확정 API 구현 (`PUT /orders/store/{ordersIdx}/confirm`)
- WAITING 상태의 발주만 확정 가능하도록 상태 검증
- 점주 인증 및 매장 소유자 검증 포함

## Test Plan
- [ ] 점주 로그인 후 WAITING 상태 발주 확정 시 CONFIRMED로 변경 확인
- [ ] 다른 매장의 발주 확정 시 권한 오류 반환 확인
- [ ] WAITING이 아닌 상태의 발주 확정 시 오류 반환 확인

## Issue
- Closes #134