### PR TITLE
[Feat] #128 - 점주 대시보드 제안 발주서 KPI 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
@@ -27,4 +27,16 @@ public class StoreDashboardController {
         StoreDashboardDto.SalesKpiRes result = storeDashboardService.getSalesKpi(authUserDetails.getIdx());
         return ResponseEntity.ok(BaseResponse.success(result));
     }
+
+    /**
+     * 제안 발주서 KPI 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity 승인 대기 상태의 제안 발주서 건수
+     */
+    @GetMapping("/orders/pending/kpi")
+    public ResponseEntity<BaseResponse> getPendingOrderKpi(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        StoreDashboardDto.PendingOrderKpiRes result = storeDashboardService.getPendingOrderKpi(authUserDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
@@ -1,8 +1,11 @@
 package com.example.nexus.domain.dashboard;
 
+import com.example.nexus.common.enums.OrdersStatus;
+import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.common.exception.BaseException;
 import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.domain.dashboard.model.StoreDashboardDto;
+import com.example.nexus.domain.orders.OrdersRepository;
 import com.example.nexus.domain.pos.PosPayRepository;
 import com.example.nexus.domain.store.StoreRepository;
 import com.example.nexus.domain.store.model.Store;
@@ -16,6 +19,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class StoreDashboardService {
     private final PosPayRepository posPayRepository;
+    private final OrdersRepository ordersRepository;
     private final StoreRepository storeRepository;
 
     /**
@@ -47,6 +51,24 @@ public class StoreDashboardService {
         return StoreDashboardDto.SalesKpiRes.builder()
                 .todaySales(todaySales)
                 .deltaPercent(deltaPercent)
+                .build();
+    }
+
+    /**
+     * 제안 발주서 KPI 조회
+     * - 점주 매장에 대해 본사가 자동 생성한 발주서 중 승인 대기(WAITING) 상태 건수 반환
+     */
+    public StoreDashboardDto.PendingOrderKpiRes getPendingOrderKpi(Long userIdx) {
+        // 점주의 매장 조회
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // 승인 대기 상태의 자동 발주 건수 조회
+        long pendingCount = ordersRepository.countByStore_IdxAndOrdersStatusAndOrdersType(
+                store.getIdx(), OrdersStatus.WAITING, OrdersType.AUTO);
+
+        return StoreDashboardDto.PendingOrderKpiRes.builder()
+                .pendingCount(pendingCount)
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
@@ -11,4 +11,10 @@ public class StoreDashboardDto {
         private long todaySales;
         private double deltaPercent;
     }
+
+    @Getter
+    @Builder
+    public static class PendingOrderKpiRes {
+        private long pendingCount;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -1,6 +1,7 @@
 package com.example.nexus.domain.orders;
 
 import com.example.nexus.common.enums.OrdersStatus;
+import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.orders.model.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -21,8 +22,8 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "WHERE o.store.idx = :storeIdx AND o.createdAt >= :since AND (:excludeIdx IS NULL OR o.idx <> :excludeIdx)")
     Integer findAvgQtyByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("since") LocalDateTime since, @Param("excludeIdx") Long excludeIdx);
 
-    // 대시보드용
-    long countByOrdersTypeAndCreatedAtAfter(com.example.nexus.common.enums.OrdersType ordersType, LocalDateTime since);
+    // 본사 대시보드용
+    long countByOrdersTypeAndCreatedAtAfter(OrdersType ordersType, LocalDateTime since);
 
     long countByOrdersStatus(OrdersStatus ordersStatus);
 
@@ -39,4 +40,8 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d') " +
             "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d')")
     List<Object[]> findWeeklyOrderStats(@Param("since") LocalDateTime since);
+
+    // 점주 대시보드용
+    long countByStore_IdxAndOrdersStatusAndOrdersType(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
+
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 매장에 대해 본사가 자동 생성한 발주서 중 승인 대기(WAITING) 건수를 조회하는 API 구현                                                                                                                                       
                                                                                                                                                                                                                                  
## 변경 파일                                                                                                                                                                                                                      
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java                                                                                                                                          
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
- backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
- backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java

## 주요 변경 사항
- StoreDashboardController에 GET /store/dashboard/orders/pending/kpi 엔드포인트 추가
- StoreDashboardService에 점주 매장별 승인 대기 자동 발주 건수 조회 로직 구현
- OrdersRepository에 매장/상태/타입 기준 카운트 쿼리 추가
- StoreDashboardDto.PendingOrderKpiRes 응답 DTO 추가

## Test Plan
- [ ] 점주 계정 로그인 후 GET /store/dashboard/orders/pending/kpi 호출 시 정상 응답 확인
- [ ] WAITING + AUTO 상태 발주 데이터 존재 시 pendingCount 정확성 확인
- [ ] 승인 대기 발주가 없을 때 pendingCount가 0으로 반환되는지 확인

## Issue
- Closes #128