### PR TITLE
[Feat] #19 - 총 매출 KPI 프론트 API 연동

### DIFF
--- a/frontend/src/api/dashboard/index.js
+++ b/frontend/src/api/dashboard/index.js
@@ -1,3 +1,5 @@
 import api from '@/plugins/axiosinterceptor'
 
 export const getStoreKpi = () => api.get('/dashboard/store/kpi')
+
+export const getRevenueKpi = () => api.get('/dashboard/revenue/kpi')

--- a/frontend/src/components/dashboard/RevenueKpiCard.vue
+++ b/frontend/src/components/dashboard/RevenueKpiCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <KpiCard title="총 매출" :value="value" unit="백만" :sub="sub" :delta="delta" to="/settlement" />
+  <KpiCard title="총 매출" :value="value" unit="원" :sub="sub" :delta="delta" to="/settlement" />
 </template>
 
 <script setup>
@@ -18,9 +18,8 @@ onMounted(async () => {
     const monthly = result.monthlyRevenue
     const today = result.todayRevenue
 
-    // 백만 단위로 변환
-    value.value = (monthly / 1000000).toFixed(1)
-    sub.value = `금일 ${(today / 1000000).toFixed(1)}백만`
+    value.value = monthly.toLocaleString()
+    sub.value = `금일 ${today.toLocaleString()}원`
 
     // 금일 매출 / 월간 매출 비율로 delta 표시
     delta.value = monthly > 0 ? Math.round(today * 1000 / monthly) / 10 : 0

--- a/frontend/src/components/dashboard/RevenueKpiCard.vue
+++ b/frontend/src/components/dashboard/RevenueKpiCard.vue
@@ -3,10 +3,29 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import KpiCard from './KpiCard.vue'
+import { getRevenueKpi } from '@/api/dashboard'
 
-const value = ref('89.2')
-const sub = ref('전일 대비')
-const delta = ref(12.4)
+const value = ref('-')
+const sub = ref('금일 매출 -')
+const delta = ref(0)
+
+onMounted(async () => {
+  try {
+    const { data } = await getRevenueKpi()
+    const result = data.result
+    const monthly = result.monthlyRevenue
+    const today = result.todayRevenue
+
+    // 백만 단위로 변환
+    value.value = (monthly / 1000000).toFixed(1)
+    sub.value = `금일 ${(today / 1000000).toFixed(1)}백만`
+
+    // 금일 매출 / 월간 매출 비율로 delta 표시
+    delta.value = monthly > 0 ? Math.round(today * 1000 / monthly) / 10 : 0
+  } catch (e) {
+    console.error('매출 KPI 조회 실패', e)
+  }
+})
 </script>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사 대시보드 총 매출 KPI 카드 API 연동                 

## 변경 파일
- src/api/dashboard/index.js
- src/components/dashboard/RevenueKpiCard.vue

## 주요 변경 사항
- dashboard API에 getRevenueKpi 함수 추가
- RevenueKpiCard 더미 데이터 → API 데이터로 교체
- 월간 매출, 금일 매출 원 단위 표시 (toLocaleString)

## Test Plan
- [ ] 총 매출 KPI 카드에 월간 매출 금액 정상 표시 확인
- [ ] 금일 매출 서브 텍스트 정상 표시 확인
- [ ] API 실패 시 기본값('-') 유지 확인

## Issue
- Closes #19