### PR TITLE
[Feat] #20 - 본사 대시보드 발주 현황 KPI API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -35,4 +35,15 @@ public class DashboardController {
         DashboardDto.RevenueKpiRes result = dashboardService.getRevenueKpi();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
+
+    /**
+     * 발주 현황 KPI 조회
+     *
+     * @return ResponseEntity 금일 자동 발주 건수, 확정 발주 건수, 금일 수동 발주 건수
+     */
+    @GetMapping("/orders/kpi")
+    public ResponseEntity<BaseResponse> getOrdersKpi() {
+        DashboardDto.OrdersKpiRes result = dashboardService.getOrdersKpi();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -1,7 +1,10 @@
 package com.example.nexus.domain.dashboard;
 
+import com.example.nexus.common.enums.OrdersStatus;
+import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.dashboard.model.DashboardDto;
 import com.example.nexus.domain.head.HeadIncomeRepository;
+import com.example.nexus.domain.orders.OrdersRepository;
 import com.example.nexus.domain.store.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +17,7 @@ import java.time.LocalDateTime;
 public class DashboardService {
     private final StoreRepository storeRepository;
     private final HeadIncomeRepository headIncomeRepository;
+    private final OrdersRepository ordersRepository;
 
     public DashboardDto.StoreKpiRes getStoreKpi() {
         long totalCount = storeRepository.countByIsDeletedFalse();
@@ -46,6 +50,25 @@ public class DashboardService {
         return DashboardDto.RevenueKpiRes.builder()
                 .monthlyRevenue(monthlyRevenue)
                 .todayRevenue(todayRevenue)
+                .build();
+    }
+
+    public DashboardDto.OrdersKpiRes getOrdersKpi() {
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+
+        // 금일 자동 발주 건수
+        long todayAutoCount = ordersRepository.countByOrdersTypeAndCreatedAtAfter(OrdersType.AUTO, todayStart);
+
+        // 현재 확정 상태 발주 건수
+        long confirmedCount = ordersRepository.countByOrdersStatus(OrdersStatus.CONFIRMED);
+
+        // 금일 수동 발주 건수
+        long todayManualCount = ordersRepository.countByOrdersTypeAndCreatedAtAfter(OrdersType.MANUAL, todayStart);
+
+        return DashboardDto.OrdersKpiRes.builder()
+                .todayAutoCount(todayAutoCount)
+                .confirmedCount(confirmedCount)
+                .todayManualCount(todayManualCount)
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -19,4 +19,12 @@ public class DashboardDto {
         private long monthlyRevenue;
         private long todayRevenue;
     }
+
+    @Getter
+    @Builder
+    public static class OrdersKpiRes {
+        private long todayAutoCount;
+        private long confirmedCount;
+        private long todayManualCount;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -20,4 +20,9 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "FROM Orders o JOIN o.ordersItemList i " +
             "WHERE o.store.idx = :storeIdx AND o.createdAt >= :since AND (:excludeIdx IS NULL OR o.idx <> :excludeIdx)")
     Integer findAvgQtyByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("since") LocalDateTime since, @Param("excludeIdx") Long excludeIdx);
+
+    // 대시보드용
+    long countByOrdersTypeAndCreatedAtAfter(com.example.nexus.common.enums.OrdersType ordersType, LocalDateTime since);
+
+    long countByOrdersStatus(OrdersStatus ordersStatus);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
  - 본사 대시보드에서 발주 현황을 보여주기 위한 KPI 조회 API 구현                                                                                                                                                                   
                                                                                                                                                                                                                                    
  ## 변경 파일                                                                                                                                                                                                                      
  - DashboardController.java                                                                                                                                                                                                        
  - DashboardService.java                                                                                                                                                                                                           
  - DashboardDto.java
  - OrdersRepository.java

  ## 주요 변경 사항
  - GET /dashboard/orders/kpi 엔드포인트 추가
  - 금일 자동 발주 건수, 확정 발주 건수, 금일 수동 발주 건수 집계 로직 구현
  - OrdersRepository에 타입별/상태별 카운트 쿼리 추가

  ## Test Plan
  - [ ] /dashboard/orders/kpi 호출 시 정상 응답 확인
  - [ ] 자동/수동 발주 생성 후 todayAutoCount, todayManualCount 반영 확인
  - [ ] 발주 확정 후 confirmedCount 반영 확인
  - [ ] 데이터 없을 시 0건 반환 확인

  ## Issue
  - Closes #20