### PR TITLE
[Feat] #18 - 총 매출 KPI 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -19,9 +19,20 @@ public class DashboardController {
      *
      * @return ResponseEntity 총 매장 수, 이번 달 신규 매장 수, 전일 대비 증감률
      */
-    @GetMapping("/store-kpi")
+    @GetMapping("/store/kpi")
     public ResponseEntity<BaseResponse> getStoreKpi() {
         DashboardDto.StoreKpiRes result = dashboardService.getStoreKpi();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
+     * 총 매출 KPI 조회
+     *
+     * @return ResponseEntity 이번 달 총 매출, 금일 매출
+     */
+    @GetMapping("/revenue/kpi")
+    public ResponseEntity<BaseResponse> getRevenueKpi() {
+        DashboardDto.RevenueKpiRes result = dashboardService.getRevenueKpi();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -1,6 +1,7 @@
 package com.example.nexus.domain.dashboard;
 
 import com.example.nexus.domain.dashboard.model.DashboardDto;
+import com.example.nexus.domain.head.HeadIncomeRepository;
 import com.example.nexus.domain.store.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class DashboardService {
     private final StoreRepository storeRepository;
+    private final HeadIncomeRepository headIncomeRepository;
 
     public DashboardDto.StoreKpiRes getStoreKpi() {
         long totalCount = storeRepository.countByIsDeletedFalse();
@@ -29,6 +31,21 @@ public class DashboardService {
                 .totalStoreCount(totalCount)
                 .newStoreCountThisMonth(newThisMonth)
                 .deltaPercent(Math.round(delta * 10) / 10.0)
+                .build();
+    }
+
+    public DashboardDto.RevenueKpiRes getRevenueKpi() {
+        // 이번 달 1일 00:00 기준 월간 매출
+        LocalDateTime monthStart = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+        long monthlyRevenue = headIncomeRepository.sumPriceByOrdersCreatedAtAfter(monthStart);
+
+        // 금일 00:00 기준 오늘 매출
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+        long todayRevenue = headIncomeRepository.sumPriceByOrdersCreatedAtAfter(todayStart);
+
+        return DashboardDto.RevenueKpiRes.builder()
+                .monthlyRevenue(monthlyRevenue)
+                .todayRevenue(todayRevenue)
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -12,4 +12,11 @@ public class DashboardDto {
         private long newStoreCountThisMonth;
         private double deltaPercent;
     }
+
+    @Getter
+    @Builder
+    public static class RevenueKpiRes {
+        private long monthlyRevenue;
+        private long todayRevenue;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java
@@ -2,6 +2,14 @@ package com.example.nexus.domain.head;
 
 import com.example.nexus.domain.head.model.HeadIncome;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface HeadIncomeRepository extends JpaRepository<HeadIncome, Long> {
+
+    // 대시보드용
+    @Query("SELECT COALESCE(SUM(h.price), 0) FROM HeadIncome h WHERE h.orders.createdAt >= :since")
+    long sumPriceByOrdersCreatedAtAfter(@Param("since") LocalDateTime since);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사 대시보드에서 총 매출 현황을 보여주기 위한 KPI 조회 API 구현                                                                                                                                                                
                                                                                                                                                                                                                                  
## 변경 파일                                                                                                                                                                                                                      
- DashboardController.java                                                                                                                                                                                                        
- DashboardService.java                                                                                                                                                                                                           
- DashboardDto.java
- HeadIncomeRepository.java

## 주요 변경 사항
- GET /dashboard/revenue/kpi 엔드포인트 추가
- 이번 달 총 매출, 금일 매출 집계 로직 구현
- HeadIncomeRepository에 Orders.createdAt 기준 매출 합산 쿼리 추가

## Test Plan
- [ ] /dashboard/revenue/kpi 호출 시 정상 응답 확인
- [ ] 발주 승인 후 monthlyRevenue, todayRevenue 값 반영 확인
- [ ] 데이터 없을 시 0원 반환 확인

## Issue
- Closes #18