### PR TITLE
[Feat] #146 - 가맹점별 배송 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
@@ -4,10 +4,7 @@ import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.domain.delivery.model.DeliveryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,5 +24,12 @@ public class DeliveryController {
             @RequestParam(required = false) Integer month,
             @RequestParam(required = false) Integer day) {
         return ResponseEntity.ok(deliveryService.getDeliveriesByHead(storeName, status, year, month, day));
+    }
+
+    // 본인 가맹점 배송 현황 조회
+    @GetMapping("/store/{storeIdx}")
+    public ResponseEntity<List<DeliveryDto>> getStoreDeliveries(@PathVariable Long storeIdx) {
+        List<DeliveryDto> response = deliveryService.getDeliveriesForStore(storeIdx);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -48,4 +48,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             @Param("year") Integer year,
             @Param("month") Integer month,
             @Param("day") Integer day);
+
+    // 본인 가맹점 배송 현황 조회
+    @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s WHERE s.idx = :storeIdx")
+    List<Delivery> findAllByOrdersStoreIdx(@Param("storeIdx") Long storeIdx);
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -22,4 +22,11 @@ public class DeliveryService {
                 .map(DeliveryDto::from)
                 .collect(Collectors.toList());
     }
+
+    public List<DeliveryDto> getDeliveriesForStore(Long storeIdx) {
+        return deliveryRepository.findAllByOrdersStoreIdx(storeIdx)
+                .stream()
+                .map(DeliveryDto::from)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 📋 Summary
- 가맹점별 배송 현황 조회 기능 구현

## 📂 변경 파일
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java`
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java`
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java`

## ✨ 주요 변경 사항
- [ ] DeliveryController 가맹점별 본인 storeIdx 로 배송현황 조회할 수 있게 구현
- [ ] DeliveryService 매장 ID로 배송 데이터를 조회 → DTO로 변환 → 리스트로 반환
- [ ] DeliveryRepository 특정 매장(storeIdx)에 속한 배송(Delivery)을 주문(Orders)과 함께 한 번에 조회 (여기서 쿼리문에서의 d:delivery, o:orders, s:store)


Closes #146 