### PR TITLE
[Feat] #540 - 점주 대시보드 제안 발주서 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
@@ -89,4 +89,16 @@ public class StoreDashboardController {
         List<StoreDashboardDto.MyDeliveryItem> result = storeDashboardService.getMyDeliveryList(authUserDetails.getIdx());
         return ResponseEntity.ok(BaseResponse.success(result));
     }
+
+    /**
+     * 제안 발주서 목록 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity 승인 대기 상태의 자동 발주서 목록
+     */
+    @GetMapping("/orders/pending/list")
+    public ResponseEntity<BaseResponse> getPendingOrderList(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        List<StoreDashboardDto.PendingOrderItem> result = storeDashboardService.getPendingOrderList(authUserDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
@@ -202,6 +202,21 @@ public class StoreDashboardService {
     }
 
     /**
+     * 제안 발주서 목록 조회
+     * - 점주 매장에 대해 본사가 자동 생성한 발주서 중 승인 대기(WAITING) 상태 목록 반환
+     */
+    public List<StoreDashboardDto.PendingOrderItem> getPendingOrderList(Long userIdx) {
+        // 점주의 매장 조회
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // WAITING + AUTO 발주서 목록 조회
+        return ordersRepository
+                .findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(store.getIdx(), OrdersStatus.WAITING, OrdersType.AUTO)
+                .stream().map(StoreDashboardDto.PendingOrderItem::from).toList();
+    }
+
+    /**
      * 나의 배송 현황 목록 조회
      * - 점주 매장으로 배송 중인 건의 상태 목록 반환 (배송완료 제외)
      */

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
@@ -1,6 +1,8 @@
 package com.example.nexus.domain.dashboard.model;
 
 import com.example.nexus.domain.delivery.model.Delivery;
+import com.example.nexus.domain.orders.model.Orders;
+import com.example.nexus.domain.orders.model.OrdersItem;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -43,6 +45,34 @@ public class StoreDashboardDto {
         private List<String> labels;
         private List<Long> thisWeek;
         private List<Long> lastWeek;
+    }
+
+    @Getter
+    @Builder
+    public static class PendingOrderItem {
+        private Long ordersIdx;
+        private String productName;
+        private int quantity;
+        private long price;
+        private String status;
+
+        public static PendingOrderItem from(Orders orders) {
+            // 첫 번째 품목명 + 외 N건 형태
+            List<OrdersItem> items = orders.getOrdersItemList();
+            String productName = items.isEmpty() ? "-" : items.get(0).getProduct().getProductName();
+            if (items.size() > 1) {
+                productName += " 외 " + (items.size() - 1) + "건";
+            }
+            int totalQty = items.stream().mapToInt(OrdersItem::getCount).sum();
+
+            return PendingOrderItem.builder()
+                    .ordersIdx(orders.getIdx())
+                    .productName(productName)
+                    .quantity(totalQty)
+                    .price(orders.getPrice())
+                    .status(orders.getOrdersStatus().name())
+                    .build();
+        }
     }
 
     @Getter

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -44,6 +44,8 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     // 점주 대시보드용
     long countByStore_IdxAndOrdersStatusAndOrdersType(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
 
+    List<Orders> findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
+
     @Query("SELECT COALESCE(SUM(o.price), 0) FROM Orders o WHERE o.store.idx = :storeIdx AND o.ordersStatus = 'APPROVE' AND o.createdAt >= :from AND o.createdAt < :to")
     long sumApprovedPriceByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사로부터 제안받은 발주서(WAITING + AUTO) 목록을 품목명, 수량, 금액, 상태와 함께 조회하는 API 구현

## 변경 파일
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
- backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
- backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java

## 주요 변경 사항
- StoreDashboardController에 GET /store/dashboard/orders/pending/list 엔드포인트 추가
- StoreDashboardService에 점주 매장별 제안 발주서 목록 조회 로직 구현
- OrdersRepository에 매장/상태/타입 기준 목록 쿼리 추가
- StoreDashboardDto.PendingOrderItem 응답 DTO 추가 (품목명 "첫 품목 외 N건" 형태, 총 수량, 금액, 상태)

## Test Plan
- [ ] 점주 계정 로그인 후 GET /store/dashboard/orders/pending/list 호출 시 정상 응답 확인
- [ ] WAITING + AUTO 조건의 발주서만 반환되는지 확인
- [ ] 품목이 여러 개인 발주서에서 "외 N건" 형태로 표시되는지 확인

## Issue
- Closes #540