### PR TITLE
[Feat] #537 - 점주 대시보드 일별 매출 추이 차트 API 연동

### DIFF
--- a/frontend/src/api/store-dashboard/index.js
+++ b/frontend/src/api/store-dashboard/index.js
@@ -7,3 +7,5 @@ export const getPendingOrderKpi = () => api.get('/store/dashboard/orders/pending
 export const getInventoryRiskKpi = () => api.get('/store/dashboard/inventory/risk/kpi')
 
 export const getSettlementKpi = () => api.get('/store/dashboard/settlement/kpi')
+
+export const getDailySalesChart = () => api.get('/store/dashboard/sales/daily')

--- a/frontend/src/components/dashboard/store/DailySalesChart.vue
+++ b/frontend/src/components/dashboard/store/DailySalesChart.vue
@@ -1,26 +1,38 @@
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { Chart } from 'chart.js/auto'
+import { getDailySalesChart } from '@/api/store-dashboard'
 
 const lineCanvas = ref(null)
 let lineChart = null
-
-const thisWeek = [72, 85, 68, 91, 84, 96, 80]
-const lastWeek = [65, 78, 74, 82, 79, 88, 71]
-const allValues = computed(() => [...thisWeek, ...lastWeek].filter(v => typeof v === 'number'))
-const yMin = computed(() => allValues.value.length ? Math.floor(Math.min(...allValues.value) / 10) * 10 - 10 : 0)
-const yMax = computed(() => allValues.value.length ? Math.ceil(Math.max(...allValues.value) / 10) * 10 + 10 : 100)
-const weekLabels = ['일', '월', '화', '수', '목', '금', '토']
 
 onUnmounted(() => {
   lineChart?.destroy()
 })
 
-onMounted(() => {
+onMounted(async () => {
+  let labels = ['일', '월', '화', '수', '목', '금', '토']
+  let thisWeek = [0, 0, 0, 0, 0, 0, 0]
+  let lastWeek = [0, 0, 0, 0, 0, 0, 0]
+
+  try {
+    const { data } = await getDailySalesChart()
+    const result = data.result
+    labels = result.labels
+    thisWeek = result.thisWeek.map(v => Math.round(v / 10000))
+    lastWeek = result.lastWeek.map(v => Math.round(v / 10000))
+  } catch (e) {
+    console.error('일별 매출 차트 조회 실패', e)
+  }
+
+  const allValues = [...thisWeek, ...lastWeek]
+  const yMin = allValues.length ? Math.floor(Math.min(...allValues) / 10) * 10 - 10 : 0
+  const yMax = allValues.length ? Math.ceil(Math.max(...allValues) / 10) * 10 + 10 : 100
+
   lineChart = new Chart(lineCanvas.value, {
     type: 'line',
     data: {
-      labels: weekLabels,
+      labels,
       datasets: [
         {
           label: '이번 주',
@@ -77,7 +89,7 @@ onMounted(() => {
           border: { display: false },
         },
         y: {
-          min: yMin.value, max: yMax.value,
+          min: yMin, max: yMax,
           grid: { color: '#f3f4f6' },
           ticks: { color: '#9ca3af', font: { size: 11 }, stepSize: 20 },
           border: { display: false },


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 대시보드 일별 매출 추이 라인차트를 하드코딩에서 실제 API 연동으로 변경                                                                                                                                                   

## 변경 파일
- frontend/src/api/store-dashboard/index.js
- frontend/src/components/dashboard/store/DailySalesChart.vue

## 주요 변경 사항
- store-dashboard API에 getDailySalesChart 함수 추가 (GET /store/dashboard/sales/daily)
- DailySalesChart.vue 하드코딩 제거 및 실제 API 데이터 바인딩
- API 응답(원 단위)을 만원 단위로 변환하여 차트에 표시

## Test Plan
- [ ] 점주 로그인 후 대시보드 진입 시 일별 매출 라인차트 정상 렌더링 확인
- [ ] 이번 주/지난 주 두 개 라인이 각각 표시되는지 확인
- [ ] 매출 데이터가 없는 요일은 0으로 표시되는지 확인

## Issue
- Closes #537