### PR TITLE
[Feat] #139 - 점주 제안 발주서 품목 수정/삭제 기능 구현

### DIFF
--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -69,6 +69,14 @@ const rejectStoreOrder = (ordersIdx) => {
   return api.put(`/orders/store/${ordersIdx}/reject`)
 }
 
+const updateStoreItemCount = (ordersItemIdx, data) => {
+  return api.put(`/orders/store/${ordersItemIdx}/items`, data)
+}
+
+const deleteStoreItem = (ordersItemIdx) => {
+  return api.delete(`/orders/store/${ordersItemIdx}/items`)
+}
+
 export default {
   getAutoOrders,
   getOrderDetail,
@@ -87,4 +95,6 @@ export default {
   confirmStoreOrder,
   addStoreOrderItem,
   rejectStoreOrder,
+  updateStoreItemCount,
+  deleteStoreItem,
 }

--- a/frontend/src/components/orders/StorePendingOrderList.vue
+++ b/frontend/src/components/orders/StorePendingOrderList.vue
@@ -6,7 +6,7 @@ const props = defineProps({
   orders: { type: Array, required: true },
 })
 
-const emit = defineEmits(['confirm', 'reject', 'refresh'])
+const emit = defineEmits(['confirm', 'reject', 'refresh', 'delete-item'])
 
 const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, clearAddItemProduct, submitAddItem } = useAddOrderItem(() => emit('refresh'))
 </script>
@@ -37,10 +37,11 @@ const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, cl
       </div>
       <table class="w-full text-sm table-fixed">
         <colgroup>
-          <col class="w-[40%]" />
-          <col class="w-[15%]" />
-          <col class="w-[20%]" />
-          <col class="w-[25%]" />
+          <col class="w-[35%]" />
+          <col class="w-[12%]" />
+          <col class="w-[18%]" />
+          <col class="w-[22%]" />
+          <col class="w-[13%]" />
         </colgroup>
         <thead>
           <tr class="border-b border-gray-200 bg-gray-50">
@@ -48,6 +49,7 @@ const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, cl
             <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">수량</th>
             <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">단가</th>
             <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">금액</th>
+            <th class="px-3 py-3"></th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
@@ -57,6 +59,12 @@ const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, cl
             <td class="px-5 py-3.5 text-gray-500">₩ {{ (item.unitPrice ?? 0).toLocaleString() }}</td>
             <td class="px-5 py-3.5 text-right font-semibold text-gray-700">
               ₩ {{ ((item.count || 0) * (item.unitPrice ?? 0)).toLocaleString() }}
+            </td>
+            <td class="px-3 py-3.5 text-center">
+              <button @click="emit('delete-item', order, item)"
+                class="px-2 py-1 text-xs font-semibold text-red-500 border border-red-200 bg-red-50 rounded-lg hover:bg-red-100 cursor-pointer">
+                삭제
+              </button>
             </td>
           </tr>
           <tr v-if="addItemForm?.ordersIdx === order.idx" class="bg-blue-50/50 border-t border-blue-100">
@@ -94,6 +102,7 @@ const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, cl
                 </button>
               </div>
             </td>
+            <td></td>
           </tr>
         </tbody>
         <tfoot class="border-t border-gray-200 bg-gray-50/60">
@@ -103,6 +112,7 @@ const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, cl
             <td class="px-5 py-3 text-right font-black text-blue-600">
               ₩ {{ (order.price ?? 0).toLocaleString() }}
             </td>
+            <td></td>
           </tr>
         </tfoot>
       </table>

--- a/frontend/src/components/orders/StorePendingOrderList.vue
+++ b/frontend/src/components/orders/StorePendingOrderList.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ClipboardList } from 'lucide-vue-next'
 import { useAddOrderItem } from '@/composables/useAddOrderItem'
+import ordersApi from '@/api/orders'
 
 const props = defineProps({
   orders: { type: Array, required: true },
@@ -9,6 +10,22 @@ const props = defineProps({
 const emit = defineEmits(['confirm', 'reject', 'refresh', 'delete-item'])
 
 const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, clearAddItemProduct, submitAddItem } = useAddOrderItem(() => emit('refresh'))
+
+let debounceTimer = null
+
+function onCountChange(item) {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(async () => {
+    if (item.count < 1) { item.count = 1 }
+    try {
+      await ordersApi.updateStoreItemCount(item.idx, { count: item.count })
+    } catch (e) {
+      console.error('수량 수정 실패', e)
+      alert('수량 수정에 실패했습니다.')
+      emit('refresh')
+    }
+  }, 500)
+}
 </script>
 
 <template>
@@ -55,7 +72,11 @@ const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, cl
         <tbody class="divide-y divide-gray-100">
           <tr v-for="item in order.ordersItemList" :key="item.idx" class="hover:bg-gray-50/50">
             <td class="px-5 py-3.5 font-semibold text-gray-900">{{ item.productName }}</td>
-            <td class="px-5 py-3.5 font-semibold text-blue-600">{{ item.count }}</td>
+            <td class="px-5 py-3.5 font-semibold text-blue-600">
+              <input v-model.number="item.count" type="number" min="1"
+                @input="onCountChange(item)"
+                class="w-16 px-2 py-1 rounded-lg border border-gray-200 text-sm outline-none focus:border-blue-400" />
+            </td>
             <td class="px-5 py-3.5 text-gray-500">₩ {{ (item.unitPrice ?? 0).toLocaleString() }}</td>
             <td class="px-5 py-3.5 text-right font-semibold text-gray-700">
               ₩ {{ ((item.count || 0) * (item.unitPrice ?? 0)).toLocaleString() }}

--- a/frontend/src/components/orders/StorePendingOrderList.vue
+++ b/frontend/src/components/orders/StorePendingOrderList.vue
@@ -3,7 +3,7 @@ import { ClipboardList } from 'lucide-vue-next'
 import { useAddOrderItem } from '@/composables/useAddOrderItem'
 import ordersApi from '@/api/orders'
 
-const props = defineProps({
+defineProps({
   orders: { type: Array, required: true },
 })
 

--- a/frontend/src/views/store/StoreOrderManageView.vue
+++ b/frontend/src/views/store/StoreOrderManageView.vue
@@ -95,6 +95,17 @@ async function rejectOrder() {
   }
 }
 
+async function deleteItem(order, item) {
+  if (!confirm(`"${item.productName}" 품목을 삭제하시겠습니까?`)) return
+  try {
+    await ordersApi.deleteStoreItem(item.idx)
+    fetchPendingOrders()
+  } catch (e) {
+    console.error('품목 삭제 실패', e)
+    alert('품목 삭제에 실패했습니다.')
+  }
+}
+
 async function cancelOrder(order) {
   if (!confirm('발주를 취소하시겠습니까?')) return
   try {
@@ -145,7 +156,8 @@ async function submitManualOrder(data) {
     </div>
 
     <StorePendingOrderList v-if="activeTab === 'pending'" :orders="pendingOrders"
-      @confirm="openConfirmModal" @reject="openRejectModal" @refresh="fetchPendingOrders" />
+      @confirm="openConfirmModal" @reject="openRejectModal" @refresh="fetchPendingOrders"
+      @delete-item="deleteItem" />
 
     <StoreOrderHistoryTable v-if="activeTab === 'history'" :orders="orderHistory"
       @open-detail="openHistoryDetail" @cancel="cancelOrder" />


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 제안 발주서의 품목 수량 수정 및 삭제 기능 프론트엔드 구현

## 변경 파일
- frontend/src/api/orders/index.js
- frontend/src/components/orders/StorePendingOrderList.vue
- frontend/src/views/store/StoreOrderManageView.vue

## 주요 변경 사항
- updateStoreItemCount, deleteStoreItem API 함수 추가
- 품목 수량을 인라인 input으로 표시하여 바로 수정 가능
- 수량 변경 시 디바운싱(500ms) 적용하여 API 호출
- 품목 테이블 오른쪽에 삭제 버튼 추가
- 미사용 props 변수 정리

## Test Plan
- [ ] 품목 수량 input 변경 → 디바운싱 후 API 호출 확인
- [ ] 품목 삭제 버튼 클릭 → confirm 후 삭제 및 목록 갱신 확인
- [ ] 수량 1 미만 입력 시 1로 보정되는지 확인

## Issue
- Closes #139