### PR TITLE
[Fix] 점주 발주 취소 API 경로 수정

### DIFF
--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -21,7 +21,7 @@ const createStoreManualOrder = (data) => {
 }
 
 const cancelOrder = (ordersIdx) => {
-  return api.put(`/orders/${ordersIdx}/cancel`)
+  return api.put(`/orders/store/${ordersIdx}/cancel`)
 }
 
 const getOrderHistory = (params = {}) => {


### PR DESCRIPTION
## Summary
- 점주 발주 취소 API 호출 경로가 백엔드 endpoint와 불일치하여 404 에러 발생하는 버그 수정

## 변경 파일
- `frontend/src/api/orders/index.js`

## 주요 변경 사항
- cancelOrder 함수의 API 경로를 `/orders/{id}/cancel`에서 `/orders/store/{id}/cancel`로 수정

## Test Plan
- [ ] 점주 페이지에서 확정 발주 취소 버튼 클릭 시 정상 동작 확인
- [ ] 취소 후 발주 상태가 CANCELLED로 변경되는지 확인
