### PR TITLE
[Feat] #141 - 점주 제안 발주서 거절 기능 구현

### DIFF
--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -65,6 +65,10 @@ const addStoreOrderItem = (ordersIdx, data) => {
   return api.post(`/orders/store/${ordersIdx}/items`, data)
 }
 
+const rejectStoreOrder = (ordersIdx) => {
+  return api.put(`/orders/store/${ordersIdx}/reject`)
+}
+
 export default {
   getAutoOrders,
   getOrderDetail,
@@ -82,4 +86,5 @@ export default {
   getStorePendingOrders,
   confirmStoreOrder,
   addStoreOrderItem,
+  rejectStoreOrder,
 }

--- a/frontend/src/components/orders/StoreOrderRejectModal.vue
+++ b/frontend/src/components/orders/StoreOrderRejectModal.vue
@@ -1,0 +1,51 @@
+<script setup>
+defineProps({
+  order: { type: Object, default: null },
+  visible: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['close', 'reject'])
+</script>
+
+<template>
+  <div v-if="visible" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-[2px]">
+    <div class="bg-white rounded-xl shadow-2xl w-full max-w-md overflow-hidden animate-modal-up">
+      <div class="px-6 py-4 border-b border-gray-100 flex justify-between items-center">
+        <h2 class="text-lg font-bold text-gray-900">발주서 거절</h2>
+        <button @click="emit('close')" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
+      </div>
+
+      <div class="p-6 space-y-4">
+        <p class="text-sm text-gray-500">아래 발주서를 거절하시겠습니까?</p>
+
+        <div class="bg-gray-50 rounded-lg p-4">
+          <div class="space-y-2 pb-3 border-b border-gray-200">
+            <div v-for="item in order?.ordersItemList" :key="item.idx" class="flex justify-between text-xs">
+              <span class="text-gray-500">{{ item.productName }} ({{ item.count }}개 × ₩{{ (item.unitPrice ?? 0).toLocaleString() }})</span>
+              <span class="font-medium text-gray-900">₩ {{ ((item.count || 0) * (item.unitPrice ?? 0)).toLocaleString() }}</span>
+            </div>
+          </div>
+          <div class="flex justify-between items-center pt-3">
+            <span class="text-sm font-bold text-gray-900">합계</span>
+            <span class="text-lg font-black text-red-500">₩ {{ (order?.price ?? 0).toLocaleString() }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="px-6 py-4 bg-gray-50 flex gap-2">
+        <button @click="emit('close')" class="flex-1 py-3 bg-white border border-gray-200 text-gray-600 font-bold rounded-lg text-sm cursor-pointer">취소</button>
+        <button @click="emit('reject')" class="flex-1 py-3 bg-red-500 text-white font-bold rounded-lg text-sm cursor-pointer">거절</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.animate-modal-up {
+  animation: modalUp 0.3s ease-out;
+}
+@keyframes modalUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+</style>

--- a/frontend/src/components/orders/StorePendingOrderList.vue
+++ b/frontend/src/components/orders/StorePendingOrderList.vue
@@ -30,7 +30,7 @@ const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, cl
             + 품목 추가
           </button>
           <button @click="emit('reject', order)"
-            class="px-4 py-2 border border-gray-200 text-gray-600 text-sm font-semibold hover:bg-gray-50 rounded-lg cursor-pointer">
+            class="px-4 py-2 border border-red-200 text-red-500 bg-red-50 text-sm font-semibold hover:bg-red-100 rounded-lg cursor-pointer">
             거절
           </button>
         </div>

--- a/frontend/src/views/store/StoreOrderManageView.vue
+++ b/frontend/src/views/store/StoreOrderManageView.vue
@@ -6,11 +6,13 @@ import StoreOrderHistoryTable from '@/components/orders/StoreOrderHistoryTable.v
 import StoreOrderDetailModal from '@/components/orders/StoreOrderDetailModal.vue'
 import StorePendingOrderList from '@/components/orders/StorePendingOrderList.vue'
 import StoreOrderConfirmModal from '@/components/orders/StoreOrderConfirmModal.vue'
+import StoreOrderRejectModal from '@/components/orders/StoreOrderRejectModal.vue'
 import ordersApi from '@/api/orders'
 
 const activeTab = ref('pending')
 const selectedOrder = ref(null)
 const isConfirmModalOpen = ref(false)
+const isRejectModalOpen = ref(false)
 
 const pendingOrders = ref([])
 const orderHistory = ref([])
@@ -74,15 +76,21 @@ async function confirmOrder() {
   }
 }
 
-async function rejectOrder(order) {
-  if (!confirm('발주서를 거절하시겠습니까?')) return
+function openRejectModal(order) {
+  selectedOrder.value = order
+  isRejectModalOpen.value = true
+}
+
+async function rejectOrder() {
+  const order = selectedOrder.value
   try {
     await ordersApi.rejectStoreOrder(order.idx)
     const idx = pendingOrders.value.indexOf(order)
     if (idx > -1) pendingOrders.value.splice(idx, 1)
+    isRejectModalOpen.value = false
     alert('발주서가 거절되었습니다.')
   } catch (e) {
-    console.error('발주서 거�� 실패', e)
+    console.error('발주서 거절 실패', e)
     alert('발주서 거절에 실패했습니다.')
   }
 }
@@ -137,7 +145,7 @@ async function submitManualOrder(data) {
     </div>
 
     <StorePendingOrderList v-if="activeTab === 'pending'" :orders="pendingOrders"
-      @confirm="openConfirmModal" @reject="rejectOrder" @refresh="fetchPendingOrders" />
+      @confirm="openConfirmModal" @reject="openRejectModal" @refresh="fetchPendingOrders" />
 
     <StoreOrderHistoryTable v-if="activeTab === 'history'" :orders="orderHistory"
       @open-detail="openHistoryDetail" @cancel="cancelOrder" />
@@ -146,6 +154,9 @@ async function submitManualOrder(data) {
 
     <StoreOrderConfirmModal :order="selectedOrder" :visible="isConfirmModalOpen"
       @close="isConfirmModalOpen = false" @confirm="confirmOrder" />
+
+    <StoreOrderRejectModal :order="selectedOrder" :visible="isRejectModalOpen"
+      @close="isRejectModalOpen = false" @reject="rejectOrder" />
 
     <StoreManualOrderModal :visible="showManualForm" @close="showManualForm = false" @submit="submitManualOrder" />
   </div>

--- a/frontend/src/views/store/StoreOrderManageView.vue
+++ b/frontend/src/views/store/StoreOrderManageView.vue
@@ -74,10 +74,16 @@ async function confirmOrder() {
   }
 }
 
-function rejectOrder(order) {
-  if (confirm('발주서를 거절하시겠습니까?')) {
+async function rejectOrder(order) {
+  if (!confirm('발주서를 거절하시겠습니까?')) return
+  try {
+    await ordersApi.rejectStoreOrder(order.idx)
     const idx = pendingOrders.value.indexOf(order)
-    pendingOrders.value.splice(idx, 1)
+    if (idx > -1) pendingOrders.value.splice(idx, 1)
+    alert('발주서가 거절되었습니다.')
+  } catch (e) {
+    console.error('발주서 거�� 실패', e)
+    alert('발주서 거절에 실패했습니다.')
   }
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 제안 발주서 거절 기능 프론트엔드 구현 및 백엔드 연동

## 변경 파일
- frontend/src/api/orders/index.js
- frontend/src/components/orders/StoreOrderRejectModal.vue (신규)
- frontend/src/components/orders/StorePendingOrderList.vue
- frontend/src/views/store/StoreOrderManageView.vue

## 주요 변경 사항
- rejectStoreOrder API 함수 추가 (PUT /orders/store/{ordersIdx}/reject)
- StoreOrderRejectModal 컴포넌트 추가 (품목 목록 확인 후 거절)
- confirm() 대신 모달 방식으로 UX 개선
- 거절 버튼 스타일을 빨간색 계열로 변경

## Test Plan
- [ ] 제안 발주서 거절 버튼 클릭 → 모달에서 품목 목록 확인
- [ ] 모달 거절 버튼 클릭 → 발주서 상태 변경 및 목록에서 제거 확인
- [ ] 모달 취소 버튼 클릭 → 모달 닫힘 확인

## Issue
- Closes #141