### PR TITLE
[Fix] 점주 대시보드 및 발주서 UX/성능 개선    

### DIFF
--- a/frontend/src/components/dashboard/store/InventoryWarningList.vue
+++ b/frontend/src/components/dashboard/store/InventoryWarningList.vue
@@ -44,7 +44,8 @@ onMounted(async () => {
               class="hover:bg-gray-50/50 cursor-pointer"
               role="button" tabindex="0"
               @click="router.push('/store-inventory')"
-              @keydown.enter="router.push('/store-inventory')">
+              @keydown.enter="router.push('/store-inventory')"
+            @keydown.space.prevent="router.push('/store-inventory')">
               <td class="px-5 py-3.5 font-semibold text-gray-800">{{ w.productName }}</td>
               <td class="px-5 py-3.5 text-right font-bold text-red-600">{{ w.currentStock }}{{ w.unit }}</td>
               <td class="px-5 py-3.5 text-right text-gray-400">{{ w.minStock }}{{ w.unit }}</td>

--- a/frontend/src/components/dashboard/store/InventoryWarningList.vue
+++ b/frontend/src/components/dashboard/store/InventoryWarningList.vue
@@ -26,32 +26,38 @@ onMounted(async () => {
     <div v-if="warnings.length === 0" class="px-5 py-8 text-center text-sm text-gray-400">
       위험 재고 품목이 없습니다
     </div>
-    <table v-else class="w-full text-sm">
-      <thead>
-        <tr class="border-b border-gray-200 bg-gray-50">
-          <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
-          <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">현재 재고</th>
-          <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">최소 재고</th>
-          <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-gray-100">
-        <tr v-for="w in warnings" :key="w.inventoryIdx"
-          class="hover:bg-gray-50/50 cursor-pointer"
-          role="button" tabindex="0"
-          @click="router.push('/store-inventory')"
-          @keydown.enter="router.push('/store-inventory')">
-          <td class="px-5 py-3.5 font-semibold text-gray-800">{{ w.productName }}</td>
-          <td class="px-5 py-3.5 text-right font-bold text-red-600">{{ w.currentStock }}{{ w.unit }}</td>
-          <td class="px-5 py-3.5 text-right text-gray-400">{{ w.minStock }}{{ w.unit }}</td>
-          <td class="px-5 py-3.5 text-right">
-            <span class="text-xs font-bold px-2 py-0.5 rounded"
-              :class="w.status === 'CRITICAL' ? 'bg-red-50 text-red-600 border border-red-200' : 'bg-orange-50 text-orange-600 border border-orange-200'">
-              {{ STATUS_LABEL[w.status] || w.status }}
-            </span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-else>
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-gray-200 bg-gray-50">
+            <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
+            <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">현재 재고</th>
+            <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">최소 재고</th>
+            <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
+          </tr>
+        </thead>
+      </table>
+      <div class="max-h-[200px] overflow-y-auto">
+        <table class="w-full text-sm">
+          <tbody class="divide-y divide-gray-100">
+            <tr v-for="w in warnings" :key="w.inventoryIdx"
+              class="hover:bg-gray-50/50 cursor-pointer"
+              role="button" tabindex="0"
+              @click="router.push('/store-inventory')"
+              @keydown.enter="router.push('/store-inventory')">
+              <td class="px-5 py-3.5 font-semibold text-gray-800">{{ w.productName }}</td>
+              <td class="px-5 py-3.5 text-right font-bold text-red-600">{{ w.currentStock }}{{ w.unit }}</td>
+              <td class="px-5 py-3.5 text-right text-gray-400">{{ w.minStock }}{{ w.unit }}</td>
+              <td class="px-5 py-3.5 text-right">
+                <span class="text-xs font-bold px-2 py-0.5 rounded"
+                  :class="w.status === 'CRITICAL' ? 'bg-red-50 text-red-600 border border-red-200' : 'bg-orange-50 text-orange-600 border border-orange-200'">
+                  {{ STATUS_LABEL[w.status] || w.status }}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </template>

--- a/frontend/src/components/dashboard/store/MyDeliveryList.vue
+++ b/frontend/src/components/dashboard/store/MyDeliveryList.vue
@@ -46,7 +46,8 @@ onMounted(async () => {
         class="px-5 py-4 hover:bg-gray-50 transition-colors cursor-pointer"
         role="button" tabindex="0"
         @click="router.push('/store-delivery')"
-        @keydown.enter="router.push('/store-delivery')">
+        @keydown.enter="router.push('/store-delivery')"
+        @keydown.space.prevent="router.push('/store-delivery')">
         <div class="flex items-center justify-between gap-3">
           <div class="flex-1 min-w-0">
             <p class="text-sm font-bold text-gray-900 font-mono">발주 #{{ d.ordersIdx }}</p>

--- a/frontend/src/components/dashboard/store/MyDeliveryList.vue
+++ b/frontend/src/components/dashboard/store/MyDeliveryList.vue
@@ -38,7 +38,7 @@ onMounted(async () => {
     <div class="px-5 pt-5 pb-4 border-b border-gray-100">
       <h2 class="font-bold text-gray-900">나의 배송 현황</h2>
     </div>
-    <div class="flex-1 divide-y divide-gray-50 overflow-y-auto">
+    <div class="flex-1 divide-y divide-gray-50 overflow-y-auto max-h-[240px]">
       <div v-if="deliveries.length === 0" class="px-5 py-8 text-center text-sm text-gray-400">
         진행중인 배송이 없습니다
       </div>

--- a/frontend/src/components/dashboard/store/PendingOrderList.vue
+++ b/frontend/src/components/dashboard/store/PendingOrderList.vue
@@ -42,7 +42,8 @@ onMounted(async () => {
               class="hover:bg-gray-50/50 cursor-pointer"
               role="button" tabindex="0"
               @click="router.push('/store-order')"
-              @keydown.enter="router.push('/store-order')">
+              @keydown.enter="router.push('/store-order')"
+            @keydown.space.prevent="router.push('/store-order')">
               <td class="px-5 py-3.5 font-semibold text-gray-800">{{ o.productName }}</td>
               <td class="px-5 py-3.5 text-right text-gray-600">{{ o.quantity.toLocaleString() }}개</td>
               <td class="px-5 py-3.5 text-right font-semibold text-gray-700">₩ {{ o.price.toLocaleString() }}</td>

--- a/frontend/src/components/dashboard/store/PendingOrderList.vue
+++ b/frontend/src/components/dashboard/store/PendingOrderList.vue
@@ -24,29 +24,35 @@ onMounted(async () => {
     <div v-if="orders.length === 0" class="px-5 py-8 text-center text-sm text-gray-400">
       제안된 발주서가 없습니다
     </div>
-    <table v-else class="w-full text-sm">
-      <thead>
-        <tr class="border-b border-gray-200 bg-gray-50">
-          <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
-          <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">제안 수량</th>
-          <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">금액</th>
-          <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-gray-100">
-        <tr v-for="o in orders" :key="o.ordersIdx"
-          class="hover:bg-gray-50/50 cursor-pointer"
-          role="button" tabindex="0"
-          @click="router.push('/store-order')"
-          @keydown.enter="router.push('/store-order')">
-          <td class="px-5 py-3.5 font-semibold text-gray-800">{{ o.productName }}</td>
-          <td class="px-5 py-3.5 text-right text-gray-600">{{ o.quantity.toLocaleString() }}개</td>
-          <td class="px-5 py-3.5 text-right font-semibold text-gray-700">₩ {{ o.price.toLocaleString() }}</td>
-          <td class="px-5 py-3.5 text-right">
-            <span class="text-xs font-bold px-2 py-0.5 rounded bg-blue-50 text-blue-600 border border-blue-200">제안중</span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-else>
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-gray-200 bg-gray-50">
+            <th class="px-5 py-3 text-left text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
+            <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">제안 수량</th>
+            <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">금액</th>
+            <th class="px-5 py-3 text-right text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
+          </tr>
+        </thead>
+      </table>
+      <div class="max-h-[200px] overflow-y-auto">
+        <table class="w-full text-sm">
+          <tbody class="divide-y divide-gray-100">
+            <tr v-for="o in orders" :key="o.ordersIdx"
+              class="hover:bg-gray-50/50 cursor-pointer"
+              role="button" tabindex="0"
+              @click="router.push('/store-order')"
+              @keydown.enter="router.push('/store-order')">
+              <td class="px-5 py-3.5 font-semibold text-gray-800">{{ o.productName }}</td>
+              <td class="px-5 py-3.5 text-right text-gray-600">{{ o.quantity.toLocaleString() }}개</td>
+              <td class="px-5 py-3.5 text-right font-semibold text-gray-700">₩ {{ o.price.toLocaleString() }}</td>
+              <td class="px-5 py-3.5 text-right">
+                <span class="text-xs font-bold px-2 py-0.5 rounded bg-blue-50 text-blue-600 border border-blue-200">제안중</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </template>

--- a/frontend/src/components/orders/StorePendingOrderList.vue
+++ b/frontend/src/components/orders/StorePendingOrderList.vue
@@ -11,6 +11,10 @@ const emit = defineEmits(['confirm', 'reject', 'refresh', 'delete-item'])
 
 const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, clearAddItemProduct, submitAddItem } = useAddOrderItem(() => emit('refresh'))
 
+function sortedItems(order) {
+  return [...(order.ordersItemList || [])].sort((a, b) => b.idx - a.idx)
+}
+
 const debounceTimers = new Map()
 
 function onCountChange(item) {
@@ -137,7 +141,7 @@ function onCountChange(item) {
             <col class="w-[12%]" />
           </colgroup>
           <tbody class="divide-y divide-gray-100">
-            <tr v-for="item in [...(order.ordersItemList || [])].sort((a, b) => b.idx - a.idx)" :key="item.idx" class="hover:bg-gray-50/50">
+            <tr v-for="item in sortedItems(order)" :key="item.idx" class="hover:bg-gray-50/50">
               <td class="px-5 py-3.5 font-semibold text-gray-900">{{ item.productName }}</td>
               <td class="px-5 py-3.5 text-gray-500">{{ item.currentStock != null ? item.currentStock + '개' : '-' }}</td>
               <td class="px-5 py-3.5 font-semibold text-blue-600">

--- a/frontend/src/components/orders/StorePendingOrderList.vue
+++ b/frontend/src/components/orders/StorePendingOrderList.vue
@@ -136,7 +136,7 @@ function onCountChange(item) {
             <col class="w-[12%]" />
           </colgroup>
           <tbody class="divide-y divide-gray-100">
-            <tr v-for="item in [...order.ordersItemList].sort((a, b) => b.idx - a.idx)" :key="item.idx" class="hover:bg-gray-50/50">
+            <tr v-for="item in [...(order.ordersItemList || [])].sort((a, b) => b.idx - a.idx)" :key="item.idx" class="hover:bg-gray-50/50">
               <td class="px-5 py-3.5 font-semibold text-gray-900">{{ item.productName }}</td>
               <td class="px-5 py-3.5 text-gray-500">{{ item.currentStock != null ? item.currentStock + '개' : '-' }}</td>
               <td class="px-5 py-3.5 font-semibold text-blue-600">

--- a/frontend/src/components/orders/StorePendingOrderList.vue
+++ b/frontend/src/components/orders/StorePendingOrderList.vue
@@ -11,11 +11,12 @@ const emit = defineEmits(['confirm', 'reject', 'refresh', 'delete-item'])
 
 const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, clearAddItemProduct, submitAddItem } = useAddOrderItem(() => emit('refresh'))
 
-let debounceTimer = null
+const debounceTimers = new Map()
 
 function onCountChange(item) {
-  if (debounceTimer) clearTimeout(debounceTimer)
-  debounceTimer = setTimeout(async () => {
+  if (debounceTimers.has(item.idx)) clearTimeout(debounceTimers.get(item.idx))
+  debounceTimers.set(item.idx, setTimeout(async () => {
+    debounceTimers.delete(item.idx)
     if (item.count < 1) { item.count = 1 }
     try {
       await ordersApi.updateStoreItemCount(item.idx, { count: item.count })
@@ -24,7 +25,7 @@ function onCountChange(item) {
       alert('수량 수정에 실패했습니다.')
       emit('refresh')
     }
-  }, 500)
+  }, 500))
 }
 </script>
 

--- a/frontend/src/composables/useAddOrderItem.js
+++ b/frontend/src/composables/useAddOrderItem.js
@@ -19,7 +19,7 @@ export function useAddOrderItem(fetchPendingOrders) {
   }
 
   function filteredProducts(order) {
-    const existing = new Set(order.ordersItemList.map(i => i.productName))
+    const existing = new Set((order.ordersItemList || []).map(i => i.productName))
     const keyword = addItemForm.value?.keyword?.trim() || ''
     return productList.value.filter(p => !existing.has(p.productName) && (keyword === '' || p.productName.includes(keyword)))
   }

--- a/frontend/src/views/store/StoreOrderManageView.vue
+++ b/frontend/src/views/store/StoreOrderManageView.vue
@@ -49,9 +49,12 @@ onMounted(() => {
   fetchPendingOrders()
 })
 
+const historyLoaded = ref(false)
+
 watch(activeTab, (tab) => {
-  if (tab === 'history') {
+  if (tab === 'history' && !historyLoaded.value) {
     fetchOrderHistory()
+    historyLoaded.value = true
   }
 })
 
@@ -171,11 +174,11 @@ async function submitManualOrder(data) {
       </button>
     </div>
 
-    <StorePendingOrderList v-if="activeTab === 'pending'" :orders="pendingOrders"
+    <StorePendingOrderList v-show="activeTab === 'pending'" :orders="pendingOrders"
       @confirm="openConfirmModal" @reject="openRejectModal" @refresh="fetchPendingOrders"
       @delete-item="deleteItem" />
 
-    <StoreOrderHistoryTable v-if="activeTab === 'history'" :orders="orderHistory"
+    <StoreOrderHistoryTable v-show="activeTab === 'history'" :orders="orderHistory"
       :current-page="historyPage" :total-pages="historyTotalPages"
       @open-detail="openHistoryDetail" @cancel="cancelOrder" @page-change="fetchOrderHistory" />
 

--- a/frontend/src/views/store/StoreOrderManageView.vue
+++ b/frontend/src/views/store/StoreOrderManageView.vue
@@ -178,7 +178,7 @@ async function submitManualOrder(data) {
       @confirm="openConfirmModal" @reject="openRejectModal" @refresh="fetchPendingOrders"
       @delete-item="deleteItem" />
 
-    <StoreOrderHistoryTable v-show="activeTab === 'history'" :orders="orderHistory"
+    <StoreOrderHistoryTable v-if="activeTab === 'history'" :orders="orderHistory"
       :current-page="historyPage" :total-pages="historyTotalPages"
       @open-detail="openHistoryDetail" @cancel="cancelOrder" @page-change="fetchOrderHistory" />
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 대시보드 목록 스크롤 처리 및 발주서 프론트엔드 코드 최적화
                                                                                                                                                                                                                                  
## 변경 파일
- frontend/src/components/dashboard/store/MyDeliveryList.vue
- frontend/src/components/dashboard/store/PendingOrderList.vue
- frontend/src/components/dashboard/store/InventoryWarningList.vue
- frontend/src/components/orders/StorePendingOrderList.vue
- frontend/src/composables/useAddOrderItem.js
- frontend/src/views/store/StoreOrderManageView.vue

## 주요 변경 사항
- 점주 대시보드 배송현황/미확정발주/재고위험 목록에 max-height 스크롤 적용
- ordersItemList null 접근 방어 처리
- 품목 수량 변경 debounce를 품목별 독립 타이머로 변경 (경쟁 조건 해소)
- 발주서 탭 전환 시 불필요한 API 재호출 방지 (v-show + 최초 1회 로드)
- 템플릿 내 인라인 정렬 로직을 메서드로 추출

## Test Plan
- [ ] 대시보드 목록 4개 초과 시 스크롤 동작 확인
- [ ] 제안 발주서 품목 수량 여러 개 동시 변경 시 각각 저장 확인
- [ ] 발주 이력 탭 전환 반복 시 API 중복 호출 없는지 확인