### PR TITLE
[Feat] #532 - 점주 대시보드 재고 위험 품목 KPI 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
@@ -39,4 +39,16 @@ public class StoreDashboardController {
         StoreDashboardDto.PendingOrderKpiRes result = storeDashboardService.getPendingOrderKpi(authUserDetails.getIdx());
         return ResponseEntity.ok(BaseResponse.success(result));
     }
+
+    /**
+     * 재고 위험 품목 KPI 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity LOW(주의)/CRITICAL(위험) 상태 품목 수
+     */
+    @GetMapping("/inventory/risk/kpi")
+    public ResponseEntity<BaseResponse> getInventoryRiskKpi(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        StoreDashboardDto.InventoryRiskKpiRes result = storeDashboardService.getInventoryRiskKpi(authUserDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
@@ -1,5 +1,6 @@
 package com.example.nexus.domain.dashboard;
 
+import com.example.nexus.common.enums.InventoryStatus;
 import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.common.exception.BaseException;
@@ -7,6 +8,7 @@ import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.domain.dashboard.model.StoreDashboardDto;
 import com.example.nexus.domain.orders.OrdersRepository;
 import com.example.nexus.domain.pos.PosPayRepository;
+import com.example.nexus.domain.store.StoreInventoryRepository;
 import com.example.nexus.domain.store.StoreRepository;
 import com.example.nexus.domain.store.model.Store;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ import java.time.LocalDateTime;
 public class StoreDashboardService {
     private final PosPayRepository posPayRepository;
     private final OrdersRepository ordersRepository;
+    private final StoreInventoryRepository storeInventoryRepository;
     private final StoreRepository storeRepository;
 
     /**
@@ -69,6 +72,26 @@ public class StoreDashboardService {
 
         return StoreDashboardDto.PendingOrderKpiRes.builder()
                 .pendingCount(pendingCount)
+                .build();
+    }
+
+    /**
+     * 재고 위험 품목 KPI 조회
+     * - 점주 매장의 재고 중 LOW(주의)/CRITICAL(위험) 상태인 품목 수 반환
+     */
+    public StoreDashboardDto.InventoryRiskKpiRes getInventoryRiskKpi(Long userIdx) {
+        // 점주의 매장 조회
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // 상태별 위험 재고 건수 조회
+        long lowCount = storeInventoryRepository.countByStore_IdxAndStatus(store.getIdx(), InventoryStatus.LOW);
+        long criticalCount = storeInventoryRepository.countByStore_IdxAndStatus(store.getIdx(), InventoryStatus.CRITICAL);
+
+        return StoreDashboardDto.InventoryRiskKpiRes.builder()
+                .lowCount(lowCount)
+                .criticalCount(criticalCount)
+                .totalDangerCount(lowCount + criticalCount)
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
@@ -17,4 +17,12 @@ public class StoreDashboardDto {
     public static class PendingOrderKpiRes {
         private long pendingCount;
     }
+
+    @Getter
+    @Builder
+    public static class InventoryRiskKpiRes {
+        private long lowCount;
+        private long criticalCount;
+        private long totalDangerCount;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreInventoryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreInventoryRepository.java
@@ -1,5 +1,6 @@
 package com.example.nexus.domain.store;
 
+import com.example.nexus.common.enums.InventoryStatus;
 import com.example.nexus.domain.store.model.StoreInventory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,7 @@ import java.util.Optional;
 public interface StoreInventoryRepository extends JpaRepository<StoreInventory, Long> {
     List<StoreInventory> findByStoreIdx(Long storeIdx);
     Optional<StoreInventory> findByStoreIdxAndProductIdx(Long storeIdx, Long productIdx);
+
+    // 점주 대시보드용
+    long countByStore_IdxAndStatus(Long storeIdx, InventoryStatus status);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 매장의 재고 중 최소 수량 이하인 품목 수를 위험(CRITICAL)/주의(LOW) 단계로 구분하여 조회하는 API 구현                                                                                                                       
                                                                                                                                                                                                                                  
## 변경 파일                                                                                                                                                                                                                      
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java                                                                                                                                          
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
- backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
- backend/src/main/java/com/example/nexus/domain/store/StoreInventoryRepository.java

## 주요 변경 사항
- StoreDashboardController에 GET /store/dashboard/inventory/risk/kpi 엔드포인트 추가
- StoreDashboardService에 점주 매장별 LOW/CRITICAL 상태 재고 카운트 로직 구현
- StoreInventoryRepository에 매장/상태 기준 카운트 쿼리 추가
- StoreDashboardDto.InventoryRiskKpiRes 응답 DTO 추가 (lowCount, criticalCount, totalDangerCount)

## Test Plan
- [ ] 점주 계정 로그인 후 GET /store/dashboard/inventory/risk/kpi 호출 시 정상 응답 확인
- [ ] LOW/CRITICAL 상태 재고 존재 시 각 건수 정확성 확인
- [ ] 위험 재고가 없을 때 모든 값이 0으로 반환되는지 확인

## Issue
- Closes #532