### PR TITLE
[Feat] #26 - 주간 발주 통계 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -63,9 +63,20 @@ public class DashboardController {
      *
      * @return ResponseEntity 최근 6개월 월별 이상 발주 상태별 건수
      */
-    @GetMapping("/orders/danger-stats")
+    @GetMapping("/orders/danger/stats")
     public ResponseEntity<BaseResponse> getDangerStats() {
         DashboardDto.DangerStatsRes result = dashboardService.getDangerStats();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
+     * 주간 발주 통계 조회
+     *
+     * @return ResponseEntity 최근 7일 일별 자동/수동 발주 건수
+     */
+    @GetMapping("/orders/weekly/stats")
+    public ResponseEntity<BaseResponse> getWeeklyOrderStats() {
+        DashboardDto.WeeklyOrderStatsRes result = dashboardService.getWeeklyOrderStats();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -163,4 +163,44 @@ public class DashboardService {
                 .rejected(rejected)
                 .build();
     }
+
+    public DashboardDto.WeeklyOrderStatsRes getWeeklyOrderStats() {
+        // 이번 주 월요일 00:00 기준으로 이번 주 / 지난 주 범위 계산
+        // 예: 오늘 2026-05-04(일) → 이번 주 월요일 04-28, 지난 주 월요일 04-21
+        LocalDate today = LocalDate.now();
+        LocalDate thisMonday = today.with(java.time.DayOfWeek.MONDAY);
+        LocalDate lastMonday = thisMonday.minusWeeks(1);
+        LocalDateTime since = lastMonday.atStartOfDay();
+
+        // 요일 라벨 (월~일)
+        List<String> labels = List.of("월", "화", "수", "목", "금", "토", "일");
+
+        // 지난 주, 이번 주 각각 7일치 카운트 초기화
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM-dd");
+        Map<String, Long> lastWeekMap = new LinkedHashMap<>();
+        Map<String, Long> thisWeekMap = new LinkedHashMap<>();
+        for (int i = 0; i < 7; i++) {
+            lastWeekMap.put(lastMonday.plusDays(i).format(formatter), 0L);
+            thisWeekMap.put(thisMonday.plusDays(i).format(formatter), 0L);
+        }
+
+        // DB에서 2주치 일별 발주 건수 조회 후 각 주에 매핑
+        List<Object[]> rows = ordersRepository.findWeeklyOrderStats(since);
+        for (Object[] row : rows) {
+            String day = (String) row[0];
+            long count = (Long) row[1];
+
+            if (lastWeekMap.containsKey(day)) {
+                lastWeekMap.put(day, count);
+            } else if (thisWeekMap.containsKey(day)) {
+                thisWeekMap.put(day, count);
+            }
+        }
+
+        return DashboardDto.WeeklyOrderStatsRes.builder()
+                .labels(labels)
+                .thisWeek(new ArrayList<>(thisWeekMap.values()))
+                .lastWeek(new ArrayList<>(lastWeekMap.values()))
+                .build();
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -65,4 +65,12 @@ public class DashboardDto {
         private List<Long> approved;
         private List<Long> rejected;
     }
+
+    @Getter
+    @Builder
+    public static class WeeklyOrderStatsRes {
+        private List<String> labels;
+        private List<Long> thisWeek;
+        private List<Long> lastWeek;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -31,4 +31,10 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus " +
             "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m')")
     List<Object[]> findDangerStatsByMonth(@Param("since") LocalDateTime since);
+
+    @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d'), COUNT(o) " +
+            "FROM Orders o WHERE o.createdAt >= :since " +
+            "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d') " +
+            "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d')")
+    List<Object[]> findWeeklyOrderStats(@Param("since") LocalDateTime since);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사 대시보드 주간 발주 통계 조회 API 구현              

## 변경 파일
- DashboardController.java
- DashboardService.java
- DashboardDto.java
- OrdersRepository.java

## 주요 변경 사항
- GET /dashboard/orders/weekly/stats 엔드포인트 추가
- 이번 주 vs 지난 주 일별 발주 건수 비교 데이터 반환 (labels: 월~일)
- OrdersRepository에 2주치 일별 발주 집계 JPQL 쿼리 추가
- WeeklyOrderStatsRes DTO 추가 (labels, thisWeek, lastWeek)

## Test Plan
- [ ] /dashboard/orders/weekly/stats 호출 시 요일 라벨 7개 및 이번 주/지난 주 건수 배열 정상 반환 확인
- [ ] 발주 데이터 없는 요일은 0으로 반환되는지 확인

## Issue
- Closes #26