### PR TITLE
[Feat] #543 - 점주 대시보드 재고 위험 품목 목록 API 연동

### DIFF
--- a/frontend/src/api/store-dashboard/index.js
+++ b/frontend/src/api/store-dashboard/index.js
@@ -13,3 +13,5 @@ export const getDailySalesChart = () => api.get('/store/dashboard/sales/daily')
 export const getMyDeliveryList = () => api.get('/store/dashboard/delivery/list')
 
 export const getPendingOrderList = () => api.get('/store/dashboard/orders/pending/list')
+
+export const getInventoryWarningList = () => api.get('/store/dashboard/inventory/risk/list')

--- a/frontend/src/components/dashboard/store/InventoryWarningList.vue
+++ b/frontend/src/components/dashboard/store/InventoryWarningList.vue
@@ -1,13 +1,21 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { getInventoryWarningList } from '@/api/store-dashboard'
 
 const router = useRouter()
+const warnings = ref([])
 
-const warnings = ref([
-  { product: '한우 등심', current: '5kg', min: '10kg', danger: true },
-  { product: '버터', current: '2kg', min: '5kg', danger: false },
-])
+const STATUS_LABEL = { CRITICAL: '위험', LOW: '주의' }
+
+onMounted(async () => {
+  try {
+    const { data } = await getInventoryWarningList()
+    warnings.value = data.result
+  } catch (e) {
+    console.error('재고 위험 품목 목록 조회 실패', e)
+  }
+})
 </script>
 
 <template>
@@ -15,7 +23,10 @@ const warnings = ref([
     <div class="px-5 py-4 border-b border-gray-100">
       <h2 class="font-bold text-gray-900">재고 위험 품목</h2>
     </div>
-    <table class="w-full text-sm">
+    <div v-if="warnings.length === 0" class="px-5 py-8 text-center text-sm text-gray-400">
+      위험 재고 품목이 없습니다
+    </div>
+    <table v-else class="w-full text-sm">
       <thead>
         <tr class="border-b border-gray-200 bg-gray-50">
           <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
@@ -25,18 +36,18 @@ const warnings = ref([
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-100">
-        <tr v-for="w in warnings" :key="w.product"
+        <tr v-for="w in warnings" :key="w.inventoryIdx"
           class="hover:bg-gray-50/50 cursor-pointer"
           role="button" tabindex="0"
           @click="router.push('/store-inventory')"
           @keydown.enter="router.push('/store-inventory')">
-          <td class="px-5 py-3.5 font-semibold text-gray-800">{{ w.product }}</td>
-          <td class="px-5 py-3.5 text-right font-bold text-red-600">{{ w.current }}</td>
-          <td class="px-5 py-3.5 text-right text-gray-400">{{ w.min }}</td>
+          <td class="px-5 py-3.5 font-semibold text-gray-800">{{ w.productName }}</td>
+          <td class="px-5 py-3.5 text-right font-bold text-red-600">{{ w.currentStock }}{{ w.unit }}</td>
+          <td class="px-5 py-3.5 text-right text-gray-400">{{ w.minStock }}{{ w.unit }}</td>
           <td class="px-5 py-3.5 text-right">
             <span class="text-xs font-bold px-2 py-0.5 rounded"
-              :class="w.danger ? 'bg-red-50 text-red-600 border border-red-200' : 'bg-orange-50 text-orange-600 border border-orange-200'">
-              {{ w.danger ? '위험' : '주의' }}
+              :class="w.status === 'CRITICAL' ? 'bg-red-50 text-red-600 border border-red-200' : 'bg-orange-50 text-orange-600 border border-orange-200'">
+              {{ STATUS_LABEL[w.status] || w.status }}
             </span>
           </td>
         </tr>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 대시보드 재고 위험 품목 목록을 하드코딩에서 실제 API 연동으로 변경                                                                                                                                                       

## 변경 파일
- frontend/src/api/store-dashboard/index.js
- frontend/src/components/dashboard/store/InventoryWarningList.vue

## 주요 변경 사항
- store-dashboard API에 getInventoryWarningList 함수 추가 (GET /store/dashboard/inventory/risk/list)
- InventoryWarningList.vue 하드코딩 제거 및 실제 API 데이터 바인딩
- 품목명, 현재 재고, 최소 재고, 단위, 상태를 테이블로 표시
- 위험(CRITICAL)/주의(LOW) 상태별 뱃지 스타일 분기
- 위험 품목이 없을 때 빈 상태 메시지 표시

## Test Plan
- [ ] 점주 로그인 후 대시보드 진입 시 재고 위험 품목 테이블 정상 렌더링 확인
- [ ] CRITICAL은 빨간 뱃지, LOW는 주황 뱃지로 표시되는지 확인
- [ ] 위험 품목이 없을 때 "위험 재고 품목이 없습니다" 메시지 표시되는지 확인
- [ ] 행 클릭 시 /store-inventory로 이동하는지 확인

## Issue
- Closes #543