### PR TITLE
[Feat] #27 - 주간 발주 통계 프론트 API 연동

### DIFF
--- a/frontend/src/api/dashboard/index.js
+++ b/frontend/src/api/dashboard/index.js
@@ -9,3 +9,5 @@ export const getOrdersKpi = () => api.get('/dashboard/orders/kpi')
 export const getDeliveryKpi = () => api.get('/dashboard/delivery/kpi')
 
 export const getDangerStats = () => api.get('/dashboard/orders/danger/stats')
+
+export const getWeeklyOrderStats = () => api.get('/dashboard/orders/weekly/stats')

--- a/frontend/src/components/dashboard/WeeklyOrderChart.vue
+++ b/frontend/src/components/dashboard/WeeklyOrderChart.vue
@@ -22,18 +22,29 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { Chart } from 'chart.js/auto'
+import { getWeeklyOrderStats } from '@/api/dashboard'
 
 const lineCanvas = ref(null)
 
-const thisWeek = [32, 48, 38, 65, 52, 78, 58]
-const lastWeek = [22, 38, 42, 48, 58, 52, 48]
-const weekLabels = ['일', '월', '화', '수', '목', '금', '토']
+onMounted(async () => {
+  let labels = []
+  let thisWeek = []
+  let lastWeek = []
 
-onMounted(() => {
+  try {
+    const { data } = await getWeeklyOrderStats()
+    const result = data.result
+    labels = result.labels
+    thisWeek = result.thisWeek
+    lastWeek = result.lastWeek
+  } catch (e) {
+    console.error('주간 발주 통계 조회 실패', e)
+  }
+
   new Chart(lineCanvas.value, {
     type: 'line',
     data: {
-      labels: weekLabels,
+      labels,
       datasets: [
         {
           label: '이번 주',
@@ -90,9 +101,9 @@ onMounted(() => {
           border: { display: false },
         },
         y: {
-          min: 10, max: 90,
+          min: 0,
           grid: { color: '#f3f4f6' },
-          ticks: { color: '#9ca3af', font: { size: 11 }, stepSize: 20 },
+          ticks: { color: '#9ca3af', font: { size: 11 }, stepSize: 2, precision: 0 },
           border: { display: false },
         },
       },


### PR DESCRIPTION
## Summary
- 본사 대시보드 주간 발주 통계 라인 차트 API 연동

## 변경 파일
- src/api/dashboard/index.js
- src/components/dashboard/WeeklyOrderChart.vue

## 주요 변경 사항
- dashboard API에 getWeeklyOrderStats 함수 추가
- WeeklyOrderChart 더미 데이터 → API 데이터로 교체
- 이번 주 vs 지난 주 일별 발주 건수 라인 차트 비교 표시

## Test Plan
- [ ] 주간 발주 통계 라인 차트 정상 렌더링 확인
- [ ] 요일 라벨(월~일) 및 이번 주/지난 주 데이터 정상 표시 확인
- [ ] 데이터 없는 요일 0으로 표시 확인

## Issue
- Closes #27
