### PR TITLE
[Feat] #529 - 지연 배송 목록 조회 구현 및 대시보드 레이아웃 재배치

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -106,4 +106,19 @@ public class DashboardController {
         DashboardDto.DangerInventoryRes result = dashboardService.getDangerInventoryList(page, size);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
+
+    /**
+     * 지연 배송 목록 조회
+     *
+     * @param page 페이지 번호 (0부터 시작, 기본값 0)
+     * @param size 페이지 크기 (기본값 4)
+     * @return ResponseEntity 지연 배송 목록 (Slice 페이징)
+     */
+    @GetMapping("/delivery/delay")
+    public ResponseEntity<BaseResponse> getDelayDeliveryList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "4") int size) {
+        DashboardDto.DelayDeliveryRes result = dashboardService.getDelayDeliveryList(page, size);
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -248,4 +248,19 @@ public class DashboardService {
                 .hasNext(slice.hasNext())
                 .build();
     }
+
+    public DashboardDto.DelayDeliveryRes getDelayDeliveryList(int page, int size) {
+        // 지연 배송 목록: status가 DELAY인 배송
+        Slice<com.example.nexus.domain.delivery.model.Delivery> slice =
+                deliveryRepository.findByDeliveryStatus(DeliveryStatus.DELAY, PageRequest.of(page, size));
+
+        List<DashboardDto.DeliveryItem> items = slice.getContent().stream()
+                .map(DashboardDto.DeliveryItem::from)
+                .toList();
+
+        return DashboardDto.DelayDeliveryRes.builder()
+                .items(items)
+                .hasNext(slice.hasNext())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -112,4 +112,11 @@ public class DashboardDto {
         private List<DangerInventoryItem> items;
         private boolean hasNext;
     }
+
+    @Getter
+    @Builder
+    public static class DelayDeliveryRes {
+        private List<DeliveryItem> items;
+        private boolean hasNext;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -2,6 +2,8 @@ package com.example.nexus.domain.delivery;
 
 import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.domain.delivery.model.Delivery;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -18,4 +20,7 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     long countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus status, LocalDateTime since);
 
     List<Delivery> findAllByDeliveryStatus(DeliveryStatus status);
+
+    // 대시보드용: 지연 배송 목록 Slice 페이징
+    Slice<Delivery> findByDeliveryStatus(DeliveryStatus status, Pageable pageable);
 }

--- a/frontend/src/api/dashboard/index.js
+++ b/frontend/src/api/dashboard/index.js
@@ -16,3 +16,6 @@ export const getDeliveryRatio = () => api.get('/dashboard/delivery/ratio')
 
 export const getDangerInventory = (page = 0, size = 4) =>
   api.get('/dashboard/inventory/danger', { params: { page, size } })
+
+export const getDelayDeliveryList = (page = 0, size = 4) =>
+  api.get('/dashboard/delivery/delay', { params: { page, size } })

--- a/frontend/src/components/dashboard/OngoingDeliveryList.vue
+++ b/frontend/src/components/dashboard/OngoingDeliveryList.vue
@@ -1,10 +1,13 @@
 <template>
   <div class="bg-white rounded-2xl border border-gray-200 shadow-sm flex flex-col">
     <div class="px-5 pt-5 pb-4 border-b border-gray-100">
-      <h2 class="font-bold text-gray-900">진행중 배송</h2>
+      <h2 class="font-bold text-gray-900">지연 배송</h2>
     </div>
-    <div class="flex-1 divide-y divide-gray-50 overflow-y-auto">
-      <div v-for="d in ongoingDeliveries" :key="d.id"
+    <div v-if="deliveries.length === 0 && !loading" class="flex-1 flex items-center justify-center py-8">
+      <p class="text-xs text-gray-400">데이터가 없습니다</p>
+    </div>
+    <div v-else class="flex-1 divide-y divide-gray-50 overflow-y-auto" ref="scrollContainer" @scroll="onScroll">
+      <div v-for="d in deliveries" :key="d.deliveryIdx"
         class="px-5 py-4 hover:bg-gray-50 transition-colors cursor-pointer"
         role="button" tabindex="0"
         @click="router.push('/delivery')"
@@ -12,23 +15,12 @@
         @keydown.space.prevent="router.push('/delivery')">
         <div class="flex items-start gap-3">
           <div class="flex-1 min-w-0">
-            <p class="text-xs text-gray-400">발주 {{ d.num }}</p>
-            <p class="text-sm font-bold text-gray-900 font-mono">{{ d.id }}</p>
-            <div class="flex items-center gap-1.5 mt-1.5 text-xs text-gray-500">
-              <span class="flex items-center gap-1">
-                <span class="w-1.5 h-1.5 rounded-full bg-blue-400 inline-block"></span>{{ d.from }}
-              </span>
-              <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                  d="M17 8l4 4m0 0l-4 4m4-4H3" />
-              </svg>
-              <span class="flex items-center gap-1">
-                <span class="w-1.5 h-1.5 rounded-full bg-green-400 inline-block"></span>{{ d.to }}
-              </span>
-            </div>
+            <p class="text-xs text-gray-400">발주 #{{ d.ordersIdx }}</p>
+            <p class="text-sm font-bold text-gray-900">{{ d.storeName }}</p>
           </div>
-          <span class="text-xs px-2 py-0.5 rounded-full font-medium shrink-0" :class="deliveryCls(d.status)">{{
-            d.status }}</span>
+          <span class="text-xs px-2 py-0.5 rounded-full font-medium shrink-0 bg-red-50 text-red-600 border border-red-200">
+            지연
+          </span>
         </div>
       </div>
     </div>
@@ -36,22 +28,43 @@
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { getDelayDeliveryList } from '@/api/dashboard'
 
 const router = useRouter()
+const deliveries = ref([])
+const scrollContainer = ref(null)
+let page = 0
+let hasNext = true
+let loading = false
 
-const ongoingDeliveries = [
-  { num: 1, id: 'ORD-2604-001', from: '본사 창고', to: '이탈리안 키친',  status: '배송중' },
-  { num: 2, id: 'ORD-2604-002', from: '본사 창고', to: '한우 오마카세',  status: '출고대기' },
-  { num: 3, id: 'ORD-2604-004', from: '본사 창고', to: '프렌치 비스트로', status: '배송지연' },
-  { num: 4, id: 'ORD-2604-005', from: '본사 창고', to: '일식 스시바',    status: '출고완료' },
-]
+const fetchData = async () => {
+  if (loading || !hasNext) return
+  loading = true
+  try {
+    const size = page === 0 ? 4 : 10
+    const { data } = await getDelayDeliveryList(page, size)
+    const result = data.result
+    deliveries.value.push(...result.items)
+    hasNext = result.hasNext
+    page++
+  } catch (e) {
+    console.error('지연 배송 조회 실패', e)
+  } finally {
+    loading = false
+  }
+}
 
-const deliveryCls = s => ({
-  '배송중': 'bg-blue-50 text-blue-600 border border-blue-200',
-  '출고대기': 'bg-gray-100 text-gray-600 border border-gray-200',
-  '출고완료': 'bg-green-50 text-green-700 border border-green-200',
-  '배송완료': 'bg-green-50 text-green-700 border border-green-200',
-  '배송지연': 'bg-red-50 text-red-600 border border-red-200',
-}[s] || 'bg-gray-100 text-gray-500 border border-gray-200')
+const onScroll = () => {
+  const el = scrollContainer.value
+  if (!el) return
+  if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
+    fetchData()
+  }
+}
+
+onMounted(() => {
+  fetchData()
+})
 </script>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -22,18 +22,18 @@
       <DeliveryKpiCard />
     </div>
 
-    <!-- 중간 행: 라인차트 + 진행중 배송 -->
+    <!-- 중간 행: 라인차트 + 재고위험 -->
     <div class="grid grid-cols-3 gap-4">
       <WeeklyOrderChart />
-      <OngoingDeliveryList />
+      <DangerInventoryList />
     </div>
 
-    <!-- 하단 행: 이상발주 바그래프 + 배송비율 도넛/재고위험 -->
+    <!-- 하단 행: 이상발주 바그래프 + 지연배송/배송비율 -->
     <div class="grid grid-cols-3 gap-4">
       <DangerOrderChart />
       <div class="space-y-4">
+        <OngoingDeliveryList />
         <DeliveryRatioChart />
-        <DangerInventoryList />
       </div>
     </div>
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 지연 배송 목록 조회 API 구현 및 프론트 연동, 대시보드 레이아웃 재배치                                                                                                                                                         

## 변경 파일
- DeliveryRepository.java
- DashboardController.java
- DashboardService.java
- DashboardDto.java
- src/api/dashboard/index.js
- src/components/dashboard/OngoingDeliveryList.vue
- src/views/DashboardView.vue

## 주요 변경 사항
- GET /dashboard/delivery/delay 엔드포인트 추가 (Slice 페이징)
- DeliveryRepository에 Slice 페이징 쿼리 추가
- DelayDeliveryRes DTO 추가 (items, hasNext)
- OngoingDeliveryList 더미 데이터 → 지연 배송 API 연동
- 초기 4건 조회, 스크롤 시 10건씩 무한스크롤 추가 로드
- 대시보드 레이아웃 재배치 (중간: 재고위험, 하단: 지연배송 + 배송비율)

## Test Plan
- [ ] /dashboard/delivery/delay 호출 시 지연 배송 목록 정상 반환 확인
- [ ] 지연 배송 목록 무한스크롤 동작 확인
- [ ] 지연 배송 없을 시 "데이터가 없습니다" 표시 확인
- [ ] 대시보드 레이아웃 변경 후 정상 렌더링 확인

## Issue
- Closes #529