### PR TITLE
[Feat] #25 - 이상 발주 통계 프론트 API 연동

### DIFF
--- a/frontend/src/api/dashboard/index.js
+++ b/frontend/src/api/dashboard/index.js
@@ -7,3 +7,5 @@ export const getRevenueKpi = () => api.get('/dashboard/revenue/kpi')
 export const getOrdersKpi = () => api.get('/dashboard/orders/kpi')
 
 export const getDeliveryKpi = () => api.get('/dashboard/delivery/kpi')
+
+export const getDangerStats = () => api.get('/dashboard/orders/danger/stats')

--- a/frontend/src/components/dashboard/DangerOrderChart.vue
+++ b/frontend/src/components/dashboard/DangerOrderChart.vue
@@ -24,37 +24,49 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { Chart } from 'chart.js/auto'
+import { getDangerStats } from '@/api/dashboard'
 
 const barCanvas = ref(null)
 
-const abnormalLabels = ['11월', '12월', '1월', '2월', '3월', '4월']
-const abnormalDanger = [3, 5, 2, 7, 4, 2]
-const abnormalApprove = [2, 4, 2, 5, 3, 1]
-const abnormalReject = [1, 1, 0, 2, 1, 1]
+onMounted(async () => {
+  let labels = []
+  let confirmed = []
+  let approved = []
+  let rejected = []
 
-onMounted(() => {
+  try {
+    const { data } = await getDangerStats()
+    const result = data.result
+    labels = result.labels
+    confirmed = result.confirmed
+    approved = result.approved
+    rejected = result.rejected
+  } catch (e) {
+    console.error('이상 발주 통계 조회 실패', e)
+  }
+
   new Chart(barCanvas.value, {
     type: 'bar',
     data: {
-      labels: abnormalLabels,
+      labels,
       datasets: [
         {
           label: '승인 대기',
-          data: abnormalDanger,
+          data: confirmed,
           backgroundColor: '#f87171',
           borderRadius: 4,
           borderSkipped: false,
         },
         {
           label: '승인',
-          data: abnormalApprove,
+          data: approved,
           backgroundColor: '#4ade80',
           borderRadius: 4,
           borderSkipped: false,
         },
         {
           label: '반려',
-          data: abnormalReject,
+          data: rejected,
           backgroundColor: '#d1d5db',
           borderRadius: 4,
           borderSkipped: false,


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사 대시보드 이상 발주 통계 바 차트 API 연동           

## 변경 파일
- src/api/dashboard/index.js
- src/components/dashboard/DangerOrderChart.vue

## 주요 변경 사항
- dashboard API에 getDangerStats 함수 추가
- DangerOrderChart 더미 데이터 → API 데이터로 교체
- 최근 6개월 월별 이상 발주 상태별(승인대기/승인/반려) 바 차트 표시

## Test Plan
- [ ] 이상 발주 통계 바 차트 정상 렌더링 확인
- [ ] 6개월치 월별 라벨 및 상태별 건수 정상 표시 확인
- [ ] 데이터 없는 월 0으로 표시 확인

## Issue
- Closes #25