### PR TITLE
[Feat] #22 - 본사 대시보드 배송 현황 KPI API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -46,4 +46,15 @@ public class DashboardController {
         DashboardDto.OrdersKpiRes result = dashboardService.getOrdersKpi();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
+
+    /**
+     * 배송 현황 KPI 조회
+     *
+     * @return ResponseEntity 진행중 배송 건수, 지연 건수, 진행중 배송 목록
+     */
+    @GetMapping("/delivery/kpi")
+    public ResponseEntity<BaseResponse> getDeliveryKpi() {
+        DashboardDto.DeliveryKpiRes result = dashboardService.getDeliveryKpi();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -1,8 +1,11 @@
 package com.example.nexus.domain.dashboard;
 
+import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.dashboard.model.DashboardDto;
+import com.example.nexus.domain.delivery.DeliveryRepository;
+import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.head.HeadIncomeRepository;
 import com.example.nexus.domain.orders.OrdersRepository;
 import com.example.nexus.domain.store.StoreRepository;
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +22,7 @@ public class DashboardService {
     private final StoreRepository storeRepository;
     private final HeadIncomeRepository headIncomeRepository;
     private final OrdersRepository ordersRepository;
+    private final DeliveryRepository deliveryRepository;
 
     public DashboardDto.StoreKpiRes getStoreKpi() {
         long totalCount = storeRepository.countByIsDeletedFalse();
@@ -69,6 +74,34 @@ public class DashboardService {
                 .todayAutoCount(todayAutoCount)
                 .confirmedCount(confirmedCount)
                 .todayManualCount(todayManualCount)
+                .build();
+    }
+
+    public DashboardDto.DeliveryKpiRes getDeliveryKpi() {
+        List<DeliveryStatus> ongoingStatuses = List.of(
+                DeliveryStatus.READY, DeliveryStatus.START, DeliveryStatus.DELIVERYING);
+
+        // 진행중 배송 건수
+        long ongoingCount = deliveryRepository.countByDeliveryStatusIn(ongoingStatuses);
+
+        // 배송 지연 건수
+        long delayCount = deliveryRepository.countByDeliveryStatus(DeliveryStatus.DELAY);
+
+        // 배송 지연 목록
+        List<Delivery> deliveries = deliveryRepository.findByDeliveryStatus(DeliveryStatus.DELAY);
+        List<DashboardDto.DeliveryItem> deliveryList = deliveries.stream()
+                .map(d -> DashboardDto.DeliveryItem.builder()
+                        .deliveryIdx(d.getIdx())
+                        .ordersIdx(d.getOrders().getIdx())
+                        .storeName(d.getOrders().getStore().getStoreName())
+                        .status(d.getDeliveryStatus().name())
+                        .build())
+                .toList();
+
+        return DashboardDto.DeliveryKpiRes.builder()
+                .ongoingCount(ongoingCount)
+                .delayCount(delayCount)
+                .deliveryList(deliveryList)
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -5,7 +5,6 @@ import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.dashboard.model.DashboardDto;
 import com.example.nexus.domain.delivery.DeliveryRepository;
-import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.head.HeadIncomeRepository;
 import com.example.nexus.domain.orders.OrdersRepository;
 import com.example.nexus.domain.store.StoreRepository;
@@ -88,14 +87,9 @@ public class DashboardService {
         long delayCount = deliveryRepository.countByDeliveryStatus(DeliveryStatus.DELAY);
 
         // 배송 지연 목록
-        List<Delivery> deliveries = deliveryRepository.findByDeliveryStatus(DeliveryStatus.DELAY);
-        List<DashboardDto.DeliveryItem> deliveryList = deliveries.stream()
-                .map(d -> DashboardDto.DeliveryItem.builder()
-                        .deliveryIdx(d.getIdx())
-                        .ordersIdx(d.getOrders().getIdx())
-                        .storeName(d.getOrders().getStore().getStoreName())
-                        .status(d.getDeliveryStatus().name())
-                        .build())
+        List<DashboardDto.DeliveryItem> deliveryList = deliveryRepository
+                .findByDeliveryStatus(DeliveryStatus.DELAY).stream()
+                .map(DashboardDto.DeliveryItem::from)
                 .toList();
 
         return DashboardDto.DeliveryKpiRes.builder()

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -1,5 +1,6 @@
 package com.example.nexus.domain.dashboard.model;
 
+import com.example.nexus.domain.delivery.model.Delivery;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -45,5 +46,14 @@ public class DashboardDto {
         private Long ordersIdx;
         private String storeName;
         private String status;
+
+        public static DeliveryItem from(Delivery entity) {
+            return DeliveryItem.builder()
+                    .deliveryIdx(entity.getIdx())
+                    .ordersIdx(entity.getOrders().getIdx())
+                    .storeName(entity.getOrders().getStore().getStoreName())
+                    .status(entity.getDeliveryStatus().name())
+                    .build();
+        }
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -3,6 +3,8 @@ package com.example.nexus.domain.dashboard.model;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 public class DashboardDto {
 
     @Getter
@@ -26,5 +28,22 @@ public class DashboardDto {
         private long todayAutoCount;
         private long confirmedCount;
         private long todayManualCount;
+    }
+
+    @Getter
+    @Builder
+    public static class DeliveryKpiRes {
+        private long ongoingCount;
+        private long delayCount;
+        private List<DeliveryItem> deliveryList;
+    }
+
+    @Getter
+    @Builder
+    public static class DeliveryItem {
+        private Long deliveryIdx;
+        private Long ordersIdx;
+        private String storeName;
+        private String status;
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -1,7 +1,17 @@
 package com.example.nexus.domain.delivery;
 
+import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.domain.delivery.model.Delivery;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+
+    // 대시보드용
+    long countByDeliveryStatusIn(List<DeliveryStatus> statuses);
+
+    long countByDeliveryStatus(DeliveryStatus status);
+
+    List<Delivery> findByDeliveryStatus(DeliveryStatus status);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사 대시보드에서 배송 현황을 보여주기 위한 KPI 조회 API 구현                                                                                                                                                                   
                                                                                                                                                                                                                                  
## 변경 파일                                                                                                                                                                                                                      
- DashboardController.java                                                                                                                                                                                                        
- DashboardService.java                                                                                                                                                                                                           
- DashboardDto.java
- DeliveryRepository.java

## 주요 변경 사항
- GET /dashboard/delivery/kpi 엔드포인트 추가
- 진행중 배송 건수(READY, START, DELIVERYING), 배송 지연 건수(DELAY) 집계
- 지연 배송 상세 목록(배송ID, 발주번호, 매장명, 상태) 반환
- DeliveryRepository에 상태별 카운트/목록 쿼리 추가

## Test Plan
- [ ] /dashboard/delivery/kpi 호출 시 정상 응답 확인
- [ ] 배송 상태 변경 후 ongoingCount, delayCount 반영 확인
- [ ] 지연 배송 발생 시 deliveryList에 포함 확인
- [ ] 데이터 없을 시 0건, 빈 목록 반환 확인

## Issue
- Closes #22