### PR TITLE
[Feat] #125 - 위험 재고 목록 프론트 API 연동

### DIFF
--- a/frontend/src/api/dashboard/index.js
+++ b/frontend/src/api/dashboard/index.js
@@ -13,3 +13,6 @@ export const getDangerStats = () => api.get('/dashboard/orders/danger/stats')
 export const getWeeklyOrderStats = () => api.get('/dashboard/orders/weekly/stats')
 
 export const getDeliveryRatio = () => api.get('/dashboard/delivery/ratio')
+
+export const getDangerInventory = (page = 0, size = 4) =>
+  api.get('/dashboard/inventory/danger', { params: { page, size } })

--- a/frontend/src/components/dashboard/DangerInventoryList.vue
+++ b/frontend/src/components/dashboard/DangerInventoryList.vue
@@ -3,19 +3,23 @@
     <div class="mb-3">
       <h2 class="font-bold text-gray-900">재고 위험</h2>
     </div>
-    <div class="space-y-2">
-      <div v-for="w in warnings" :key="w.store + w.product"
+    <div v-if="warnings.length === 0" class="text-xs text-gray-400 text-center py-4">
+      데이터가 없습니다
+    </div>
+    <div v-else class="space-y-2 max-h-48 overflow-y-auto" ref="scrollContainer" @scroll="onScroll">
+      <div v-for="w in warnings" :key="w.inventoryIdx"
         class="flex items-center justify-between py-1.5 cursor-pointer hover:bg-gray-50 rounded px-1 transition-colors"
         role="button" tabindex="0"
-        @click="router.push('/inventory/franchise')"
-        @keydown.enter="router.push('/inventory/franchise')"
-        @keydown.space.prevent="router.push('/inventory/franchise')">
+        @click="router.push('/inventory/head-office')"
+        @keydown.enter="router.push('/inventory/head-office')"
+        @keydown.space.prevent="router.push('/inventory/head-office')">
         <div class="flex items-center gap-2">
-          <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>
-          <p class="text-sm text-gray-800 truncate max-w-28">{{ w.product }}</p>
+          <span class="w-1.5 h-1.5 rounded-full" :class="w.status === 'CRITICAL' ? 'bg-red-500' : 'bg-yellow-500'"></span>
+          <p class="text-sm text-gray-800 truncate max-w-28">{{ w.productName }}</p>
         </div>
-        <span class="text-xs px-2 py-0.5 rounded-full font-medium bg-red-100 text-red-600">
-          {{ w.current }}/{{ w.min }}
+        <span class="text-xs px-2 py-0.5 rounded-full font-medium"
+          :class="w.status === 'CRITICAL' ? 'bg-red-100 text-red-600' : 'bg-yellow-100 text-yellow-600'">
+          {{ w.count }}/{{ w.minStock }}
         </span>
       </div>
     </div>
@@ -23,15 +27,43 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { getDangerInventory } from '@/api/dashboard'
 
 const router = useRouter()
+const warnings = ref([])
+const scrollContainer = ref(null)
+let page = 0
+let hasNext = true
+let loading = false
 
-const warnings = ref([
-  { store: '이탈리안 키친',  product: '한우 등심',  current: 30,  min: 50   },
-  { store: '일식 스시바',    product: '올리브오일', current: 2,   min: 5    },
-  { store: '한우 오마카세',  product: '버터',       current: 8,   min: 20   },
-  { store: '차이나 가든',    product: '생수',       current: 200, min: 500  },
-])
+const fetchData = async () => {
+  if (loading || !hasNext) return
+  loading = true
+  try {
+    const size = page === 0 ? 4 : 10
+    const { data } = await getDangerInventory(page, size)
+    const result = data.result
+    warnings.value.push(...result.items)
+    hasNext = result.hasNext
+    page++
+  } catch (e) {
+    console.error('위험 재고 조회 실패', e)
+  } finally {
+    loading = false
+  }
+}
+
+const onScroll = () => {
+  const el = scrollContainer.value
+  if (!el) return
+  if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
+    fetchData()
+  }
+}
+
+onMounted(() => {
+  fetchData()
+})
 </script>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사 대시보드 위험 재고 목록 API 연동 (무한스크롤)                                                                                                                                                                            

## 변경 파일
- src/api/dashboard/index.js
- src/components/dashboard/DangerInventoryList.vue

## 주요 변경 사항
- dashboard API에 getDangerInventory 함수 추가 (page/size 파라미터)
- DangerInventoryList 더미 데이터 → API 데이터로 교체
- 초기 4건 조회, 스크롤 시 10건씩 무한스크롤 추가 로드
- CRITICAL 빨간색, LOW 노란색 상태별 색상 분기
- 데이터 없을 시 "데이터가 없습니다" 표시

## Test Plan
- [ ] 위험 재고 목록 정상 표시 확인
- [ ] 스크롤 시 추가 데이터 로드 확인
- [ ] CRITICAL/LOW 상태별 색상 분기 확인
- [ ] 위험 재고 없을 시 빈 상태 메시지 확인

## Issue
- Closes #125