### PR TITLE
[Feat] #541 - 점주 대시보드 제안 발주서 목록 API 연동

### DIFF
--- a/frontend/src/api/store-dashboard/index.js
+++ b/frontend/src/api/store-dashboard/index.js
@@ -11,3 +11,5 @@ export const getSettlementKpi = () => api.get('/store/dashboard/settlement/kpi')
 export const getDailySalesChart = () => api.get('/store/dashboard/sales/daily')
 
 export const getMyDeliveryList = () => api.get('/store/dashboard/delivery/list')
+
+export const getPendingOrderList = () => api.get('/store/dashboard/orders/pending/list')

--- a/frontend/src/components/dashboard/store/PendingOrderList.vue
+++ b/frontend/src/components/dashboard/store/PendingOrderList.vue
@@ -1,14 +1,19 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { getPendingOrderList } from '@/api/store-dashboard'
 
 const router = useRouter()
+const orders = ref([])
 
-const orders = ref([
-  { id: 1, product: '한우 등심', qty: 20, unitPrice: 85000 },
-  { id: 2, product: '올리브오일', qty: 5, unitPrice: 12000 },
-  { id: 3, product: '생크림', qty: 8, unitPrice: 7000 },
-])
+onMounted(async () => {
+  try {
+    const { data } = await getPendingOrderList()
+    orders.value = data.result
+  } catch (e) {
+    console.error('제안 발주서 목록 조회 실패', e)
+  }
+})
 </script>
 
 <template>
@@ -16,7 +21,10 @@ const orders = ref([
     <div class="px-5 py-4 border-b border-gray-100">
       <h2 class="font-bold text-gray-900">미확정 발주</h2>
     </div>
-    <table class="w-full text-sm">
+    <div v-if="orders.length === 0" class="px-5 py-8 text-center text-sm text-gray-400">
+      제안된 발주서가 없습니다
+    </div>
+    <table v-else class="w-full text-sm">
       <thead>
         <tr class="border-b border-gray-200 bg-gray-50">
           <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
@@ -26,14 +34,14 @@ const orders = ref([
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-100">
-        <tr v-for="o in orders" :key="o.id"
+        <tr v-for="o in orders" :key="o.ordersIdx"
           class="hover:bg-gray-50/50 cursor-pointer"
           role="button" tabindex="0"
           @click="router.push('/store-order')"
           @keydown.enter="router.push('/store-order')">
-          <td class="px-5 py-3.5 font-semibold text-gray-800">{{ o.product }}</td>
-          <td class="px-5 py-3.5 text-right text-gray-600">{{ o.qty.toLocaleString() }}개</td>
-          <td class="px-5 py-3.5 text-right font-semibold text-gray-700">₩ {{ (o.qty * o.unitPrice).toLocaleString() }}</td>
+          <td class="px-5 py-3.5 font-semibold text-gray-800">{{ o.productName }}</td>
+          <td class="px-5 py-3.5 text-right text-gray-600">{{ o.quantity.toLocaleString() }}개</td>
+          <td class="px-5 py-3.5 text-right font-semibold text-gray-700">₩ {{ o.price.toLocaleString() }}</td>
           <td class="px-5 py-3.5 text-right">
             <span class="text-xs font-bold px-2 py-0.5 rounded bg-blue-50 text-blue-600 border border-blue-200">제안중</span>
           </td>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 대시보드 제안 발주서 목록을 하드코딩에서 실제 API 연동으로 변경                                                                                                                                                          

## 변경 파일
- frontend/src/api/store-dashboard/index.js
- frontend/src/components/dashboard/store/PendingOrderList.vue

## 주요 변경 사항
- store-dashboard API에 getPendingOrderList 함수 추가 (GET /store/dashboard/orders/pending/list)
- PendingOrderList.vue 하드코딩 제거 및 실제 API 데이터 바인딩
- 품목명, 제안 수량, 금액, 상태를 테이블로 표시
- 발주 건이 없을 때 빈 상태 메시지 표시

## Test Plan
- [ ] 점주 로그인 후 대시보드 진입 시 미확정 발주 테이블 정상 렌더링 확인
- [ ] 품목명이 "외 N건" 형태로 정상 표시되는지 확인
- [ ] 발주 건이 없을 때 "제안된 발주서가 없습니다" 메시지 표시되는지 확인
- [ ] 행 클릭 시 /store-order로 이동하는지 확인

## Issue
- Closes #541