### PR TITLE
[feat] #56 - 메뉴 조회 (BACKEND)

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuCategoryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.nexus.domain.menu;
+
+import com.example.nexus.domain.menu.model.MenuCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuCategoryRepository extends JpaRepository<MenuCategory, Long> {
+}

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuController.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuController.java
@@ -1,12 +1,25 @@
 package com.example.nexus.domain.menu;
 
+import com.example.nexus.common.model.BaseEntity;
+import com.example.nexus.common.model.BaseResponse;
+import com.example.nexus.domain.menu.model.MenuDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RequestMapping("/menu")
 @RestController
 @RequiredArgsConstructor
 public class MenuController {
     private final MenuService menuService;
+
+    @GetMapping("/list")
+    public ResponseEntity list(){
+        List<MenuDto.MenuListRes> result =  menuService.list();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuController.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuController.java
@@ -1,16 +1,11 @@
 package com.example.nexus.domain.menu;
 
-import com.example.nexus.common.model.BaseEntity;
 import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.domain.menu.model.MenuDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RequestMapping("/menu")
 @RestController
@@ -18,12 +13,21 @@ import java.util.List;
 public class MenuController {
     private final MenuService menuService;
 
+    // 메뉴 리스트 조회
     @GetMapping("/list")
     public ResponseEntity list(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size)
     {
         MenuDto.MenuPageRes result =  menuService.list(page, size);
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+
+    // 메뉴 재료 조회
+    @GetMapping("/item/list/{menuIdx}")
+    public ResponseEntity menuItemList(@PathVariable Long menuIdx){
+        MenuDto.MenuItemListRes result = menuService.menuItemList(menuIdx);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuController.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuController.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RequestMapping("/menu")
 @RestController
@@ -28,6 +30,14 @@ public class MenuController {
     @GetMapping("/item/list/{menuIdx}")
     public ResponseEntity menuItemList(@PathVariable Long menuIdx){
         MenuDto.MenuItemListRes result = menuService.menuItemList(menuIdx);
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+
+    // 메뉴 카테고리 조회
+    @GetMapping("/category/list")
+    public ResponseEntity menuCategory(){
+        List<MenuDto.MenuCategoryRes> result =  menuService.menucategory();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuController.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -18,8 +19,11 @@ public class MenuController {
     private final MenuService menuService;
 
     @GetMapping("/list")
-    public ResponseEntity list(){
-        List<MenuDto.MenuListRes> result =  menuService.list();
+    public ResponseEntity list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size)
+    {
+        MenuDto.MenuPageRes result =  menuService.list(page, size);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -6,9 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +18,15 @@ public class MenuService {
         Page<Menu> result = menuRepository.findAll(pageRequest);
 
         return MenuDto.MenuPageRes.from(result);
+    }
+
+    public MenuDto.MenuItemListRes menuItemList(Long menuIdx) {
+        Optional<Menu> res = menuRepository.findById(menuIdx);
+
+        if(res.isPresent()){
+            Menu menu = res.get();
+            return MenuDto.MenuItemListRes.from(menu);
+        }
+        return null;
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -1,17 +1,22 @@
 package com.example.nexus.domain.menu;
 
 import com.example.nexus.domain.menu.model.Menu;
+import com.example.nexus.domain.menu.model.MenuCategory;
 import com.example.nexus.domain.menu.model.MenuDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class MenuService {
     private final MenuRepository menuRepository;
+    private final MenuCategoryRepository menuCategoryRepository;
 
     public MenuDto.MenuPageRes list(int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
@@ -28,5 +33,15 @@ public class MenuService {
             return MenuDto.MenuItemListRes.from(menu);
         }
         return null;
+    }
+
+    public List<MenuDto.MenuCategoryRes> menucategory() {
+        List<MenuCategory> res = menuCategoryRepository.findAll();
+        List<MenuDto.MenuCategoryRes> result = new ArrayList<>();
+
+        for (MenuCategory data: res){
+            result.add(MenuDto.MenuCategoryRes.from(data));
+        }
+        return result;
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -3,6 +3,8 @@ package com.example.nexus.domain.menu;
 import com.example.nexus.domain.menu.model.Menu;
 import com.example.nexus.domain.menu.model.MenuDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -13,13 +15,10 @@ import java.util.List;
 public class MenuService {
     private final MenuRepository menuRepository;
 
-    public List<MenuDto.MenuListRes> list() {
-        List<Menu> res = menuRepository.findAll();
-        List<MenuDto.MenuListRes> result = new ArrayList<>();
+    public MenuDto.MenuPageRes list(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<Menu> result = menuRepository.findAll(pageRequest);
 
-        for(Menu data : res){
-            result.add(MenuDto.MenuListRes.from(data));
-        }
-        return result;
+        return MenuDto.MenuPageRes.from(result);
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -1,10 +1,25 @@
 package com.example.nexus.domain.menu;
 
+import com.example.nexus.domain.menu.model.Menu;
+import com.example.nexus.domain.menu.model.MenuDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MenuService {
     private final MenuRepository menuRepository;
+
+    public List<MenuDto.MenuListRes> list() {
+        List<Menu> res = menuRepository.findAll();
+        List<MenuDto.MenuListRes> result = new ArrayList<>();
+
+        for(Menu data : res){
+            result.add(MenuDto.MenuListRes.from(data));
+        }
+        return result;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/Menu.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/Menu.java
@@ -32,4 +32,7 @@ public class Menu {
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 
+    @OneToMany(mappedBy = "menu")
+    private List<MenuItem> menuItemList = new ArrayList<>();
+
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/Menu.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/Menu.java
@@ -35,4 +35,7 @@ public class Menu {
     @OneToMany(mappedBy = "menu")
     private List<MenuItem> menuItemList = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_category_idx")
+    private MenuCategory menuCategory;
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/Menu.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/Menu.java
@@ -1,6 +1,5 @@
 package com.example.nexus.domain.menu.model;
 
-import com.example.nexus.domain.store.model.Store;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/MenuCategory.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/MenuCategory.java
@@ -1,8 +1,15 @@
 package com.example.nexus.domain.menu.model;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "menu_category")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class MenuCategory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -13,5 +20,5 @@ public class MenuCategory {
     private String menuCategoryName;
 
     @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted;
+    private boolean isDeleted = false;
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/MenuCategory.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/MenuCategory.java
@@ -1,0 +1,17 @@
+package com.example.nexus.domain.menu.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class MenuCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "menu_category_idx")
+    private Long idx;
+
+    @Column(name = "menu_category_name", nullable = false, unique = true)
+    private String menuCategoryName;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+}

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
@@ -44,7 +44,7 @@ public class MenuDto {
 
         public static MenuPageRes from(Page<Menu> entity){
             return MenuPageRes.builder()
-                    .menuList(entity.get().map(MenuDto.MenuListRes::from).toList())
+                    .menuList(entity.map(MenuDto.MenuListRes::from).getContent())
                     .totalPage(entity.getTotalPages())
                     .totalCount(entity.getTotalElements())
                     .currentPage(entity.getPageable().getPageNumber())

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
@@ -2,6 +2,9 @@ package com.example.nexus.domain.menu.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 public class MenuDto {
 
@@ -22,6 +25,26 @@ public class MenuDto {
                     .price(entity.getPrice())
                     .menuCategory(entity.getMenuCategory().getMenuCategoryName())
                     .menuItemCount(entity.getMenuItemList().size())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class MenuPageRes{
+        private List<MenuListRes> menuList;
+        private int totalPage;
+        private long totalCount;
+        private int currentPage;
+        private int currentSize;
+
+        public static MenuPageRes from(Page<Menu> entity){
+            return MenuPageRes.builder()
+                    .menuList(entity.get().map(MenuDto.MenuListRes::from).toList())
+                    .totalPage(entity.getTotalPages())
+                    .totalCount(entity.getTotalElements())
+                    .currentPage(entity.getPageable().getPageNumber())
+                    .currentSize(entity.getPageable().getPageSize())
                     .build();
         }
     }

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
@@ -1,0 +1,26 @@
+package com.example.nexus.domain.menu.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class MenuDto {
+
+    @Builder
+    @Getter
+    public static class MenuListRes{
+        private Long idx;
+        private String menuName;
+        private Integer price;
+        private Integer menuItemCount;
+
+
+        public static MenuDto.MenuListRes from(Menu entity){
+            return MenuListRes.builder()
+                    .idx(entity.getIdx())
+                    .menuName(entity.getMenuName())
+                    .price(entity.getPrice())
+                    .menuItemCount(entity.getMenuItemList().size())
+                    .build();
+        }
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
@@ -11,6 +11,7 @@ public class MenuDto {
         private Long idx;
         private String menuName;
         private Integer price;
+        private String menuCategory;
         private Integer menuItemCount;
 
 
@@ -19,6 +20,7 @@ public class MenuDto {
                     .idx(entity.getIdx())
                     .menuName(entity.getMenuName())
                     .price(entity.getPrice())
+                    .menuCategory(entity.getMenuCategory().getMenuCategoryName())
                     .menuItemCount(entity.getMenuItemList().size())
                     .build();
         }

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
@@ -1,10 +1,14 @@
 package com.example.nexus.domain.menu.model;
 
+import com.example.nexus.domain.product.model.Product;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class MenuDto {
 
@@ -45,6 +49,50 @@ public class MenuDto {
                     .totalCount(entity.getTotalElements())
                     .currentPage(entity.getPageable().getPageNumber())
                     .currentSize(entity.getPageable().getPageSize())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class ItemList{
+        private Long idx;
+        private String productName;
+        private Integer quantity;
+        private String menuUnit;
+
+
+        public static ItemList from(MenuItem entity){
+            return ItemList.builder()
+                    .idx(entity.getIdx())
+                    .productName(entity.getProduct().getProductName())
+                    .quantity(entity.getQuantity())
+                    .menuUnit(entity.getMenuUnit())
+                    .build();
+        }
+
+    }
+
+    @Getter
+    @Builder
+    public static class MenuItemListRes{
+        private Long idx;
+        private String menuName;
+        private String menuCategory;
+        private Integer price;
+        private String imgPath;
+        private List<ItemList> menuItemList;
+
+        public static MenuDto.MenuItemListRes from(Menu entity){
+            return MenuItemListRes.builder()
+                    .idx(entity.getIdx())
+                    .menuName(entity.getMenuName())
+                    .menuCategory(entity.getMenuCategory().getMenuCategoryName())
+                    .price(entity.getPrice())
+                    .imgPath(entity.getImgPath())
+                    .menuItemList(entity.getMenuItemList().stream()
+                            .map(ItemList::from)
+                            .collect(Collectors.toList()))
                     .build();
         }
     }

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
@@ -1,12 +1,9 @@
 package com.example.nexus.domain.menu.model;
 
-import com.example.nexus.domain.product.model.Product;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,6 +30,7 @@ public class MenuDto {
         }
     }
 
+    // 메뉴 페이징 조회
     @Getter
     @Builder
     public static class MenuPageRes{
@@ -73,6 +71,7 @@ public class MenuDto {
 
     }
 
+    // 메뉴 재료 조회
     @Getter
     @Builder
     public static class MenuItemListRes{
@@ -93,6 +92,19 @@ public class MenuDto {
                     .menuItemList(entity.getMenuItemList().stream()
                             .map(ItemList::from)
                             .collect(Collectors.toList()))
+                    .build();
+        }
+    }
+
+    // 카테고리 조회
+    @Getter
+    @Builder
+    public static class MenuCategoryRes{
+        private String menuCategoryName;
+
+        public static MenuDto.MenuCategoryRes from(MenuCategory entity){
+            return MenuCategoryRes.builder()
+                    .menuCategoryName(entity.getMenuCategoryName())
                     .build();
         }
     }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -56,9 +56,6 @@ INSERT INTO store (user_idx, store_name, address, address_detail, file_path, bus
 (7, '더벤티 잠실점', '서울특별시 송파구 올림픽로 240', '1층', '/uploads/store/jamsil.jpg', '567-89-01234', 05554, '2024-04-20 09:00:00', NULL, false);
 
 
-
-
-
 -- ============================================================
 -- 3. Category (원자재 카테고리)
 -- ============================================================
@@ -113,27 +110,45 @@ INSERT INTO product (category_idx, product_name, product_unit, max_stock, min_st
 (7, '연유', 'kg', 10, 2, 8000, '30', false);
 
 -- ============================================================
--- 5. Menu (더벤티 대표 메뉴)
+-- 5. MenuCategoryItem (메뉴별 원자재 레시피)
 -- ============================================================
-INSERT INTO menu (menu_name, price, img_path, is_deleted) VALUES
-('아메리카노', 1500, '/uploads/menu/americano.jpg', false),
-('카페라떼', 2500, '/uploads/menu/cafelatte.jpg', false),
-('바닐라라떼', 3000, '/uploads/menu/vanillalatte.jpg', false),
-('카라멜마끼아또', 3500, '/uploads/menu/caramelmacchiato.jpg', false),
-('카푸치노', 2500, '/uploads/menu/cappuccino.jpg', false),
-('딸기스무디', 3500, '/uploads/menu/strawberrysmoothie.jpg', false),
-('망고스무디', 3500, '/uploads/menu/mangosmoothie.jpg', false),
-('복숭아아이스티', 2500, '/uploads/menu/peachicedtea.jpg', false),
-('레몬에이드', 2500, '/uploads/menu/lemonade.jpg', false),
-('자몽에이드', 3000, '/uploads/menu/grapefruitade.jpg', false),
-('녹차라떼', 3000, '/uploads/menu/greentealatte.jpg', false),
-('초코라떼', 3000, '/uploads/menu/chocolatte.jpg', false),
-('얼그레이티', 2000, '/uploads/menu/earlgrey.jpg', false),
-('캐모마일티', 2000, '/uploads/menu/chamomile.jpg', false),
-('히비스커스티', 2000, '/uploads/menu/hibiscus.jpg', false);
+INSERT INTO menu_category (menu_category_name, is_deleted) VALUES
+('커피', false),
+('베버리지', false),
+('아이스블렌디드', false),
+('티 & 에이드', false);
 
 -- ============================================================
--- 6. MenuItem (메뉴별 원자재 레시피)
+-- 6. Menu (더벤티 대표 메뉴)
+-- ============================================================
+INSERT INTO menu (menu_name, price, img_path, is_deleted, menu_category_idx) VALUES
+-- 커피 (idx: 1)
+('아메리카노', 1500, '/uploads/menu/americano.jpg', false, 1),
+('카페라떼', 2500, '/uploads/menu/cafelatte.jpg', false, 1),
+('바닐라라떼', 3000, '/uploads/menu/vanillalatte.jpg', false, 1),
+('카라멜마끼아또', 3500, '/uploads/menu/caramelmacchiato.jpg', false, 1),
+('카푸치노', 2500, '/uploads/menu/cappuccino.jpg', false, 1),
+
+-- 베버리지 (idx: 2)
+('녹차라떼', 3000, '/uploads/menu/greentealatte.jpg', false, 2),
+('초코라떼', 3000, '/uploads/menu/chocolatte.jpg', false, 2),
+
+-- 아이스블렌디드 (idx: 3)
+('딸기스무디', 3500, '/uploads/menu/strawberrysmoothie.jpg', false, 3),
+('망고스무디', 3500, '/uploads/menu/mangosmoothie.jpg', false, 3),
+
+-- 티 & 에이드 (idx: 4)
+('복숭아아이스티', 2500, '/uploads/menu/peachicedtea.jpg', false, 4),
+('레몬에이드', 2500, '/uploads/menu/lemonade.jpg', false, 4),
+('자몽에이드', 3000, '/uploads/menu/grapefruitade.jpg', false, 4),
+('얼그레이티', 2000, '/uploads/menu/earlgrey.jpg', false, 4),
+('캐모마일티', 2000, '/uploads/menu/chamomile.jpg', false, 4),
+('히비스커스티', 2000, '/uploads/menu/hibiscus.jpg', false, 4);
+
+
+
+-- ============================================================
+-- 7. MenuItem (메뉴별 원자재 레시피)
 -- ============================================================
 INSERT INTO menu_item (menu_idx, product_idx, quantity, menu_unit) VALUES
 -- 아메리카노: 원두 20g, 얼음 200g, 라지컵 1개
@@ -209,13 +224,13 @@ INSERT INTO menu_item (menu_idx, product_idx, quantity, menu_unit) VALUES
 (15, 22, 1, 'ea');
 
 -- ============================================================
--- 7. Danger (위험 발주 설정)
+-- 8. Danger (위험 발주 설정)
 -- ============================================================
 INSERT INTO danger (ratio, period) VALUES
 (30, 7);
 
 -- ============================================================
--- 8. HeadInventory (본사 재고)
+--9. HeadInventory (본사 재고)
 -- ============================================================
 INSERT INTO head_inventory (product_idx, count, status, manufactured_date) VALUES
 (1, 500, 'NORMAL', '2026-04-20 08:00:00'),
@@ -249,7 +264,7 @@ INSERT INTO head_inventory (product_idx, count, status, manufactured_date) VALUE
 (29, 50, 'NORMAL', '2026-04-10 08:00:00');
 
 -- ============================================================
--- 9. StoreInventory (가맹점 재고 - 5개 매장)
+-- 10. StoreInventory (가맹점 재고 - 5개 매장)
 -- ============================================================
 -- 강남역점 (store 1) - 재고 넉넉
 INSERT INTO store_inventory (store_idx, product_idx, count, status, manufactured_date, avg_stock) VALUES
@@ -356,7 +371,7 @@ INSERT INTO store_inventory (store_idx, product_idx, count, status, manufactured
 (5, 27, 130, 'NORMAL', '2026-04-29 05:00:00', 110);
 
 -- ============================================================
--- 10. PosStoreInventory (POS 재고 — store_inventory와 동일 행, avg_stock 제외)
+-- 11. PosStoreInventory (POS 재고 — store_inventory와 동일 행, avg_stock 제외)
 -- ============================================================
 INSERT INTO pos_store_inventory (store_idx, product_idx, count, status, manufactured_date) VALUES
 (1, 1, 20, 'NORMAL', '2026-04-25 08:00:00'),
@@ -450,7 +465,7 @@ INSERT INTO pos_store_inventory (store_idx, product_idx, count, status, manufact
 (5, 27, 130, 'NORMAL', '2026-04-29 05:00:00');
 
 -- ============================================================
--- 11. Orders (발주서)
+-- 12. Orders (발주서)
 -- ============================================================
 -- 강남역점 발주 (승인 완료)
 INSERT INTO orders (store_idx, price, order_type, order_status, is_danger, created_at) VALUES
@@ -547,7 +562,7 @@ INSERT INTO orders (store_idx, price, order_type, order_status, is_danger, creat
 (1, 126500, 'AUTO', 'WAITING', false, '2026-05-02 07:00:00');
 
 -- ============================================================
--- 12. OrdersItem (발주 항목)
+-- 13. OrdersItem (발주 항목)
 -- ============================================================
 -- 강남역점 1차 발주 (orders 1): 원두, 우유, 시럽
 INSERT INTO orders_item (orders_idx, product_idx, count) VALUES
@@ -767,7 +782,7 @@ INSERT INTO orders_item (orders_idx, product_idx, count) VALUES
 (36, 18, 3);
 
 -- ============================================================
--- 13. Delivery (배송)
+-- 14. Delivery (배송)
 -- ============================================================
 INSERT INTO delivery (orders_idx, delivery_status, delay_reason, dep_date, est_des_date, deliveryed_date) VALUES
 -- 강남역점 1차: 배송완료
@@ -802,7 +817,7 @@ INSERT INTO delivery (orders_idx, delivery_status, delay_reason, dep_date, est_d
 (34, 'DELIVERED', NULL, '2026-04-15 14:00:00', '2026-04-16 10:00:00', '2026-04-16 10:15:00');
 
 -- ============================================================
--- 14. PosPay (POS 결제 - 최근 매출 데이터)
+-- 15. PosPay (POS 결제 - 최근 매출 데이터)
 -- ============================================================
 -- 강남역점 4/28 매출
 INSERT INTO pos_pay (store_idx, method, paid_at, pay_amount) VALUES
@@ -893,7 +908,7 @@ INSERT INTO pos_pay (store_idx, method, paid_at, pay_amount) VALUES
 (5, 'CARD', '2026-04-28 19:30:00', 3000);
 
 -- ============================================================
--- 15. PosOrdersItem (POS 주문 항목 - 일부 결제건)
+-- 16. PosOrdersItem (POS 주문 항목 - 일부 결제건)
 -- ============================================================
 -- 강남역점 4/28 첫 주문: 아메리카노 1잔
 INSERT INTO pos_orders_item (pos_pay_idx, menu_idx, quantity) VALUES
@@ -952,7 +967,7 @@ INSERT INTO pos_orders_item (pos_pay_idx, menu_idx, quantity) VALUES
 (30, 9, 1);
 
 -- ============================================================
--- 16. WasteLog (폐기 기록)
+-- 17. WasteLog (폐기 기록)
 -- ============================================================
 INSERT INTO waste_log (store_idx, product_idx, quantity, amount_loss, waste_date, waste_reason) VALUES
 -- 강남역점
@@ -977,7 +992,7 @@ INSERT INTO waste_log (store_idx, product_idx, quantity, amount_loss, waste_date
 (5, 5, 2, 9000, '2026-04-26 22:00:00', '유통기한 만료');
 
 -- ============================================================
--- 17. News (뉴스 요약 - AI 생성)
+-- 18. News (뉴스 요약 - AI 생성)
 -- ============================================================
 INSERT INTO news_summary (store_idx, summary_date, target, summary_title, summary_contents, url, category) VALUES
 -- 본사 대상 뉴스 (store_idx NULL)
@@ -1022,7 +1037,7 @@ INSERT INTO news_summary (store_idx, summary_date, target, summary_title, summar
 'https://example.com/news/jamsil-lotteworld', 'LOCAL_EVENT');
 
 -- ============================================================
--- 18. HeadIncome (본사 수익)
+-- 19. HeadIncome (본사 수익)
 -- ============================================================
 INSERT INTO head_income (store_idx, orders_idx, price, status) VALUES
 (1, 1, 310000, true),
@@ -1050,7 +1065,7 @@ INSERT INTO head_income (store_idx, orders_idx, price, status) VALUES
 (3, 34, 110500, true);
 
 -- ============================================================
--- 19. HeadNotification (본사 알림)
+-- 20. HeadNotification (본사 알림)
 -- ============================================================
 INSERT INTO head_notification (type, is_read, created_at) VALUES
 ('CRITICAL', true, '2026-04-22 07:05:00'),
@@ -1062,7 +1077,7 @@ INSERT INTO head_notification (type, is_read, created_at) VALUES
 ('ABNORMAL', false, '2026-04-29 07:05:00');
 
 -- ============================================================
--- 20. StoreNotification (가맹점 알림)
+-- 21. StoreNotification (가맹점 알림)
 -- ============================================================
 INSERT INTO store_notification (store_idx, type, is_read, created_at) VALUES
 -- 강남역점
@@ -1093,7 +1108,7 @@ INSERT INTO store_notification (store_idx, type, is_read, created_at) VALUES
 (5, 'REJECT', true, '2026-04-25 10:00:00');
 
 -- ============================================================
--- 21. Report (리포트)
+-- 22. Report (리포트)
 -- ============================================================
 INSERT INTO report (report_title, report_file_path, created_at) VALUES
 ('2026년 3월 월간 매출 리포트', '/uploads/report/monthly_sales_202603.pdf', '2026-04-01 09:00:00'),

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -37,3 +37,5 @@ __screenshots__/
 
 # Vite
 *.timestamp-*-*.mjs
+
+.env


### PR DESCRIPTION
## Summary
- `Menu` 카테고리 관리, 메뉴-재료 관계 매핑, 그리고 페이징 처리가 포함된 목록 조회 기능을 구현

## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/menu/MenuController.java`
- `backend/src/main/java/com/example/nexus/domain/menu/MenuService.java`
- `backend/src/main/java/com/example/nexus/domain/menu/model/Menu.java`
- `backend/src/main/java/com/example/nexus/domain/menu/model/MenuCategory.java`
- `backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java`
- `backend/src/main/resources/data.sql`
- `frontend/.gitignore`

## 주요 변경 사항
- [x] MenuCategory 엔티티 정의 및 메뉴와 일대다 연관관계 설정
- [x] page, size 파라미터를 통한 페이징 처리 구현
- [x] 메뉴 재료 조회 기능 
- [x] 메뉴 카테고리 조회 기능

## DB & Infrastructure (해당 시)
- [x] 엔티티 수정으로 인한 테이블 스키마 변경: menu_category 테이블 신규 생성 및 외래키 매핑 확인
- [x] 더미 데이터 잘 들어가는지 확인


## Test Plan
- [x] 메뉴 목록 페이징 조회 API 응답 확인
- [x] 메뉴별 재료 리스트 조회 API 정상 동작 확인
- [x] 메뉴 카테고리 조회 API 응답 확인

## Issue
- Closes #56 