### PR TITLE
[Feat] #539 - 점주 대시보드 나의 배송 현황 목록 API 연동

### DIFF
--- a/frontend/src/api/store-dashboard/index.js
+++ b/frontend/src/api/store-dashboard/index.js
@@ -9,3 +9,5 @@ export const getInventoryRiskKpi = () => api.get('/store/dashboard/inventory/ris
 export const getSettlementKpi = () => api.get('/store/dashboard/settlement/kpi')
 
 export const getDailySalesChart = () => api.get('/store/dashboard/sales/daily')
+
+export const getMyDeliveryList = () => api.get('/store/dashboard/delivery/list')

--- a/frontend/src/components/dashboard/store/MyDeliveryList.vue
+++ b/frontend/src/components/dashboard/store/MyDeliveryList.vue
@@ -1,24 +1,36 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { getMyDeliveryList } from '@/api/store-dashboard'
 
 const router = useRouter()
+const deliveries = ref([])
 
-const deliveries = ref([
-  { id: 'ORD-2604-008', items: '한우 등심(kg) 외 1건', status: '배송중' },
-  { id: 'ORD-2604-011', items: '올리브오일(L) 외 1건', status: '출고대기' },
-  { id: 'ORD-2604-015', items: '버터 외 2건', status: '배송지연' },
-  { id: 'ORD-2604-003', items: '생수 외 1건', status: '출고완료' },
-])
+const STATUS_LABEL = {
+  READY: '출고대기',
+  START: '출고완료',
+  DELIVERYING: '배송중',
+  DELIVERED: '배송완료',
+  DELAY: '배송지연',
+}
 
 const DELIVERY_STATUS_CLS = {
-  '배송중': 'bg-blue-50 text-blue-600 border-blue-200',
-  '출고대기': 'bg-gray-100 text-gray-600 border-gray-200',
-  '출고완료': 'bg-green-50 text-green-700 border-green-200',
-  '배송완료': 'bg-green-50 text-green-700 border-green-200',
-  '배송지연': 'bg-red-50 text-red-600 border-red-200',
+  READY: 'bg-gray-100 text-gray-600 border-gray-200',
+  START: 'bg-green-50 text-green-700 border-green-200',
+  DELIVERYING: 'bg-blue-50 text-blue-600 border-blue-200',
+  DELIVERED: 'bg-green-50 text-green-700 border-green-200',
+  DELAY: 'bg-red-50 text-red-600 border-red-200',
 }
 const deliveryCls = s => DELIVERY_STATUS_CLS[s] ?? 'bg-gray-100 text-gray-500 border-gray-200'
+
+onMounted(async () => {
+  try {
+    const { data } = await getMyDeliveryList()
+    deliveries.value = data.result
+  } catch (e) {
+    console.error('배송 현황 조회 실패', e)
+  }
+})
 </script>
 
 <template>
@@ -27,18 +39,21 @@ const deliveryCls = s => DELIVERY_STATUS_CLS[s] ?? 'bg-gray-100 text-gray-500 bo
       <h2 class="font-bold text-gray-900">나의 배송 현황</h2>
     </div>
     <div class="flex-1 divide-y divide-gray-50 overflow-y-auto">
-      <div v-for="d in deliveries" :key="d.id"
+      <div v-if="deliveries.length === 0" class="px-5 py-8 text-center text-sm text-gray-400">
+        진행중인 배송이 없습니다
+      </div>
+      <div v-for="d in deliveries" :key="d.deliveryIdx"
         class="px-5 py-4 hover:bg-gray-50 transition-colors cursor-pointer"
         role="button" tabindex="0"
         @click="router.push('/store-delivery')"
         @keydown.enter="router.push('/store-delivery')">
         <div class="flex items-center justify-between gap-3">
           <div class="flex-1 min-w-0">
-            <p class="text-sm font-bold text-gray-900 font-mono">{{ d.id }}</p>
-            <p class="text-xs text-gray-500 mt-0.5 truncate">{{ d.items }}</p>
+            <p class="text-sm font-bold text-gray-900 font-mono">발주 #{{ d.ordersIdx }}</p>
+            <p class="text-xs text-gray-500 mt-0.5">도착 예정: {{ d.estimatedArrival }}</p>
           </div>
           <span class="text-xs px-2 py-0.5 rounded-full font-medium shrink-0 border"
-            :class="deliveryCls(d.status)">{{ d.status }}</span>
+            :class="deliveryCls(d.status)">{{ STATUS_LABEL[d.status] || d.status }}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 대시보드 나의 배송 현황 목록을 하드코딩에서 실제 API 연동으로 변경                                                                                                                                                       

## 변경 파일
- frontend/src/api/store-dashboard/index.js
- frontend/src/components/dashboard/store/MyDeliveryList.vue

## 주요 변경 사항
- store-dashboard API에 getMyDeliveryList 함수 추가 (GET /store/dashboard/delivery/list)
- MyDeliveryList.vue 하드코딩 제거 및 실제 API 데이터 바인딩
- 배송 상태별 한글 라벨(출고대기/출고완료/배송중/배송완료/배송지연) 및 뱃지 스타일 매핑
- 배송 건이 없을 때 빈 상태 메시지 표시

## Test Plan
- [ ] 점주 로그인 후 대시보드 진입 시 배송 현황 목록 정상 렌더링 확인
- [ ] 배송 상태별 뱃지 색상이 정상 표시되는지 확인
- [ ] 배송 건이 없을 때 "진행중인 배송이 없습니다" 메시지 표시되는지 확인
- [ ] 항목 클릭 시 /store-delivery로 이동하는지 확인

## Issue
- Closes #539