### PR TITLE
[Feat] #536 - 점주 대시보드 일별 매출 추이 차트 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
@@ -63,4 +63,16 @@ public class StoreDashboardController {
         StoreDashboardDto.SettlementKpiRes result = storeDashboardService.getSettlementKpi(authUserDetails.getIdx());
         return ResponseEntity.ok(BaseResponse.success(result));
     }
+
+    /**
+     * 일별 매출 추이 차트 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity 이번 주/지난 주 요일별 매출 데이터
+     */
+    @GetMapping("/sales/daily")
+    public ResponseEntity<BaseResponse> getDailySalesChart(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        StoreDashboardDto.DailySalesChartRes result = storeDashboardService.getDailySalesChart(authUserDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
@@ -14,8 +14,13 @@ import com.example.nexus.domain.store.model.Store;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -147,5 +152,58 @@ public class StoreDashboardService {
                 .currentPeriod(currentPeriod)
                 .deltaPercent(deltaPercent)
                 .build();
+    }
+
+    /**
+     * 일별 매출 추이 차트 조회
+     * - 이번 주(일~토)와 지난 주의 일별 POS 매출을 비교
+     * - 단위: 원 (프론트에서 만원 변환)
+     */
+    public StoreDashboardDto.DailySalesChartRes getDailySalesChart(Long userIdx) {
+        // 점주의 매장 조회
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // 이번 주 일요일 ~ 토요일 구간 계산
+        LocalDate today = LocalDate.now();
+        LocalDate thisWeekSunday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        LocalDate lastWeekSunday = thisWeekSunday.minusWeeks(1);
+
+        LocalDateTime thisWeekStart = thisWeekSunday.atStartOfDay();
+        LocalDateTime thisWeekEnd = thisWeekSunday.plusWeeks(1).atStartOfDay();
+        LocalDateTime lastWeekStart = lastWeekSunday.atStartOfDay();
+        LocalDateTime lastWeekEnd = thisWeekStart;
+
+        // 일별 매출 조회
+        Map<LocalDate, Long> thisWeekMap = toDailySalesMap(
+                posPayRepository.findDailySalesByStoreAndPeriod(store.getIdx(), thisWeekStart, thisWeekEnd));
+        Map<LocalDate, Long> lastWeekMap = toDailySalesMap(
+                posPayRepository.findDailySalesByStoreAndPeriod(store.getIdx(), lastWeekStart, lastWeekEnd));
+
+        // 요일별 데이터 배열 생성 (일~토)
+        List<String> labels = Arrays.asList("일", "월", "화", "수", "목", "금", "토");
+        Long[] thisWeekData = new Long[7];
+        Long[] lastWeekData = new Long[7];
+
+        for (int i = 0; i < 7; i++) {
+            thisWeekData[i] = thisWeekMap.getOrDefault(thisWeekSunday.plusDays(i), 0L);
+            lastWeekData[i] = lastWeekMap.getOrDefault(lastWeekSunday.plusDays(i), 0L);
+        }
+
+        return StoreDashboardDto.DailySalesChartRes.builder()
+                .labels(labels)
+                .thisWeek(Arrays.asList(thisWeekData))
+                .lastWeek(Arrays.asList(lastWeekData))
+                .build();
+    }
+
+    private Map<LocalDate, Long> toDailySalesMap(List<Object[]> rows) {
+        Map<LocalDate, Long> map = new java.util.HashMap<>();
+        for (Object[] row : rows) {
+            LocalDate date = ((java.sql.Date) row[0]).toLocalDate();
+            Long amount = (Long) row[1];
+            map.put(date, amount);
+        }
+        return map;
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
@@ -3,6 +3,8 @@ package com.example.nexus.domain.dashboard.model;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 public class StoreDashboardDto {
 
     @Getter
@@ -32,5 +34,13 @@ public class StoreDashboardDto {
         private long currentAmount;
         private String currentPeriod;
         private double deltaPercent;
+    }
+
+    @Getter
+    @Builder
+    public static class DailySalesChartRes {
+        private List<String> labels;
+        private List<Long> thisWeek;
+        private List<Long> lastWeek;
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java
@@ -15,4 +15,8 @@ public interface PosPayRepository extends JpaRepository<PosPay, Long> {
     // 대시보드: 반개방 구간 [from, to)
     @Query("SELECT COALESCE(SUM(p.payAmount), 0) FROM PosPay p WHERE p.store.idx = :storeIdx AND p.paidAt >= :from AND p.paidAt < :to")
     long sumPayAmountByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
+    // 대시보드: 기간 내 일별 매출 합산 (날짜, 금액)
+    @Query("SELECT CAST(p.paidAt AS LocalDate), COALESCE(SUM(p.payAmount), 0) FROM PosPay p WHERE p.store.idx = :storeIdx AND p.paidAt >= :from AND p.paidAt < :to GROUP BY CAST(p.paidAt AS LocalDate) ORDER BY CAST(p.paidAt AS LocalDate)")
+    List<Object[]> findDailySalesByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 매장의 이번 주/지난 주 요일별(일~토) POS 매출을 비교하는 라인차트 데이터 조회 API 구현                                                                                                                                     
                                                                                                                                                                                                                                  
## 변경 파일                                                                                                                                                                                                                      
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java                                                                                                                                          
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java                                                                                                                                             
- backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
- backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java

## 주요 변경 사항
- StoreDashboardController에 GET /store/dashboard/sales/daily 엔드포인트 추가
- StoreDashboardService에 이번 주/지난 주 일별 매출 집계 및 요일 매핑 로직 구현
- PosPayRepository에 기간 내 일별 매출 그룹 쿼리(findDailySalesByStoreAndPeriod) 추가
- StoreDashboardDto.DailySalesChartRes 응답 DTO 추가 (labels, thisWeek, lastWeek)

## Test Plan
- [ ] 점주 계정 로그인 후 GET /store/dashboard/sales/daily 호출 시 정상 응답 확인
- [ ] labels가 ["일","월","화","수","목","금","토"] 7개로 반환되는지 확인
- [ ] POS 매출 데이터가 없는 요일은 0으로 반환되는지 확인

## Issue
- Closes #536