### PR TITLE
[Feat] #542 - 점주 대시보드 재고 위험 품목 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
@@ -101,4 +101,16 @@ public class StoreDashboardController {
         List<StoreDashboardDto.PendingOrderItem> result = storeDashboardService.getPendingOrderList(authUserDetails.getIdx());
         return ResponseEntity.ok(BaseResponse.success(result));
     }
+
+    /**
+     * 재고 위험 품목 목록 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity LOW/CRITICAL 상태 재고 품목 목록
+     */
+    @GetMapping("/inventory/risk/list")
+    public ResponseEntity<BaseResponse> getInventoryWarningList(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        List<StoreDashboardDto.InventoryWarningItem> result = storeDashboardService.getInventoryWarningList(authUserDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
@@ -231,6 +231,21 @@ public class StoreDashboardService {
                 .stream().map(StoreDashboardDto.MyDeliveryItem::from).toList();
     }
 
+    /**
+     * 재고 위험 품목 목록 조회
+     * - 점주 매장의 LOW/CRITICAL 상태 재고를 품목명, 현재 재고, 최소 재고, 상태와 함께 반환
+     */
+    public List<StoreDashboardDto.InventoryWarningItem> getInventoryWarningList(Long userIdx) {
+        // 점주의 매장 조회
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // LOW/CRITICAL 상태 재고 목록 조회 (CRITICAL 우선 정렬)
+        return storeInventoryRepository
+                .findByStore_IdxAndStatusInOrderByStatusDesc(store.getIdx(), List.of(InventoryStatus.CRITICAL, InventoryStatus.LOW))
+                .stream().map(StoreDashboardDto.InventoryWarningItem::from).toList();
+    }
+
     private Map<LocalDate, Long> toDailySalesMap(List<Object[]> rows) {
         Map<LocalDate, Long> map = new java.util.HashMap<>();
         for (Object[] row : rows) {

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
@@ -3,6 +3,7 @@ package com.example.nexus.domain.dashboard.model;
 import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.orders.model.Orders;
 import com.example.nexus.domain.orders.model.OrdersItem;
+import com.example.nexus.domain.store.model.StoreInventory;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -93,4 +94,25 @@ public class StoreDashboardDto {
         }
     }
 
+    @Getter
+    @Builder
+    public static class InventoryWarningItem {
+        private Long inventoryIdx;
+        private String productName;
+        private int currentStock;
+        private int minStock;
+        private String unit;
+        private String status;
+
+        public static InventoryWarningItem from(StoreInventory entity) {
+            return InventoryWarningItem.builder()
+                    .inventoryIdx(entity.getIdx())
+                    .productName(entity.getProduct().getProductName())
+                    .currentStock(entity.getCount())
+                    .minStock(entity.getProduct().getMinStock())
+                    .unit(entity.getProduct().getProductUnit())
+                    .status(entity.getStatus().name())
+                    .build();
+        }
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreInventoryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreInventoryRepository.java
@@ -13,4 +13,6 @@ public interface StoreInventoryRepository extends JpaRepository<StoreInventory, 
 
     // 점주 대시보드용
     long countByStore_IdxAndStatus(Long storeIdx, InventoryStatus status);
+
+    List<StoreInventory> findByStore_IdxAndStatusInOrderByStatusDesc(Long storeIdx, List<InventoryStatus> statuses);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 매장의 최소 재고 이하 품목을 위험(CRITICAL)/주의(LOW) 단계로 구분하여 목록 조회하는 API 구현                                                                                                                               
                                                                                                                                                                                                                                  
## 변경 파일
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardController.java
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
- backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
- backend/src/main/java/com/example/nexus/domain/store/StoreInventoryRepository.java

## 주요 변경 사항
- StoreDashboardController에 GET /store/dashboard/inventory/risk/list 엔드포인트 추가
- StoreDashboardService에 점주 매장별 위험 재고 목록 조회 로직 구현 (CRITICAL 우선 정렬)
- StoreInventoryRepository에 매장/상태 기준 목록 쿼리 추가
- StoreDashboardDto.InventoryWarningItem 응답 DTO 추가 (품목명, 현재재고, 최소재고, 단위, 상태)

## Test Plan
- [ ] 점주 계정 로그인 후 GET /store/dashboard/inventory/risk/list 호출 시 정상 응답 확인
- [ ] CRITICAL 상태가 LOW보다 먼저 정렬되는지 확인
- [ ] NORMAL 상태 재고는 목록에서 제외되는지 확인

## Issue
- Closes #542