### PR TITLE
[Feat] #24 - 이상 발주 통계 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -50,11 +50,22 @@ public class DashboardController {
     /**
      * 배송 현황 KPI 조회
      *
-     * @return ResponseEntity 진행중 배송 건수, 지연 건수, 진행중 배송 목록
+     * @return ResponseEntity 진행중 배송 건수, 지연 건수, 지연 배송 목록
      */
     @GetMapping("/delivery/kpi")
     public ResponseEntity<BaseResponse> getDeliveryKpi() {
         DashboardDto.DeliveryKpiRes result = dashboardService.getDeliveryKpi();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
+     * 이상 발주 통계 조회
+     *
+     * @return ResponseEntity 최근 6개월 월별 이상 발주 상태별 건수
+     */
+    @GetMapping("/orders/danger-stats")
+    public ResponseEntity<BaseResponse> getDangerStats() {
+        DashboardDto.DangerStatsRes result = dashboardService.getDangerStats();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -3,6 +3,11 @@ package com.example.nexus.domain.dashboard;
 import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.common.enums.OrdersType;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import com.example.nexus.domain.dashboard.model.DashboardDto;
 import com.example.nexus.domain.delivery.DeliveryRepository;
 import com.example.nexus.domain.head.HeadIncomeRepository;
@@ -96,6 +101,66 @@ public class DashboardService {
                 .ongoingCount(ongoingCount)
                 .delayCount(delayCount)
                 .deliveryList(deliveryList)
+                .build();
+    }
+
+    public DashboardDto.DangerStatsRes getDangerStats() {
+        // 조회 시작 시점: 현재 월 포함 6개월 전 1일 00:00
+        // 예: 현재 2026-05 → 2025-12-01 00:00부터 조회
+        LocalDateTime since = LocalDate.now().minusMonths(5).withDayOfMonth(1).atStartOfDay();
+
+        // 6개월치 라벨(yyyy-MM)을 순서대로 생성하고, 각 월별 카운트 배열 초기화
+        // LinkedHashMap으로 삽입 순서 보장 → 프론트 차트 x축 순서 유지
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        Map<String, long[]> monthMap = new LinkedHashMap<>();
+        for (int i = 0; i < 6; i++) {
+            String label = YearMonth.now().minusMonths(5 - i).format(formatter);
+            monthMap.put(label, new long[3]); // [0: 승인대기(CONFIRMED), 1: 승인(APPROVE), 2: 반려(REJECT)]
+        }
+
+        // DB에서 월별 + 상태별 이상 발주 건수 조회 후 monthMap에 매핑
+        List<Object[]> rows = ordersRepository.findDangerStatsByMonth(since);
+        for (Object[] row : rows) {
+            String month = (String) row[0];
+            long count = (Long) row[2];
+
+            long[] counts = monthMap.get(month);
+            if (counts == null) {
+                continue;
+            }
+
+            OrdersStatus status = (OrdersStatus) row[1];
+            switch (status) {
+                case CONFIRMED :
+                    counts[0] = count;
+                    break; // 승인 대기
+                case APPROVE :
+                    counts[1] = count;
+                    break; // 승인
+                case REJECT :
+                    counts[2] = count;
+                    break; // 반려
+                default: break;
+            }
+        }
+
+        // monthMap을 프론트 차트에 맞는 배열 형태로 변환
+        List<String> labels = new ArrayList<>(monthMap.keySet());
+        List<Long> confirmed = new ArrayList<>();
+        List<Long> approved = new ArrayList<>();
+        List<Long> rejected = new ArrayList<>();
+
+        for (long[] counts : monthMap.values()) {
+            confirmed.add(counts[0]);
+            approved.add(counts[1]);
+            rejected.add(counts[2]);
+        }
+
+        return DashboardDto.DangerStatsRes.builder()
+                .labels(labels)
+                .confirmed(confirmed)
+                .approved(approved)
+                .rejected(rejected)
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -56,4 +56,13 @@ public class DashboardDto {
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    public static class DangerStatsRes {
+        private List<String> labels;
+        private List<Long> confirmed;
+        private List<Long> approved;
+        private List<Long> rejected;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -25,4 +25,10 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     long countByOrdersTypeAndCreatedAtAfter(com.example.nexus.common.enums.OrdersType ordersType, LocalDateTime since);
 
     long countByOrdersStatus(OrdersStatus ordersStatus);
+
+    @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus, COUNT(o) " +
+            "FROM Orders o WHERE o.isDanger = true AND o.createdAt >= :since " +
+            "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus " +
+            "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m')")
+    List<Object[]> findDangerStatsByMonth(@Param("since") LocalDateTime since);
 }


### PR DESCRIPTION
## Summary
- 본사 대시보드 이상 발주 통계 조회 API 구현

## 변경 파일
- DashboardController.java
- DashboardService.java
- DashboardDto.java
- OrdersRepository.java

## 주요 변경 사항
- GET /dashboard/orders/danger-stats 엔드포인트 추가
- 최근 6개월 월별 이상 발주 상태별(승인대기/승인/반려) 건수 집계 로직 구현
- OrdersRepository에 월별 이상 발주 JPQL 집계 쿼리 추가
- DangerStatsRes DTO 추가 (labels, confirmed, approved, rejected)

## Test Plan
- [ ] /dashboard/orders/danger-stats 호출 시 6개월치 월별 라벨 및 상태별 건수 정상 반환 확인
- [ ] 이상 발주 데이터 없는 월은 0으로 반환되는지 확인

## Issue
- Closes #24