### PR TITLE
[Feat] #63 - POS 마감 버튼에 AI 자동 발주 API 연동

### DIFF
--- a/frontend/src/api/pos/index.js
+++ b/frontend/src/api/pos/index.js
@@ -17,3 +17,6 @@ export const postPosPay = (body) => api.post('/pos/pay', body)
 
 /** 당일 결제 내역 (BaseResponse.result = TodayPayRes[]) */
 export const getPosPayToday = () => api.get('/pos/pay/today')
+
+/** POS 영업 마감 → AI 자동 발주서 생성 */
+export const postPosClose = () => api.post('/pos/close')

--- a/frontend/src/views/store/PosView.vue
+++ b/frontend/src/views/store/PosView.vue
@@ -53,7 +53,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
-import { getMenuCategoryList, getMenuListPaged, getPosPayToday, postPosPay } from '@/api/pos'
+import { getMenuCategoryList, getMenuListPaged, getPosPayToday, postPosPay, postPosClose } from '@/api/pos'
 import { formatPrice } from '@/utils/formatPrice.js'
 import PosHeaderBar from '@/components/pos/PosHeaderBar.vue'
 import PosMenuBoard from '@/components/pos/PosMenuBoard.vue'
@@ -279,10 +279,17 @@ function toggleStoreStatus() {
   }
 }
 
-function confirmClose() {
-  salesData.value.isClosed = true
-  showCloseModal.value = false
-  showToastMsg('성공적으로 영업이 마감되었습니다. 데이터가 본사로 전송됩니다.')
+async function confirmClose() {
+  try {
+    await postPosClose()
+    salesData.value.isClosed = true
+    showCloseModal.value = false
+    showToastMsg('영업이 마감되었습니다. AI 자동 발주서가 생성되었습니다.')
+  } catch (e) {
+    console.error(e)
+    showCloseModal.value = false
+    showToastMsg('영업 마감 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.')
+  }
 }
 
 watch(


### PR DESCRIPTION
## Summary
- POS 영업 마감 시 백엔드 AI 자동 발주서 생성 API를 호출하도록 프론트엔드 연동

## 변경 파일
- `frontend/src/api/pos/index.js`
- `frontend/src/views/store/PosView.vue`

## 주요 변경 사항
- `postPosClose()` API 함수 추가 (`POST /pos/close`)
- `confirmClose()`에서 API 호출하도록 변경 (기존: 로컬 상태만 변경)
- 성공/실패 시 토스트 메시지 분기 처리

## Test Plan
- [ ] store01 로그인 → POS → 정산 탭 → 영업 마감 → 마감 승인 클릭
- [ ] 성공 토스트 "AI 자동 발주서가 생성되었습니다" 확인
- [ ] orders 테이블에 AUTO/WAITING 행 생성 확인
- [ ] 네트워크 오류 시 실패 토스트 노출 확인

## Issue
- Closes #63