### PR TITLE
[Feat] #124 - 위험 재고 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -2,11 +2,11 @@ package com.example.nexus.domain.dashboard;
 
 import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.domain.dashboard.model.DashboardDto;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -95,11 +95,15 @@ public class DashboardController {
     /**
      * 위험 재고 목록 조회
      *
-     * @return ResponseEntity LOW/CRITICAL 상태 본사 재고 목록
+     * @param page 페이지 번호 (0부터 시작, 기본값 0)
+     * @param size 페이지 크기 (기본값 4)
+     * @return ResponseEntity LOW/CRITICAL 상태 본사 재고 목록 (Slice 페이징)
      */
     @GetMapping("/inventory/danger")
-    public ResponseEntity<BaseResponse> getDangerInventoryList() {
-        List<DashboardDto.DangerInventoryItem> result = dashboardService.getDangerInventoryList();
+    public ResponseEntity<BaseResponse> getDangerInventoryList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "4") int size) {
+        DashboardDto.DangerInventoryRes result = dashboardService.getDangerInventoryList(page, size);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -2,6 +2,7 @@ package com.example.nexus.domain.dashboard;
 
 import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.domain.dashboard.model.DashboardDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -88,6 +89,17 @@ public class DashboardController {
     @GetMapping("/delivery/ratio")
     public ResponseEntity<BaseResponse> getDeliveryRatio() {
         DashboardDto.DeliveryRatioRes result = dashboardService.getDeliveryRatio();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
+     * 위험 재고 목록 조회
+     *
+     * @return ResponseEntity LOW/CRITICAL 상태 본사 재고 목록
+     */
+    @GetMapping("/inventory/danger")
+    public ResponseEntity<BaseResponse> getDangerInventoryList() {
+        List<DashboardDto.DangerInventoryItem> result = dashboardService.getDangerInventoryList();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -8,9 +8,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import com.example.nexus.common.enums.InventoryStatus;
 import com.example.nexus.domain.dashboard.model.DashboardDto;
 import com.example.nexus.domain.delivery.DeliveryRepository;
 import com.example.nexus.domain.head.HeadIncomeRepository;
+import com.example.nexus.domain.head.HeadInventoryRepository;
 import com.example.nexus.domain.orders.OrdersRepository;
 import com.example.nexus.domain.store.StoreRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class DashboardService {
     private final HeadIncomeRepository headIncomeRepository;
     private final OrdersRepository ordersRepository;
     private final DeliveryRepository deliveryRepository;
+    private final HeadInventoryRepository headInventoryRepository;
 
     public DashboardDto.StoreKpiRes getStoreKpi() {
         long totalCount = storeRepository.countByIsDeletedFalse();
@@ -219,5 +222,14 @@ public class DashboardService {
                 .delivered(delivered)
                 .delay(delay)
                 .build();
+    }
+
+    public List<DashboardDto.DangerInventoryItem> getDangerInventoryList() {
+        // 위험 재고: status가 LOW 또는 CRITICAL인 본사 재고 목록
+        List<InventoryStatus> dangerStatuses = List.of(InventoryStatus.LOW, InventoryStatus.CRITICAL);
+
+        return headInventoryRepository.findByStatusIn(dangerStatuses).stream()
+                .map(DashboardDto.DangerInventoryItem::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -13,8 +13,11 @@ import com.example.nexus.domain.dashboard.model.DashboardDto;
 import com.example.nexus.domain.delivery.DeliveryRepository;
 import com.example.nexus.domain.head.HeadIncomeRepository;
 import com.example.nexus.domain.head.HeadInventoryRepository;
+import com.example.nexus.domain.head.model.HeadInventory;
 import com.example.nexus.domain.orders.OrdersRepository;
 import com.example.nexus.domain.store.StoreRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -224,12 +227,20 @@ public class DashboardService {
                 .build();
     }
 
-    public List<DashboardDto.DangerInventoryItem> getDangerInventoryList() {
+    public DashboardDto.DangerInventoryRes getDangerInventoryList(int page, int size) {
         // 위험 재고: status가 LOW 또는 CRITICAL인 본사 재고 목록
         List<InventoryStatus> dangerStatuses = List.of(InventoryStatus.LOW, InventoryStatus.CRITICAL);
 
-        return headInventoryRepository.findByStatusIn(dangerStatuses).stream()
+        Slice<HeadInventory> slice =
+                headInventoryRepository.findByStatusIn(dangerStatuses, PageRequest.of(page, size));
+
+        List<DashboardDto.DangerInventoryItem> items = slice.getContent().stream()
                 .map(DashboardDto.DangerInventoryItem::from)
                 .toList();
+
+        return DashboardDto.DangerInventoryRes.builder()
+                .items(items)
+                .hasNext(slice.hasNext())
+                .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -104,4 +104,11 @@ public class DashboardDto {
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    public static class DangerInventoryRes {
+        private List<DangerInventoryItem> items;
+        private boolean hasNext;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -1,6 +1,7 @@
 package com.example.nexus.domain.dashboard.model;
 
 import com.example.nexus.domain.delivery.model.Delivery;
+import com.example.nexus.domain.head.model.HeadInventory;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -82,5 +83,25 @@ public class DashboardDto {
         private long delivering;
         private long delivered;
         private long delay;
+    }
+
+    @Getter
+    @Builder
+    public static class DangerInventoryItem {
+        private Long inventoryIdx;
+        private String productName;
+        private int count;
+        private int minStock;
+        private String status;
+
+        public static DangerInventoryItem from(HeadInventory entity) {
+            return DangerInventoryItem.builder()
+                    .inventoryIdx(entity.getIdx())
+                    .productName(entity.getProduct().getProductName())
+                    .count(entity.getCount())
+                    .minStock(entity.getProduct().getMinStock())
+                    .status(entity.getStatus().name())
+                    .build();
+        }
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadInventoryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadInventoryRepository.java
@@ -2,6 +2,8 @@ package com.example.nexus.domain.head;
 
 import com.example.nexus.common.enums.InventoryStatus;
 import com.example.nexus.domain.head.model.HeadInventory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,6 +12,6 @@ import java.util.Optional;
 public interface HeadInventoryRepository extends JpaRepository<HeadInventory, Long> {
     Optional<HeadInventory> findByProductIdx(Long productIdx);
 
-    // 대시보드용: 위험 재고 목록 조회
-    List<HeadInventory> findByStatusIn(List<InventoryStatus> statuses);
+    // 대시보드용: 위험 재고 목록 조회 (Slice 페이징)
+    Slice<HeadInventory> findByStatusIn(List<InventoryStatus> statuses, Pageable pageable);
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadInventoryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadInventoryRepository.java
@@ -1,10 +1,15 @@
 package com.example.nexus.domain.head;
 
+import com.example.nexus.common.enums.InventoryStatus;
 import com.example.nexus.domain.head.model.HeadInventory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface HeadInventoryRepository extends JpaRepository<HeadInventory, Long> {
     Optional<HeadInventory> findByProductIdx(Long productIdx);
+
+    // 대시보드용: 위험 재고 목록 조회
+    List<HeadInventory> findByStatusIn(List<InventoryStatus> statuses);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사 대시보드 위험 재고 목록 조회 API 구현              

## 변경 파일
- DashboardController.java
- DashboardService.java
- DashboardDto.java
- HeadInventoryRepository.java

## 주요 변경 사항
- GET /dashboard/inventory/danger 엔드포인트 추가
- LOW/CRITICAL 상태 본사 재고 목록 반환
- HeadInventoryRepository에 상태별 조회 쿼리 추가 (findByStatusIn)
- DangerInventoryItem DTO 추가 (from 패턴 적용)

## Test Plan
- [ ] /dashboard/inventory/danger 호출 시 LOW/CRITICAL 재고만 반환 확인
- [ ] 위험 재고 없을 시 빈 배열 반환 확인
- [ ] productName, count, minStock, status 필드 정상 반환 확인

## Issue
- Closes #124