### PR TITLE
[Feat] #62 - AI 자동 발주서 생성 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -15,6 +15,7 @@ java {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
 }
 
 dependencies {
@@ -48,6 +49,13 @@ dependencies {
 
 	// --- S3 관련 ---
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.2'
+
+	// --- Spring AI (OpenAI) ---
+	implementation platform('org.springframework.ai:spring-ai-bom:1.0.0-M6')
+	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
+
+	// --- 크롤링 ---
+	implementation 'org.jsoup:jsoup:1.18.1'
 
 }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
@@ -37,6 +37,9 @@ public class Orders {
     @Column(name = "is_danger", nullable = false)
     private boolean isDanger;
 
+    @Column(name = "reason")
+    private String reason;
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 

--- a/backend/src/main/java/com/example/nexus/domain/pos/AutoOrderService.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/AutoOrderService.java
@@ -1,0 +1,171 @@
+package com.example.nexus.domain.pos;
+
+import com.example.nexus.common.enums.OrdersStatus;
+import com.example.nexus.common.enums.OrdersType;
+import com.example.nexus.common.exception.BaseException;
+import com.example.nexus.common.model.BaseResponseStatus;
+import com.example.nexus.domain.orders.OrdersItemRepository;
+import com.example.nexus.domain.orders.OrdersRepository;
+import com.example.nexus.domain.orders.model.Orders;
+import com.example.nexus.domain.orders.model.OrdersItem;
+import com.example.nexus.domain.product.ProductRepository;
+import com.example.nexus.domain.product.model.Product;
+import com.example.nexus.domain.store.StoreInventoryRepository;
+import com.example.nexus.domain.store.StoreRepository;
+import com.example.nexus.domain.store.model.Store;
+import com.example.nexus.domain.store.model.StoreInventory;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AutoOrderService {
+
+    private final ChatClient.Builder chatClientBuilder;
+    private final StoreRepository storeRepository;
+    private final StoreInventoryRepository storeInventoryRepository;
+    private final OrdersRepository ordersRepository;
+    private final OrdersItemRepository ordersItemRepository;
+    private final ProductRepository productRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void generateAutoOrder(Long userIdx) {
+        // 1. 매장 조회
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+
+        // 2. 현재 재고 조회
+        List<StoreInventory> inventoryList = storeInventoryRepository.findByStoreIdx(store.getIdx());
+        if (inventoryList.isEmpty()) {
+            return;
+        }
+
+        // 3. 프롬프트 생성
+        String prompt = buildPrompt(store, inventoryList);
+
+        // 4. OpenAI 호출
+        ChatClient chatClient = chatClientBuilder.build();
+        String aiResponse = chatClient.prompt()
+                .user(prompt)
+                .call()
+                .content();
+
+        // 5. AI 응답 파싱 → 발주서 저장
+        saveAutoOrder(store, aiResponse);
+    }
+
+    private String buildPrompt(Store store, List<StoreInventory> inventoryList) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("당신은 프랜차이즈 매장의 재고 관리 전문가입니다.\n");
+        sb.append("아래 매장의 현재 재고를 분석하여 발주가 필요한 품목과 적정 수량을 추천해주세요.\n\n");
+
+        // 요일 정보
+        LocalDate today = LocalDate.now();
+        DayOfWeek dow = today.getDayOfWeek();
+        sb.append(String.format("[마감일] %s (%s)\n", today, dow.name()));
+
+        // 주말 배송 불가 고려
+        if (dow == DayOfWeek.FRIDAY || dow == DayOfWeek.SATURDAY) {
+            sb.append("[주의] 주말에는 본사 배송이 불가합니다. 월요일까지 버틸 수 있도록 넉넉하게 발주해주세요.\n");
+        }
+
+        sb.append(String.format("\n[매장명] %s\n", store.getStoreName()));
+        sb.append("\n[현재 재고 현황]\n");
+        sb.append("상품명 | 현재수량 | 최소재고 | 최대재고 | 단위\n");
+
+        for (StoreInventory inv : inventoryList) {
+            Product p = inv.getProduct();
+            sb.append(String.format("%s | %d | %d | %d | %s\n",
+                    p.getProductName(),
+                    inv.getCount(),
+                    p.getMinStock(),
+                    p.getMaxStock(),
+                    p.getProductUnit()));
+        }
+
+        sb.append("\n[규칙]\n");
+        sb.append("- 현재수량이 최소재고 이하인 품목은 반드시 발주에 포함\n");
+        sb.append("- 발주수량은 최대재고 - 현재수량을 기본으로 하되, 상황에 맞게 조정\n");
+        sb.append("- 현재수량이 충분한 품목은 발주하지 마세요\n");
+        sb.append("\n[응답 형식] 반드시 아래 JSON 배열만 출력하세요. 다른 텍스트 없이 JSON만:\n");
+        sb.append("[{\"productIdx\": 숫자, \"productName\": \"상품명\", \"quantity\": 숫자}]\n");
+        sb.append("발주할 품목이 없으면 빈 배열 []을 반환하세요.\n");
+
+        return sb.toString();
+    }
+
+    @Transactional
+    public void saveAutoOrder(Store store, String aiResponse) {
+        try {
+            // JSON 파싱
+            String json = extractJson(aiResponse);
+            List<AutoOrderItem> items = objectMapper.readValue(json, new TypeReference<>() {});
+
+            if (items.isEmpty()) {
+                log.info("AI 판단: 발주 필요 품목 없음 (store={})", store.getStoreName());
+                return;
+            }
+
+            // 총 가격 계산 + Orders 생성
+            long totalPrice = 0;
+            for (AutoOrderItem item : items) {
+                Product product = productRepository.findById(item.productIdx()).orElse(null);
+                if (product != null) {
+                    totalPrice += (long) product.getUnitPrice() * item.quantity();
+                }
+            }
+
+            Orders orders = ordersRepository.save(Orders.builder()
+                    .price(totalPrice)
+                    .ordersType(OrdersType.AUTO)
+                    .ordersStatus(OrdersStatus.WAITING)
+                    .isDanger(false)
+                    .createdAt(LocalDateTime.now())
+                    .store(store)
+                    .build());
+
+            // OrdersItem 저장
+            for (AutoOrderItem item : items) {
+                Product product = productRepository.findById(item.productIdx()).orElse(null);
+                if (product != null) {
+                    ordersItemRepository.save(OrdersItem.builder()
+                            .count(item.quantity())
+                            .product(product)
+                            .orders(orders)
+                            .build());
+                }
+            }
+
+            log.info("AI 자동 발주서 생성 완료: store={}, items={}", store.getStoreName(), items.size());
+
+        } catch (Exception e) {
+            log.error("AI 응답 파싱 실패: {}", aiResponse, e);
+            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+        }
+    }
+
+    private String extractJson(String response) {
+        // AI 응답에서 JSON 배열 부분만 추출
+        int start = response.indexOf('[');
+        int end = response.lastIndexOf(']');
+        if (start == -1 || end == -1) {
+            return "[]";
+        }
+        return response.substring(start, end + 1);
+    }
+
+    private record AutoOrderItem(Long productIdx, String productName, int quantity) {}
+}

--- a/backend/src/main/java/com/example/nexus/domain/pos/AutoOrderService.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/AutoOrderService.java
@@ -25,6 +25,8 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -121,10 +123,17 @@ public class AutoOrderService {
                 return;
             }
 
+            // Product 일괄 조회 (중복 DB 호출 방지)
+            List<Long> productIds = response.items().stream()
+                    .map(AutoOrderItem::productIdx)
+                    .toList();
+            Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
+                    .collect(Collectors.toMap(Product::getIdx, p -> p));
+
             // 총 가격 계산
             long totalPrice = 0;
             for (AutoOrderItem item : response.items()) {
-                Product product = productRepository.findById(item.productIdx()).orElse(null);
+                Product product = productMap.get(item.productIdx());
                 if (product != null) {
                     totalPrice += (long) product.getUnitPrice() * item.quantity();
                 }
@@ -143,7 +152,7 @@ public class AutoOrderService {
 
             // OrdersItem 저장
             for (AutoOrderItem item : response.items()) {
-                Product product = productRepository.findById(item.productIdx()).orElse(null);
+                Product product = productMap.get(item.productIdx());
                 if (product != null) {
                     ordersItemRepository.save(OrdersItem.builder()
                             .count(item.quantity())

--- a/backend/src/main/java/com/example/nexus/domain/pos/AutoOrderService.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/AutoOrderService.java
@@ -14,7 +14,6 @@ import com.example.nexus.domain.store.StoreInventoryRepository;
 import com.example.nexus.domain.store.StoreRepository;
 import com.example.nexus.domain.store.model.Store;
 import com.example.nexus.domain.store.model.StoreInventory;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -100,9 +99,12 @@ public class AutoOrderService {
         sb.append("- 현재수량이 최소재고 이하인 품목은 반드시 발주에 포함\n");
         sb.append("- 발주수량은 최대재고 - 현재수량을 기본으로 하되, 상황에 맞게 조정\n");
         sb.append("- 현재수량이 충분한 품목은 발주하지 마세요\n");
-        sb.append("\n[응답 형식] 반드시 아래 JSON 배열만 출력하세요. 다른 텍스트 없이 JSON만:\n");
-        sb.append("[{\"productIdx\": 숫자, \"productName\": \"상품명\", \"quantity\": 숫자}]\n");
-        sb.append("발주할 품목이 없으면 빈 배열 []을 반환하세요.\n");
+        sb.append("\n[응답 형식] 반드시 아래 JSON만 출력하세요. 다른 텍스트 없이 JSON만:\n");
+        sb.append("{\n");
+        sb.append("  \"reason\": \"발주 추천 이유 한 줄 요약\",\n");
+        sb.append("  \"items\": [{\"productIdx\": 숫자, \"productName\": \"상품명\", \"quantity\": 숫자}]\n");
+        sb.append("}\n");
+        sb.append("발주할 품목이 없으면 {\"reason\": \"\", \"items\": []}을 반환하세요.\n");
 
         return sb.toString();
     }
@@ -112,33 +114,35 @@ public class AutoOrderService {
         try {
             // JSON 파싱
             String json = extractJson(aiResponse);
-            List<AutoOrderItem> items = objectMapper.readValue(json, new TypeReference<>() {});
+            AutoOrderResponse response = objectMapper.readValue(json, AutoOrderResponse.class);
 
-            if (items.isEmpty()) {
+            if (response.items() == null || response.items().isEmpty()) {
                 log.info("AI 판단: 발주 필요 품목 없음 (store={})", store.getStoreName());
                 return;
             }
 
-            // 총 가격 계산 + Orders 생성
+            // 총 가격 계산
             long totalPrice = 0;
-            for (AutoOrderItem item : items) {
+            for (AutoOrderItem item : response.items()) {
                 Product product = productRepository.findById(item.productIdx()).orElse(null);
                 if (product != null) {
                     totalPrice += (long) product.getUnitPrice() * item.quantity();
                 }
             }
 
+            // Orders 생성 (reason 포함)
             Orders orders = ordersRepository.save(Orders.builder()
                     .price(totalPrice)
                     .ordersType(OrdersType.AUTO)
                     .ordersStatus(OrdersStatus.WAITING)
                     .isDanger(false)
+                    .reason(response.reason())
                     .createdAt(LocalDateTime.now())
                     .store(store)
                     .build());
 
             // OrdersItem 저장
-            for (AutoOrderItem item : items) {
+            for (AutoOrderItem item : response.items()) {
                 Product product = productRepository.findById(item.productIdx()).orElse(null);
                 if (product != null) {
                     ordersItemRepository.save(OrdersItem.builder()
@@ -149,7 +153,8 @@ public class AutoOrderService {
                 }
             }
 
-            log.info("AI 자동 발주서 생성 완료: store={}, items={}", store.getStoreName(), items.size());
+            log.info("AI 자동 발주서 생성 완료: store={}, reason={}, items={}",
+                    store.getStoreName(), response.reason(), response.items().size());
 
         } catch (Exception e) {
             log.error("AI 응답 파싱 실패: {}", aiResponse, e);
@@ -158,14 +163,16 @@ public class AutoOrderService {
     }
 
     private String extractJson(String response) {
-        // AI 응답에서 JSON 배열 부분만 추출
-        int start = response.indexOf('[');
-        int end = response.lastIndexOf(']');
+        // AI 응답에서 JSON 객체 부분만 추출
+        int start = response.indexOf('{');
+        int end = response.lastIndexOf('}');
         if (start == -1 || end == -1) {
-            return "[]";
+            return "{\"reason\": \"\", \"items\": []}";
         }
         return response.substring(start, end + 1);
     }
+
+    private record AutoOrderResponse(String reason, List<AutoOrderItem> items) {}
 
     private record AutoOrderItem(Long productIdx, String productName, int quantity) {}
 }

--- a/backend/src/main/java/com/example/nexus/domain/pos/PosController.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/PosController.java
@@ -23,6 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PosController {
     private final PosService posService;
+    private final AutoOrderService autoOrderService;
 
     // [가맹점] 로그인한 가맹점주(STORE)의 user_idx로 해당 매장 재고 조회
     @GetMapping("/inventory/list")
@@ -56,5 +57,17 @@ public class PosController {
     public ResponseEntity<BaseResponse<List<PosPayDto.TodayPayRes>>> todayPays(@AuthenticationPrincipal AuthUserDetails userDetails) {
         List<PosPayDto.TodayPayRes> result = posService.listTodayPayHistory(userDetails.getIdx());
         return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
+     * POS 영업 마감 및 AI 자동 발주서 생성
+     *
+     * @param userDetails 인증된 가맹점주 정보
+     * @return ResponseEntity 자동 발주서 생성 결과 메시지
+     */
+    @PostMapping("/close")
+    public ResponseEntity<BaseResponse<String>> close(@AuthenticationPrincipal AuthUserDetails userDetails) {
+        autoOrderService.generateAutoOrder(userDetails.getIdx());
+        return ResponseEntity.ok(BaseResponse.success("자동 발주서가 생성되었습니다."));
     }
 }

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -12,6 +12,14 @@ spring:
     show-sql: false
     defer-datasource-initialization: true
 
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o
+          temperature: 0.3
+
   cloud:
     aws:
       credentials:

--- a/docs/auto-order-ai-구현가이드.md
+++ b/docs/auto-order-ai-구현가이드.md
@@ -1,0 +1,90 @@
+# 자동 발주서 생성 (AI) - 구현 가이드
+
+> 요구사항 ID: ORDER_001
+> 브랜치: feat/backend/auto-order-ai
+> 이슈: #62
+
+---
+
+## 단계별 구현 내역
+
+### 1단계: 의존성 추가 (`build.gradle`)
+
+#### 추가한 코드
+
+```groovy
+repositories {
+    mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }  // 추가
+}
+
+dependencies {
+    // --- Spring AI (OpenAI) ---
+    implementation platform('org.springframework.ai:spring-ai-bom:1.0.0-M6')
+    implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
+
+    // --- 크롤링 ---
+    implementation 'org.jsoup:jsoup:1.18.1'
+}
+```
+
+#### 왜 추가했는가
+
+| 의존성 | 역할 | 선택 이유 |
+|--------|------|-----------|
+| `spring-ai-bom` | Spring AI 버전 관리 BOM | Spring Boot 3.4와 호환되는 버전 통일 |
+| `spring-ai-openai-spring-boot-starter` | OpenAI GPT-4o 호출 | Python 없이 Spring Boot 안에서 LLM 호출 가능. 팀 전원 Java 사용 중이라 학습 비용 최소화 |
+| `jsoup` | HTML 크롤링/파싱 | 뉴스/이벤트 데이터 수집용. Java 네이티브라 별도 서비스 불필요 |
+| Spring milestone repo | Spring AI가 아직 정식 릴리즈 전 | mavenCentral에 없는 M6 버전을 받기 위해 필요 |
+
+#### 코드 설명
+
+- **BOM (Bill of Materials)**: `platform()`으로 선언하면 Spring AI 관련 라이브러리의 버전을 일괄 관리. 개별 버전 명시 불필요.
+- **spring-ai-openai-spring-boot-starter**: 이 하나로 `ChatClient`, `OpenAiChatModel` 등 OpenAI 연동에 필요한 Bean이 자동 등록됨.
+- **Jsoup**: 2단계(뉴스/행사 크롤링)에서 사용 예정. HTML을 DOM처럼 파싱해서 원하는 데이터만 추출.
+
+---
+
+### 2단계: OpenAI 설정 (`application.yml`)
+
+> (구현 후 업데이트 예정)
+
+---
+
+### 3단계: 마감 API (`POST /pos/close`)
+
+> (구현 후 업데이트 예정)
+
+---
+
+### 4단계: AI 발주서 생성 Service
+
+> (구현 후 업데이트 예정)
+
+---
+
+## 전체 흐름 요약
+
+```
+[점주 마감 버튼 클릭]
+  → Frontend: POST /api/pos/close 호출
+  → Backend:
+      ① 마감 기록 저장
+      ② 해당 매장 재고 현황 조회 (StoreInventory)
+      ③ 재고 차감 이력 조회 (InventoryMovement)
+      ④ 과거 발주 이력 조회 (Orders)
+      ⑤ 요일/배송 가능일 계산
+      ⑥ OpenAI GPT-4o 호출 (Spring AI) - 프롬프트에 위 데이터 전달
+      ⑦ AI 응답 파싱 → Orders 테이블에 AUTO/WAITING 상태로 저장
+  → 점주 대시보드에서 제안 발주서 확인
+```
+
+## 기존 코드와의 관계
+
+| 기존 코드 | 이번 기능에서의 역할 |
+|-----------|---------------------|
+| `Orders` Entity (ordersType=AUTO) | AI가 생성한 발주서 저장 |
+| `StoreInventory` Entity | 현재 재고 수량 조회 |
+| `InventoryMovement` Entity | 과거 사용량 패턴 분석 데이터 |
+| `OrdersScheduler` | Scheduler 패턴 참고 |
+| `PosController` | 마감 API 추가 위치 |

--- a/docs/auto-order-ai-구현가이드.md
+++ b/docs/auto-order-ai-구현가이드.md
@@ -82,15 +82,57 @@ OPENAI_API_KEY=your-openai-api-key-here
 
 ---
 
-### 3단계: 마감 API (`POST /pos/close`)
+### 3단계: 마감 API + AI 자동 발주서 생성
 
-> (구현 후 업데이트 예정)
+#### 추가/수정한 파일
 
----
+| 파일 | 작업 |
+|------|------|
+| `PosController.java` | `POST /pos/close` 엔드포인트 추가 |
+| `AutoOrderService.java` | **신규** — AI 자동 발주서 생성 전담 서비스 |
 
-### 4단계: AI 발주서 생성 Service
+#### PosController — 마감 엔드포인트
 
-> (구현 후 업데이트 예정)
+```java
+@PostMapping("/close")
+public ResponseEntity<BaseResponse<String>> close(@AuthenticationPrincipal AuthUserDetails userDetails) {
+    autoOrderService.generateAutoOrder(userDetails.getIdx());
+    return ResponseEntity.ok(BaseResponse.success("자동 발주서가 생성되었습니다."));
+}
+```
+
+- 점주가 POS에서 영업 마감 버튼을 누르면 호출
+- 인증된 유저의 `userIdx`를 넘겨서 해당 매장의 발주서 생성
+
+#### AutoOrderService — 핵심 로직
+
+```
+generateAutoOrder(userIdx)
+  ├─ 1. 매장 조회 (userIdx → Store)
+  ├─ 2. 현재 재고 조회 (StoreInventory)
+  ├─ 3. 프롬프트 생성 (buildPrompt)
+  ├─ 4. OpenAI GPT-4o 호출 (Spring AI ChatClient)
+  └─ 5. 응답 파싱 → Orders(AUTO/WAITING) + OrdersItem 저장
+```
+
+#### 왜 이렇게 구성했는가
+
+| 결정 | 이유 |
+|------|------|
+| `AutoOrderService`를 별도 클래스로 분리 | PosService는 결제/재고 로직 전담. AI 발주는 관심사가 다르므로 분리 |
+| `ChatClient.Builder`를 주입받아 사용 | Spring AI가 자동 등록하는 Bean. 매 요청마다 `build()`해서 사용 |
+| 프롬프트에 최소재고/최대재고 포함 | AI가 "얼마나 주문해야 하는지" 판단할 근거 제공 |
+| 금요일/토요일 마감 시 추가 안내 | 주말 배송 불가 → 월요일까지 버틸 양 고려 |
+| JSON만 응답하도록 프롬프트 제약 | 파싱 안정성 확보. `extractJson()`으로 혹시 모를 부가 텍스트 제거 |
+| `ordersType=AUTO`, `ordersStatus=WAITING` | 기존 프론트 대시보드가 AUTO+WAITING 목록을 조회하고 있으므로 자동 연동됨 |
+
+#### temperature를 0.3으로 낮춘 이유
+
+발주서는 "정확한 수량"이 중요한 비즈니스 문서. temperature가 높으면:
+- 같은 재고 상태에서도 매번 다른 수량 추천
+- 가끔 엉뚱한 품목 추천
+
+0.3이면 안정적이면서도 상황(요일, 재고량)에 따른 유연한 판단은 가능.
 
 ---
 

--- a/docs/auto-order-ai-구현가이드.md
+++ b/docs/auto-order-ai-구현가이드.md
@@ -45,9 +45,40 @@ dependencies {
 
 ---
 
-### 2단계: OpenAI 설정 (`application.yml`)
+### 2단계: OpenAI 설정 (`application-dev.yaml` + `.env`)
 
-> (구현 후 업데이트 예정)
+#### 추가한 코드
+
+**application-dev.yaml:**
+```yaml
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o
+          temperature: 0.3
+```
+
+**.env:**
+```
+OPENAI_API_KEY=your-openai-api-key-here
+```
+
+#### 왜 이렇게 설정했는가
+
+| 설정 | 역할 | 이유 |
+|------|------|------|
+| `api-key: ${OPENAI_API_KEY}` | 환경변수로 API Key 주입 | 코드에 키를 직접 넣지 않음 (보안). 기존 `.env` 패턴 동일하게 사용 |
+| `model: gpt-4o` | 사용할 LLM 모델 지정 | 학원 제공 API Key가 GPT-4o 지원 |
+| `temperature: 0.3` | 응답의 창의성 정도 (0~1) | 발주서는 정확한 수치가 중요하므로 낮게 설정. 높으면 매번 다른 결과 나옴 |
+
+#### 코드 설명
+
+- Spring AI starter가 `spring.ai.openai.*` 프로퍼티를 자동으로 읽어서 `ChatClient` Bean을 구성함
+- `.env` 파일은 `.gitignore`에 포함되어 있어 원격 저장소에 올라가지 않음
+- 팀원은 각자 `.env`에 본인 API Key를 넣으면 됨
 
 ---
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 POS 영업 마감 시 Spring AI(GPT-4o)를 활용하여 자동 발주서를 생성하는 기능 구현
- 현재 재고 현황을 AI가 분석하여 발주 필요 품목과 적정 수량을 추천

## 변경 파일
- `backend/build.gradle`
- `backend/src/main/resources/application-dev.yaml`
- `backend/src/main/java/com/example/nexus/domain/pos/PosController.java`
- `backend/src/main/java/com/example/nexus/domain/pos/AutoOrderService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java`
- `backend/src/main/resources/datalocal.sql`
- `docs/auto-order-ai-구현가이드.md`

## 주요 변경 사항
- Spring AI + Jsoup 의존성 추가
- OpenAI API Key 환경변수 설정 추가
- `POST /pos/close` 마감 API 엔드포인트 추가
- `AutoOrderService` 신규 생성 (재고 조회 → 프롬프트 조립 → OpenAI 호출 → 발주서 저장)
- `Orders` Entity에 `reason` 컬럼 추가 (AI 발주 추천 사유, nullable)
- `datalocal.sql`에 reason 반영 및 강남역점 테스트 데이터 보강
-  팀 공유용 구현 가이드 문서 작성

## DB & Infrastructure (해당 시)
- [ ] Orders 테이블에 `reason VARCHAR(255) NULL` 컬럼 추가 (ddl-auto: update로 자동 반영)

## Test Plan
- [ ] `.env`에 `OPENAI_API_KEY` 설정 후 서버 실행
- [ ] store01 계정 로그인 → POS 영업 마감 버튼 클릭
- [ ] orders 테이블에 AUTO/WAITING 상태 발주서 생성 확인
- [ ] 점주 대시보드 제안 발주서 목록에 노출 확인

## Issue
- Closes #62