### PR TITLE
[Feat] #533 - 점주 대시보드 재고 위험 품목 KPI 카드 API 연동

### DIFF
--- a/frontend/src/api/store-dashboard/index.js
+++ b/frontend/src/api/store-dashboard/index.js
@@ -3,3 +3,5 @@ import api from '@/plugins/axiosinterceptor'
 export const getSalesKpi = () => api.get('/store/dashboard/sales/kpi')
 
 export const getPendingOrderKpi = () => api.get('/store/dashboard/orders/pending/kpi')
+
+export const getInventoryRiskKpi = () => api.get('/store/dashboard/inventory/risk/kpi')

--- a/frontend/src/components/dashboard/store/InventoryRiskKpiCard.vue
+++ b/frontend/src/components/dashboard/store/InventoryRiskKpiCard.vue
@@ -1,11 +1,30 @@
 <template>
-  <KpiCard title="재고 위험 품목" :value="value" unit="종" :sub="sub" :badge-danger="true" to="/store-inventory" />
+  <KpiCard title="재고 위험 품목" :value="value" unit="종" :sub="sub" :badge="badge" :badge-danger="badgeDanger" to="/store-inventory" />
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import KpiCard from '../KpiCard.vue'
+import { getInventoryRiskKpi } from '@/api/store-dashboard'
 
-const value = ref('2')
-const sub = ref('최소재고 이하 품목')
+const value = ref('-')
+const sub = ref('위험 -건 · 주의 -건')
+const badge = ref(null)
+const badgeDanger = ref(false)
+
+onMounted(async () => {
+  try {
+    const { data } = await getInventoryRiskKpi()
+    const result = data.result
+    value.value = result.totalDangerCount.toLocaleString()
+    sub.value = `위험 ${result.criticalCount}건 · 주의 ${result.lowCount}건`
+
+    if (result.criticalCount > 0) {
+      badge.value = `위험 ${result.criticalCount}건`
+      badgeDanger.value = true
+    }
+  } catch (e) {
+    console.error('재고 위험 KPI 조회 실패', e)
+  }
+})
 </script>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 대시보드 재고 위험 품목 KPI 카드를 하드코딩에서 실제 API 연동으로 변경                                                                                                                                                     
                                                                                                                                                                                                                                  
## 변경 파일
- frontend/src/api/store-dashboard/index.js
- frontend/src/components/dashboard/store/InventoryRiskKpiCard.vue

## 주요 변경 사항
- store-dashboard API에 getInventoryRiskKpi 함수 추가 (GET /store/dashboard/inventory/risk/kpi)
- InventoryRiskKpiCard.vue 하드코딩 제거 및 실제 API 데이터 바인딩
- CRITICAL 상태 품목 존재 시 위험 뱃지 표시

## Test Plan
- [ ] 점주 로그인 후 대시보드 진입 시 재고 위험 KPI 카드 정상 렌더링 확인
- [ ] 위험/주의 건수가 sub 텍스트에 정확히 표시되는지 확인
- [ ] CRITICAL 품목 존재 시 빨간 뱃지 표시되는지 확인

## Issue
- Closes #533