### PR TITLE
[Fix] #16 - 가맹점 KPI 전일 대비 증감률 계산 로직 수정

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -20,13 +20,10 @@ public class DashboardService {
         LocalDateTime monthStart = LocalDate.now().withDayOfMonth(1).atStartOfDay();
         long newThisMonth = storeRepository.countByIsDeletedFalseAndCreatedAtAfter(monthStart);
 
-        // 전일 대비 증감률: 어제 매장 수 대비 오늘 매장 수
+        // 전일 대비 증감률: 어제까지 총 매장 수 vs 오늘까지 총 매장 수
         LocalDateTime todayStart = LocalDate.now().atStartOfDay();
-        LocalDateTime yesterdayStart = todayStart.minusDays(1);
-        long newToday = storeRepository.countByIsDeletedFalseAndCreatedAtAfter(todayStart);
-        long newYesterday = storeRepository.countByIsDeletedFalseAndCreatedAtAfter(yesterdayStart) - newToday;
-
-        double delta = newYesterday > 0 ? (double) (newToday - newYesterday) * 100 / newYesterday : 0;
+        long yesterdayTotal = storeRepository.countByIsDeletedFalseAndCreatedAtBefore(todayStart);
+        double delta = yesterdayTotal > 0 ? (double) (totalCount - yesterdayTotal) * 100 / yesterdayTotal : 0;
 
         return DashboardDto.StoreKpiRes.builder()
                 .totalStoreCount(totalCount)

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java
@@ -19,7 +19,10 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
 
     Optional<Store> findByBusiness(String business);
 
+    // 아래 3개는 대시보드 사용
     long countByIsDeletedFalse();
 
     long countByIsDeletedFalseAndCreatedAtAfter(LocalDateTime since);
+
+    long countByIsDeletedFalseAndCreatedAtBefore(LocalDateTime until);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 코드 리뷰 반영: 가맹점 KPI 전일 대비 증감률 계산 방식 개선                                                                                                                                                                      
                                                                                                                                                                                                                                  
## 변경 파일                                                                                                                                                                                                                      
- DashboardService.java                                                                                                                                                                                                           
- StoreRepository.java

## 주요 변경 사항
- 어제 신규 vs 오늘 신규 비교에서 어제까지 총 매장 수 vs 현재 총 매장 수 비교로 변경
- 불필요한 DB 호출 제거 (3회 → 정확히 필요한 3회로 정리)
- StoreRepository에 createdAtBefore 카운트 쿼리 추가

## Test Plan
- [ ] 매장 신규 등록 후 deltaPercent 값이 정상 반영되는지 확인

## Issue
- Closes #16
