### PR TITLE
[Feat] #21 - 발주 현황 KPI 프론트 API 연동

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -80,10 +80,14 @@ public class DashboardService {
         // 금일 수동 발주 건수
         long todayManualCount = ordersRepository.countByOrdersTypeAndCreatedAtAfter(OrdersType.MANUAL, todayStart);
 
+        // 이상 발주 건수
+        long dangerCount = ordersRepository.countByIsDangerTrue();
+
         return DashboardDto.OrdersKpiRes.builder()
                 .todayAutoCount(todayAutoCount)
                 .confirmedCount(confirmedCount)
                 .todayManualCount(todayManualCount)
+                .dangerCount(dangerCount)
                 .build();
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -30,6 +30,7 @@ public class DashboardDto {
         private long todayAutoCount;
         private long confirmedCount;
         private long todayManualCount;
+        private long dangerCount;
     }
 
     @Getter

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -26,6 +26,8 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
 
     long countByOrdersStatus(OrdersStatus ordersStatus);
 
+    long countByIsDangerTrue();
+
     @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus, COUNT(o) " +
             "FROM Orders o WHERE o.isDanger = true AND o.createdAt >= :since " +
             "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus " +

--- a/frontend/src/api/dashboard/index.js
+++ b/frontend/src/api/dashboard/index.js
@@ -3,3 +3,5 @@ import api from '@/plugins/axiosinterceptor'
 export const getStoreKpi = () => api.get('/dashboard/store/kpi')
 
 export const getRevenueKpi = () => api.get('/dashboard/revenue/kpi')
+
+export const getOrdersKpi = () => api.get('/dashboard/orders/kpi')

--- a/frontend/src/components/dashboard/KpiCard.vue
+++ b/frontend/src/components/dashboard/KpiCard.vue
@@ -10,7 +10,8 @@
     </div>
     <div class="mt-4 flex items-center justify-between">
       <span class="text-xs text-gray-500">{{ sub }}</span>
-      <span class="text-xs font-semibold" :class="delta > 0 ? 'text-emerald-600' : 'text-red-500'">
+      <span v-if="badge" class="text-xs px-2 py-0.5 rounded-full font-medium bg-red-100 text-red-600">{{ badge }}</span>
+      <span v-else-if="delta != null" class="text-xs font-semibold" :class="delta > 0 ? 'text-emerald-600' : 'text-red-500'">
         {{ delta > 0 ? '+' : '' }}{{ delta }}%
       </span>
     </div>
@@ -26,6 +27,7 @@ defineProps({
   unit: String,
   sub: String,
   delta: Number,
+  badge: String,
   to: String,
 })
 </script>

--- a/frontend/src/components/dashboard/KpiCard.vue
+++ b/frontend/src/components/dashboard/KpiCard.vue
@@ -10,7 +10,8 @@
     </div>
     <div class="mt-4 flex items-center justify-between">
       <span class="text-xs text-gray-500">{{ sub }}</span>
-      <span v-if="badge" class="text-xs px-2 py-0.5 rounded-full font-medium bg-red-100 text-red-600">{{ badge }}</span>
+      <span v-if="badge" class="text-xs px-2 py-0.5 rounded-full font-medium"
+        :class="badgeDanger ? 'bg-red-100 text-red-600' : 'bg-gray-100 text-gray-500'">{{ badge }}</span>
       <span v-else-if="delta != null" class="text-xs font-semibold" :class="delta > 0 ? 'text-emerald-600' : 'text-red-500'">
         {{ delta > 0 ? '+' : '' }}{{ delta }}%
       </span>
@@ -28,6 +29,7 @@ defineProps({
   sub: String,
   delta: Number,
   badge: String,
+  badgeDanger: { type: Boolean, default: false },
   to: String,
 })
 </script>

--- a/frontend/src/components/dashboard/OrdersKpiCard.vue
+++ b/frontend/src/components/dashboard/OrdersKpiCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <KpiCard title="금일 자동 발주" :value="value" unit="건" :sub="sub" :badge="badge" to="/order" />
+  <KpiCard title="금일 자동 발주" :value="value" unit="건" :sub="sub" :badge="badge" :badge-danger="badgeDanger" to="/order" />
 </template>
 
 <script setup>
@@ -9,7 +9,8 @@ import { getOrdersKpi } from '@/api/dashboard'
 
 const value = ref('-')
 const sub = ref('확정 -건 · 수동 -건')
-const badge = ref(null)
+const badge = ref('이상 0건')
+const badgeDanger = ref(false)
 
 onMounted(async () => {
   try {
@@ -18,7 +19,8 @@ onMounted(async () => {
 
     value.value = result.todayAutoCount.toLocaleString()
     sub.value = `확정 ${result.confirmedCount}건 · 수동 ${result.todayManualCount}건`
-    badge.value = result.dangerCount > 0 ? `이상 ${result.dangerCount}건` : null
+    badge.value = `이상 ${result.dangerCount}건`
+    badgeDanger.value = result.dangerCount > 0
   } catch (e) {
     console.error('발주 KPI 조회 실패', e)
   }

--- a/frontend/src/components/dashboard/OrdersKpiCard.vue
+++ b/frontend/src/components/dashboard/OrdersKpiCard.vue
@@ -1,12 +1,26 @@
 <template>
-  <KpiCard title="금일 자동 발주" :value="value" unit="건" :sub="sub" :delta="delta" to="/order" />
+  <KpiCard title="금일 자동 발주" :value="value" unit="건" :sub="sub" :badge="badge" to="/order" />
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import KpiCard from './KpiCard.vue'
+import { getOrdersKpi } from '@/api/dashboard'
 
-const value = ref('85')
-const sub = ref('확정 62건')
-const delta = ref(8.7)
+const value = ref('-')
+const sub = ref('확정 -건 · 수동 -건')
+const badge = ref(null)
+
+onMounted(async () => {
+  try {
+    const { data } = await getOrdersKpi()
+    const result = data.result
+
+    value.value = result.todayAutoCount.toLocaleString()
+    sub.value = `확정 ${result.confirmedCount}건 · 수동 ${result.todayManualCount}건`
+    badge.value = result.dangerCount > 0 ? `이상 ${result.dangerCount}건` : null
+  } catch (e) {
+    console.error('발주 KPI 조회 실패', e)
+  }
+})
 </script>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사 대시보드 발주 현황 KPI 카드 API 연동               

## 변경 파일
- src/api/dashboard/index.js
- src/components/dashboard/KpiCard.vue
- src/components/dashboard/OrdersKpiCard.vue
- DashboardDto.java
- DashboardService.java
- OrdersRepository.java

## 주요 변경 사항
- dashboard API에 getOrdersKpi 함수 추가
- OrdersKpiCard 더미 데이터 → API 데이터로 교체
- KpiCard에 badge/badgeDanger prop 추가
- 이상 발주 건수 뱃지 표시 (0건 회색, 1건 이상 빨간색)
- OrdersKpiRes에 dangerCount 필드 추가
- OrdersRepository에 countByIsDangerTrue 쿼리 추가

## Test Plan
- [ ] 금일 자동 발주 건수 정상 표시 확인
- [ ] 확정/수동 건수 서브 텍스트 정상 표시 확인
- [ ] 이상 발주 0건 시 회색 뱃지, 1건 이상 시 빨간 뱃지 확인

## Issue
- Closes #21