### PR TITLE
[Feat] #127 - 점주 대시보드 금일 매출 KPI 카드 API 연동

### DIFF
--- a/frontend/src/api/store-dashboard/index.js
+++ b/frontend/src/api/store-dashboard/index.js
@@ -1,0 +1,3 @@
+import api from '@/plugins/axiosinterceptor'
+
+export const getSalesKpi = () => api.get('/store/dashboard/sales/kpi')

--- a/frontend/src/components/dashboard/store/SalesKpiCard.vue
+++ b/frontend/src/components/dashboard/store/SalesKpiCard.vue
@@ -3,10 +3,22 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import KpiCard from '../KpiCard.vue'
+import { getSalesKpi } from '@/api/store-dashboard'
 
-const value = ref('84.5')
+const value = ref('-')
 const sub = ref('전일 대비')
-const delta = ref(5.2)
+const delta = ref(0)
+
+onMounted(async () => {
+  try {
+    const { data } = await getSalesKpi()
+    const result = data.result
+    value.value = (result.todaySales / 10000).toFixed(1)
+    delta.value = result.deltaPercent
+  } catch (e) {
+    console.error('금일 매출 KPI 조회 실패', e)
+  }
+})
 </script>

--- a/frontend/src/components/dashboard/store/SalesKpiCard.vue
+++ b/frontend/src/components/dashboard/store/SalesKpiCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <KpiCard title="금일 매출" :value="value" unit="만원" :sub="sub" :delta="delta" to="/store-settlement" />
+  <KpiCard title="금일 매출" :value="value" unit="원" :sub="sub" :delta="delta" to="/store-settlement" />
 </template>
 
 <script setup>
@@ -15,7 +15,7 @@ onMounted(async () => {
   try {
     const { data } = await getSalesKpi()
     const result = data.result
-    value.value = (result.todaySales / 10000).toFixed(1)
+    value.value = result.todaySales.toLocaleString()
     delta.value = result.deltaPercent
   } catch (e) {
     console.error('금일 매출 KPI 조회 실패', e)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 대시보드 금일 매출 KPI 카드를 하드코딩에서 실제 API 연동으로 변경                                                                                                                                                        

## 변경 파일
- frontend/src/api/store-dashboard/index.js (신규)
- frontend/src/components/dashboard/store/SalesKpiCard.vue

## 주요 변경 사항
- store-dashboard API 모듈 생성 (GET /store/dashboard/sales/kpi)
- SalesKpiCard.vue 하드코딩 제거 및 실제 API 데이터 바인딩
- 매출 금액 원 단위로 표시 (toLocaleString 포맷)

## Test Plan
- [ ] 점주 로그인 후 대시보드 진입 시 금일 매출 KPI 카드 정상 렌더링 확인
- [ ] 전일 대비 증감률이 정상 표시되는지 확인
- [ ] API 실패 시 기본값('-')이 표시되는지 확인

## Issue
- Closes #127