### PR TITLE
[Feat] #123 - 배송 비율 조회 프론트 API 연동

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -215,12 +215,13 @@ public class DashboardService {
     }
 
     public DashboardDto.DeliveryRatioRes getDeliveryRatio() {
-        // 배송 상태별 건수 조회
-        long ready = deliveryRepository.countByDeliveryStatus(DeliveryStatus.READY);
-        long start = deliveryRepository.countByDeliveryStatus(DeliveryStatus.START);
-        long delivering = deliveryRepository.countByDeliveryStatus(DeliveryStatus.DELIVERYING);
-        long delivered = deliveryRepository.countByDeliveryStatus(DeliveryStatus.DELIVERED);
-        long delay = deliveryRepository.countByDeliveryStatus(DeliveryStatus.DELAY);
+        // 최근 한달 기준 배송 상태별 건수 조회
+        LocalDateTime monthAgo = LocalDate.now().minusMonths(1).atStartOfDay();
+        long ready = deliveryRepository.countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus.READY, monthAgo);
+        long start = deliveryRepository.countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus.START, monthAgo);
+        long delivering = deliveryRepository.countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus.DELIVERYING, monthAgo);
+        long delivered = deliveryRepository.countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus.DELIVERED, monthAgo);
+        long delay = deliveryRepository.countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus.DELAY, monthAgo);
 
         return DashboardDto.DeliveryRatioRes.builder()
                 .ready(ready)

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -4,6 +4,7 @@ import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.domain.delivery.model.Delivery;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
@@ -12,6 +13,9 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     long countByDeliveryStatusIn(List<DeliveryStatus> statuses);
 
     long countByDeliveryStatus(DeliveryStatus status);
+
+    // 배송 비율용: 최근 한달 상태별 건수
+    long countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus status, LocalDateTime since);
 
     List<Delivery> findAllByDeliveryStatus(DeliveryStatus status);
 }

--- a/frontend/src/api/dashboard/index.js
+++ b/frontend/src/api/dashboard/index.js
@@ -11,3 +11,5 @@ export const getDeliveryKpi = () => api.get('/dashboard/delivery/kpi')
 export const getDangerStats = () => api.get('/dashboard/orders/danger/stats')
 
 export const getWeeklyOrderStats = () => api.get('/dashboard/orders/weekly/stats')
+
+export const getDeliveryRatio = () => api.get('/dashboard/delivery/ratio')

--- a/frontend/src/components/dashboard/DeliveryRatioChart.vue
+++ b/frontend/src/components/dashboard/DeliveryRatioChart.vue
@@ -27,19 +27,38 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { Chart } from 'chart.js/auto'
+import { getDeliveryRatio } from '@/api/dashboard'
 
 const donutCanvas = ref(null)
 
 const donutLegend = ref([
-  { label: '배송완료', pct: 65, color: '#f97316' },
-  { label: '배송중', pct: 20, color: '#60a5fa' },
-  { label: '배송지연', pct: 10, color: '#f87171' },
-  { label: '출고대기', pct: 5, color: '#a78bfa' },
+  { label: '배송완료', pct: 0, color: '#f97316' },
+  { label: '배송중', pct: 0, color: '#60a5fa' },
+  { label: '배송지연', pct: 0, color: '#f87171' },
+  { label: '출고대기', pct: 0, color: '#a78bfa' },
+  { label: '출발', pct: 0, color: '#34d399' },
 ])
 
 const deliveryRate = computed(() => donutLegend.value[0].pct)
 
-onMounted(() => {
+onMounted(async () => {
+  try {
+    const { data } = await getDeliveryRatio()
+    const r = data.result
+    const total = r.ready + r.start + r.delivering + r.delivered + r.delay
+
+    if (total > 0) {
+      const pct = (v) => Math.round(v * 1000 / total) / 10
+      donutLegend.value[0].pct = pct(r.delivered)
+      donutLegend.value[1].pct = pct(r.delivering)
+      donutLegend.value[2].pct = pct(r.delay)
+      donutLegend.value[3].pct = pct(r.ready)
+      donutLegend.value[4].pct = pct(r.start)
+    }
+  } catch (e) {
+    console.error('배송 비율 조회 실패', e)
+  }
+
   new Chart(donutCanvas.value, {
     type: 'doughnut',
     data: {

--- a/frontend/src/components/dashboard/DeliveryRatioChart.vue
+++ b/frontend/src/components/dashboard/DeliveryRatioChart.vue
@@ -2,7 +2,7 @@
   <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
     <div class="flex items-center justify-between mb-4">
       <h2 class="font-bold text-gray-900">배송 비율</h2>
-      <span class="text-xs text-gray-400">오늘 기준</span>
+      <span class="text-xs text-gray-400">최근 1개월</span>
     </div>
     <div class="relative mx-auto" style="width:140px;height:140px">
       <canvas ref="donutCanvas"></canvas>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사 대시보드 배송 비율 도넛 차트 API 연동 (최근 1개월 기준)                                                                                                                                                                    
                                                                                                                                                                                                                                
## 변경 파일
- src/api/dashboard/index.js
- src/components/dashboard/DeliveryRatioChart.vue
- DeliveryRepository.java
- DashboardService.java

## 주요 변경 사항
- dashboard API에 getDeliveryRatio 함수 추가
- DeliveryRatioChart 더미 데이터 → API 데이터로 교체
- 배송 상태별(완료/배송중/지연/대기/출발) 비율 도넛 차트 표시
- 배송 비율 조회 기간 전체 → 최근 1개월로 변경
- DeliveryRepository에 날짜 필터 쿼리 추가

## Test Plan
- [ ] 배송 비율 도넛 차트 정상 렌더링 확인
- [ ] 차트 중앙 배송완료율 동적 표시 확인
- [ ] 최근 1개월 데이터만 반영되는지 확인
- [ ] 배송 데이터 없을 시 모든 값 0 표시 확인

## Issue
- Closes #123