### PR TITLE
[Feat] #538 - 점주 대시보드 나의 배송 현황 목록 조회 API 구현    

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
@@ -4,6 +4,8 @@ import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.domain.dashboard.model.StoreDashboardDto;
 import com.example.nexus.domain.user.model.AuthUserDetails;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -73,6 +75,18 @@ public class StoreDashboardController {
     @GetMapping("/sales/daily")
     public ResponseEntity<BaseResponse> getDailySalesChart(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
         StoreDashboardDto.DailySalesChartRes result = storeDashboardService.getDailySalesChart(authUserDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
+     * 나의 배송 현황 목록 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity 배송 진행중인 건의 상태 목록
+     */
+    @GetMapping("/delivery/list")
+    public ResponseEntity<BaseResponse> getMyDeliveryList(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        List<StoreDashboardDto.MyDeliveryItem> result = storeDashboardService.getMyDeliveryList(authUserDetails.getIdx());
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
@@ -1,11 +1,14 @@
 package com.example.nexus.domain.dashboard;
 
+import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.common.enums.InventoryStatus;
 import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.common.exception.BaseException;
 import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.domain.dashboard.model.StoreDashboardDto;
+import com.example.nexus.domain.delivery.DeliveryRepository;
+import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.orders.OrdersRepository;
 import com.example.nexus.domain.pos.PosPayRepository;
 import com.example.nexus.domain.store.StoreInventoryRepository;
@@ -27,6 +30,7 @@ import java.util.Map;
 public class StoreDashboardService {
     private final PosPayRepository posPayRepository;
     private final OrdersRepository ordersRepository;
+    private final DeliveryRepository deliveryRepository;
     private final StoreInventoryRepository storeInventoryRepository;
     private final StoreRepository storeRepository;
 
@@ -195,6 +199,21 @@ public class StoreDashboardService {
                 .thisWeek(Arrays.asList(thisWeekData))
                 .lastWeek(Arrays.asList(lastWeekData))
                 .build();
+    }
+
+    /**
+     * 나의 배송 현황 목록 조회
+     * - 점주 매장으로 배송 중인 건의 상태 목록 반환 (배송완료 제외)
+     */
+    public List<StoreDashboardDto.MyDeliveryItem> getMyDeliveryList(Long userIdx) {
+        // 점주의 매장 조회
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // 배송완료(DELIVERED) 제외한 배송 목록 조회
+        return deliveryRepository
+                .findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc(store.getIdx(), DeliveryStatus.DELIVERED)
+                .stream().map(StoreDashboardDto.MyDeliveryItem::from).toList();
     }
 
     private Map<LocalDate, Long> toDailySalesMap(List<Object[]> rows) {

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
@@ -1,5 +1,6 @@
 package com.example.nexus.domain.dashboard.model;
 
+import com.example.nexus.domain.delivery.model.Delivery;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -43,4 +44,23 @@ public class StoreDashboardDto {
         private List<Long> thisWeek;
         private List<Long> lastWeek;
     }
+
+    @Getter
+    @Builder
+    public static class MyDeliveryItem {
+        private Long deliveryIdx;
+        private Long ordersIdx;
+        private String status;
+        private String estimatedArrival;
+
+        public static MyDeliveryItem from(Delivery entity) {
+            return MyDeliveryItem.builder()
+                    .deliveryIdx(entity.getIdx())
+                    .ordersIdx(entity.getOrders().getIdx())
+                    .status(entity.getDeliveryStatus().name())
+                    .estimatedArrival(entity.getEstimatedArrivalAt().toLocalDate().toString())
+                    .build();
+        }
+    }
+
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -23,4 +23,7 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
     // 대시보드용: 지연 배송 목록 Slice 페이징
     Slice<Delivery> findByDeliveryStatus(DeliveryStatus status, Pageable pageable);
+
+    // 점주 대시보드용: 매장별 배송 목록 (배송완료 제외)
+    List<Delivery> findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc(Long storeIdx, DeliveryStatus excludeStatus);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 매장으로 배송 중인 발주건의 배송 진행 현황을 목록으로 조회하는 API 구현 (배송완료 제외)                                                                                                                                    
                                                                                                                                                                                                                                  
## 변경 파일                                              
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
- backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
- backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java

## 주요 변경 사항
- StoreDashboardController에 GET /store/dashboard/delivery/list 엔드포인트 추가
- StoreDashboardService에 점주 매장별 진행중 배송 목록 조회 로직 구현 (stream + map 활용)
- DeliveryRepository에 매장별 배송완료 제외 목록 쿼리 추가
- StoreDashboardDto.MyDeliveryItem 응답 DTO 추가 (deliveryIdx, ordersIdx, status, estimatedArrival)

## Test Plan
- [ ] 점주 계정 로그인 후 GET /store/dashboard/delivery/list 호출 시 정상 응답 확인
- [ ] DELIVERED 상태 건이 목록에서 제외되는지 확인
- [ ] 배송 건이 없을 때 빈 배열로 반환되는지 확인

## Issue
- Closes #538