### PR TITLE
[Feat] #126 - 점주 대시보드 금일 매출 KPI 조회 API 구현     

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
@@ -1,0 +1,30 @@
+package com.example.nexus.domain.dashboard;
+
+import com.example.nexus.common.model.BaseResponse;
+import com.example.nexus.domain.dashboard.model.StoreDashboardDto;
+import com.example.nexus.domain.user.model.AuthUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/store/dashboard")
+@RequiredArgsConstructor
+public class StoreDashboardController {
+    private final StoreDashboardService storeDashboardService;
+
+    /**
+     * 금일 매출 KPI 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity 금일 매출 총액, 전일 대비 증감률
+     */
+    @GetMapping("/sales/kpi")
+    public ResponseEntity<BaseResponse> getSalesKpi(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        StoreDashboardDto.SalesKpiRes result = storeDashboardService.getSalesKpi(authUserDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
@@ -35,8 +35,8 @@ public class StoreDashboardService {
         LocalDateTime yesterdayStart = today.minusDays(1).atStartOfDay();
 
         // POS 매출 합산
-        long todaySales = posPayRepository.sumPayAmountByStoreAndPaidAtBetween(store.getIdx(), todayStart, todayEnd);
-        long yesterdaySales = posPayRepository.sumPayAmountByStoreAndPaidAtBetween(store.getIdx(), yesterdayStart, todayStart);
+        long todaySales = posPayRepository.sumPayAmountByStoreAndPeriod(store.getIdx(), todayStart, todayEnd);
+        long yesterdaySales = posPayRepository.sumPayAmountByStoreAndPeriod(store.getIdx(), yesterdayStart, todayStart);
 
         // 전일 대비 증감률 계산 (전일 매출이 0이면 0.0%)
         double deltaPercent = 0.0;

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
@@ -1,0 +1,52 @@
+package com.example.nexus.domain.dashboard;
+
+import com.example.nexus.common.exception.BaseException;
+import com.example.nexus.common.model.BaseResponseStatus;
+import com.example.nexus.domain.dashboard.model.StoreDashboardDto;
+import com.example.nexus.domain.pos.PosPayRepository;
+import com.example.nexus.domain.store.StoreRepository;
+import com.example.nexus.domain.store.model.Store;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class StoreDashboardService {
+    private final PosPayRepository posPayRepository;
+    private final StoreRepository storeRepository;
+
+    /**
+     * 금일 매출 KPI 조회
+     * - 로그인된 점주의 매장에서 당일 발생한 POS 매출 총액을 집계
+     * - 전일 매출과 비교하여 증감률(%) 계산
+     */
+    public StoreDashboardDto.SalesKpiRes getSalesKpi(Long userIdx) {
+        // 점주의 매장 조회
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // 금일/전일 기간 설정
+        LocalDate today = LocalDate.now();
+        LocalDateTime todayStart = today.atStartOfDay();
+        LocalDateTime todayEnd = today.plusDays(1).atStartOfDay();
+        LocalDateTime yesterdayStart = today.minusDays(1).atStartOfDay();
+
+        // POS 매출 합산
+        long todaySales = posPayRepository.sumPayAmountByStoreAndPaidAtBetween(store.getIdx(), todayStart, todayEnd);
+        long yesterdaySales = posPayRepository.sumPayAmountByStoreAndPaidAtBetween(store.getIdx(), yesterdayStart, todayStart);
+
+        // 전일 대비 증감률 계산 (전일 매출이 0이면 0.0%)
+        double deltaPercent = 0.0;
+        if (yesterdaySales > 0) {
+            deltaPercent = Math.round((todaySales - yesterdaySales) * 1000.0 / yesterdaySales) / 10.0;
+        }
+
+        return StoreDashboardDto.SalesKpiRes.builder()
+                .todaySales(todaySales)
+                .deltaPercent(deltaPercent)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
@@ -1,0 +1,14 @@
+package com.example.nexus.domain.dashboard.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class StoreDashboardDto {
+
+    @Getter
+    @Builder
+    public static class SalesKpiRes {
+        private long todaySales;
+        private double deltaPercent;
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface PosPayRepository extends JpaRepository<PosPay, Long> {
     List<PosPay> findByStore_IdxAndPaidAtBetweenOrderByPaidAtDesc(Long storeIdx, LocalDateTime from, LocalDateTime to);
 
-    // 대시보드
-    @Query("SELECT COALESCE(SUM(p.payAmount), 0) FROM PosPay p WHERE p.store.idx = :storeIdx AND p.paidAt BETWEEN :from AND :to")
-    long sumPayAmountByStoreAndPaidAtBetween(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+    // 대시보드: 반개방 구간 [from, to)
+    @Query("SELECT COALESCE(SUM(p.payAmount), 0) FROM PosPay p WHERE p.store.idx = :storeIdx AND p.paidAt >= :from AND p.paidAt < :to")
+    long sumPayAmountByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 }

--- a/backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java
@@ -3,9 +3,15 @@ package com.example.nexus.domain.pos;
 import com.example.nexus.domain.pos.model.PosPay;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PosPayRepository extends JpaRepository<PosPay, Long> {
     List<PosPay> findByStore_IdxAndPaidAtBetweenOrderByPaidAtDesc(Long storeIdx, LocalDateTime from, LocalDateTime to);
+
+    @Query("SELECT COALESCE(SUM(p.payAmount), 0) FROM PosPay p WHERE p.store.idx = :storeIdx AND p.paidAt BETWEEN :from AND :to")
+    long sumPayAmountByStoreAndPaidAtBetween(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 }

--- a/backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
 public interface PosPayRepository extends JpaRepository<PosPay, Long> {
     List<PosPay> findByStore_IdxAndPaidAtBetweenOrderByPaidAtDesc(Long storeIdx, LocalDateTime from, LocalDateTime to);
 
+    // 대시보드
     @Query("SELECT COALESCE(SUM(p.payAmount), 0) FROM PosPay p WHERE p.store.idx = :storeIdx AND p.paidAt BETWEEN :from AND :to")
     long sumPayAmountByStoreAndPaidAtBetween(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 로그인 시 본인 매장의 금일 POS 매출 총액과 전일 대비 증감률을 조회하는 API 구현                                                                                                                                          
                                                                                                                                                                                                                                
## 변경 파일
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java (신규)
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java (신규)
- backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java (신규)
- backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java (수정)

## 주요 변경 사항
- StoreDashboardController 신규 생성 (GET /store/dashboard/sales/kpi)
- StoreDashboardService에서 금일/전일 매출 합산 및 증감률 계산 로직 구현
- StoreDashboardDto.SalesKpiRes 응답 DTO 추가 (todaySales, deltaPercent)
- PosPayRepository에 매장별 기간 매출 합산 JPQL 쿼리 추가

## Test Plan
- [ ] 점주 계정 로그인 후 GET /store/dashboard/sales/kpi 호출 시 정상 응답 확인
- [ ] 금일 POS 결제 데이터 존재 시 todaySales 합산 정확성 확인
- [ ] 전일 매출 0원일 때 deltaPercent가 0.0으로 반환되는지 확인

## Issue
- Closes #126