### PR TITLE
[Feat] #23 - 배송 현황 KPI 프론트 API 연동

### DIFF
--- a/frontend/src/api/dashboard/index.js
+++ b/frontend/src/api/dashboard/index.js
@@ -5,3 +5,5 @@ export const getStoreKpi = () => api.get('/dashboard/store/kpi')
 export const getRevenueKpi = () => api.get('/dashboard/revenue/kpi')
 
 export const getOrdersKpi = () => api.get('/dashboard/orders/kpi')
+
+export const getDeliveryKpi = () => api.get('/dashboard/delivery/kpi')

--- a/frontend/src/components/dashboard/DeliveryKpiCard.vue
+++ b/frontend/src/components/dashboard/DeliveryKpiCard.vue
@@ -1,12 +1,28 @@
 <template>
-  <KpiCard title="배송 지연" :value="value" unit="건" :sub="sub" :delta="delta" to="/delivery" />
+  <KpiCard title="배송 현황" :value="value" unit="건" :sub="sub" :badge="badge" :badge-danger="badgeDanger" to="/delivery" />
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import KpiCard from './KpiCard.vue'
+import { getDeliveryKpi } from '@/api/dashboard'
 
-const value = ref('4')
-const sub = ref('즉시 확인 필요')
-const delta = ref(-1.8)
+const value = ref('-')
+const sub = ref('지연 -건')
+const badge = ref('지연 0건')
+const badgeDanger = ref(false)
+
+onMounted(async () => {
+  try {
+    const { data } = await getDeliveryKpi()
+    const result = data.result
+
+    value.value = result.ongoingCount.toLocaleString()
+    sub.value = `진행중 ${result.ongoingCount}건`
+    badge.value = `지연 ${result.delayCount}건`
+    badgeDanger.value = result.delayCount > 0
+  } catch (e) {
+    console.error('배송 KPI 조회 실패', e)
+  }
+})
 </script>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사 대시보드 배송 현황 KPI 카드 API 연동               

## 변경 파일
- src/api/dashboard/index.js
- src/components/dashboard/DeliveryKpiCard.vue

## 주요 변경 사항
- dashboard API에 getDeliveryKpi 함수 추가
- DeliveryKpiCard 더미 데이터 → API 데이터로 교체
- 진행중 배송 건수 메인 표시, 지연 건수 뱃지 표시
- 지연 0건 회색, 1건 이상 빨간 뱃지

## Test Plan
- [ ] 배송 현황 KPI 카드에 진행중 배송 건수 정상 표시 확인
- [ ] 지연 건수 뱃지 색상 분기 확인 (0건 회색, 1건 이상 빨간)
- [ ] API 실패 시 기본값 유지 확인

## Issue
- Closes #23