### PR TITLE
[Feat] #129 - 점주 대시보드 제안 발주서 KPI 카드 API 연동

### DIFF
--- a/frontend/src/api/store-dashboard/index.js
+++ b/frontend/src/api/store-dashboard/index.js
@@ -1,3 +1,5 @@
 import api from '@/plugins/axiosinterceptor'
 
 export const getSalesKpi = () => api.get('/store/dashboard/sales/kpi')
+
+export const getPendingOrderKpi = () => api.get('/store/dashboard/orders/pending/kpi')

--- a/frontend/src/components/dashboard/store/PendingOrderKpiCard.vue
+++ b/frontend/src/components/dashboard/store/PendingOrderKpiCard.vue
@@ -3,9 +3,19 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import KpiCard from '../KpiCard.vue'
+import { getPendingOrderKpi } from '@/api/store-dashboard'
 
-const value = ref('3')
+const value = ref('-')
 const sub = ref('자동 발주 승인 대기')
+
+onMounted(async () => {
+  try {
+    const { data } = await getPendingOrderKpi()
+    value.value = data.result.pendingCount.toLocaleString()
+  } catch (e) {
+    console.error('제안 발주서 KPI 조회 실패', e)
+  }
+})
 </script>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 대시보드 제안 발주서 KPI 카드를 하드코딩에서 실제 API 연동으로 변경

## 변경 파일
- frontend/src/api/store-dashboard/index.js
- frontend/src/components/dashboard/store/PendingOrderKpiCard.vue

## 주요 변경 사항
- store-dashboard API에 getPendingOrderKpi 함수 추가 (GET /store/dashboard/orders/pending/kpi)
- PendingOrderKpiCard.vue 하드코딩 제거 및 실제 API 데이터 바인딩

## Test Plan
- [ ] 점주 로그인 후 대시보드 진입 시 미확정 발주 KPI 카드 정상 렌더링 확인
- [ ] 승인 대기 발주가 없을 때 0으로 표시되는지 확인
- [ ] 카드 클릭 시 /store-order로 이동하는지 확인

## Issue
- Closes #129