### PR TITLE
[Feat] #535 - 점주 대시보드 정산 현황 KPI 카드 API 연동 

### DIFF
--- a/frontend/src/api/store-dashboard/index.js
+++ b/frontend/src/api/store-dashboard/index.js
@@ -5,3 +5,5 @@ export const getSalesKpi = () => api.get('/store/dashboard/sales/kpi')
 export const getPendingOrderKpi = () => api.get('/store/dashboard/orders/pending/kpi')
 
 export const getInventoryRiskKpi = () => api.get('/store/dashboard/inventory/risk/kpi')
+
+export const getSettlementKpi = () => api.get('/store/dashboard/settlement/kpi')

--- a/frontend/src/components/dashboard/store/SettlementKpiCard.vue
+++ b/frontend/src/components/dashboard/store/SettlementKpiCard.vue
@@ -1,12 +1,25 @@
 <template>
-  <KpiCard title="이번달 정산 예정" :value="value" unit="만원" :sub="sub" :delta="delta" to="/store-settlement" />
+  <KpiCard title="정산 현황" :value="value" unit="원" :sub="sub" :delta="delta" to="/store-settlement" />
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import KpiCard from '../KpiCard.vue'
+import { getSettlementKpi } from '@/api/store-dashboard'
 
-const value = ref('12.5')
-const sub = ref('2026-04 납부 예정')
-const delta = ref(-3.1)
+const value = ref('-')
+const sub = ref('')
+const delta = ref(0)
+
+onMounted(async () => {
+  try {
+    const { data } = await getSettlementKpi()
+    const result = data.result
+    value.value = result.currentAmount.toLocaleString()
+    sub.value = result.currentPeriod
+    delta.value = result.deltaPercent
+  } catch (e) {
+    console.error('정산 현황 KPI 조회 실패', e)
+  }
+})
 </script>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 대시보드 정산 현황 KPI 카드를 하드코딩에서 실제 API 연동으로 변경                                                                                                                                                        

## 변경 파일
- frontend/src/api/store-dashboard/index.js
- frontend/src/components/dashboard/store/SettlementKpiCard.vue

## 주요 변경 사항
- store-dashboard API에 getSettlementKpi 함수 추가 (GET /store/dashboard/settlement/kpi)
- SettlementKpiCard.vue 하드코딩 제거 및 실제 API 데이터 바인딩
- 정산 금액 원 단위 표시, 현재 구간명(상반기/하반기) 및 직전 구간 대비 증감률 표시

## Test Plan
- [ ] 점주 로그인 후 대시보드 진입 시 정산 현황 KPI 카드 정상 렌더링 확인
- [ ] currentPeriod가 sub 텍스트에 정상 표시되는지 확인
- [ ] 직전 구간 대비 증감률이 정상 표시되는지 확인

## Issue
- Closes #535