### PR TITLE
[Feat] #16 - 본사 대시보드 가맹점 현황 KPI API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -1,0 +1,27 @@
+package com.example.nexus.domain.dashboard;
+
+import com.example.nexus.common.model.BaseResponse;
+import com.example.nexus.domain.dashboard.model.DashboardDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/dashboard")
+@RequiredArgsConstructor
+public class DashboardController {
+    private final DashboardService dashboardService;
+
+    /**
+     * 가맹점 현황 KPI 조회
+     *
+     * @return ResponseEntity 총 매장 수, 이번 달 신규 매장 수, 전일 대비 증감률
+     */
+    @GetMapping("/store-kpi")
+    public ResponseEntity<BaseResponse> getStoreKpi() {
+        DashboardDto.StoreKpiRes result = dashboardService.getStoreKpi();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -1,0 +1,37 @@
+package com.example.nexus.domain.dashboard;
+
+import com.example.nexus.domain.dashboard.model.DashboardDto;
+import com.example.nexus.domain.store.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardService {
+    private final StoreRepository storeRepository;
+
+    public DashboardDto.StoreKpiRes getStoreKpi() {
+        long totalCount = storeRepository.countByIsDeletedFalse();
+
+        // 이번 달 1일 00:00 기준 신규 매장 수
+        LocalDateTime monthStart = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+        long newThisMonth = storeRepository.countByIsDeletedFalseAndCreatedAtAfter(monthStart);
+
+        // 전일 대비 증감률: 어제 매장 수 대비 오늘 매장 수
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+        LocalDateTime yesterdayStart = todayStart.minusDays(1);
+        long newToday = storeRepository.countByIsDeletedFalseAndCreatedAtAfter(todayStart);
+        long newYesterday = storeRepository.countByIsDeletedFalseAndCreatedAtAfter(yesterdayStart) - newToday;
+
+        double delta = newYesterday > 0 ? (double) (newToday - newYesterday) * 100 / newYesterday : 0;
+
+        return DashboardDto.StoreKpiRes.builder()
+                .totalStoreCount(totalCount)
+                .newStoreCountThisMonth(newThisMonth)
+                .deltaPercent(Math.round(delta * 10) / 10.0)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -1,0 +1,15 @@
+package com.example.nexus.domain.dashboard.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class DashboardDto {
+
+    @Getter
+    @Builder
+    public static class StoreKpiRes {
+        private long totalStoreCount;
+        private long newStoreCountThisMonth;
+        private double deltaPercent;
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java
@@ -4,6 +4,7 @@ import com.example.nexus.domain.store.model.Store;
 import com.example.nexus.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +18,8 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
     Optional<Store> findByStoreName(String storeName);
 
     Optional<Store> findByBusiness(String business);
+
+    long countByIsDeletedFalse();
+
+    long countByIsDeletedFalseAndCreatedAtAfter(LocalDateTime since);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
  - 본사 대시보드에서 가맹점 현황을 보여주기 위한 KPI 조회 API 구현                                                                                                                                                                 
                                                                                                                                                                                                                                  
  ## 변경 파일
  - DashboardController.java (신규)
  - DashboardService.java (신규)
  - DashboardDto.java (신규)
  - StoreRepository.java

  ## 주요 변경 사항
  - GET /dashboard/store-kpi 엔드포인트 추가
  - 총 매장 수, 이번 달 신규 매장 수, 전일 대비 증감률 집계 로직 구현
  - StoreRepository에 isDeleted/createdAt 기반 카운트 쿼리 추가

  ## Test Plan
  - [ ] /dashboard/store-kpi 호출 시 정상 응답 확인
  - [ ] 매장 등록 후 totalStoreCount, newStoreCountThisMonth 값 반영 확인

  ## Issue
  - Closes #16