### PR TITLE
 [Feat] #575 - 배송 지연 발생시 본사에서 지연사유 입력

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
@@ -26,10 +26,16 @@ public class DeliveryController {
         return ResponseEntity.ok(deliveryService.getDeliveriesByHead(storeName, status, year, month, day));
     }
 
-    // 본인 가맹점 배송 현황 조회
+    // 본인 가맹점 배송 현황 조회 (발주 번호 및 날짜/상태 필터 추가)
     @GetMapping("/store/{storeIdx}")
-    public ResponseEntity<List<DeliveryDto>> getStoreDeliveries(@PathVariable Long storeIdx) {
-        List<DeliveryDto> response = deliveryService.getDeliveriesForStore(storeIdx);
+    public ResponseEntity<List<DeliveryDto>> getStoreDeliveries(
+            @PathVariable Long storeIdx,
+            @RequestParam(required = false) Long orderIdx, // 발주 번호 검색용
+            @RequestParam(required = false) DeliveryStatus status,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month,
+            @RequestParam(required = false) Integer day) {
+        List<DeliveryDto> response = deliveryService.getDeliveriesForStore(storeIdx, orderIdx, status, year, month, day);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
@@ -30,12 +30,27 @@ public class DeliveryController {
     @GetMapping("/store/{storeIdx}")
     public ResponseEntity<List<DeliveryDto>> getStoreDeliveries(
             @PathVariable Long storeIdx,
-            @RequestParam(required = false) Long orderIdx, // 발주 번호 검색용
+            @RequestParam(required = false) Long orderIdx,
             @RequestParam(required = false) DeliveryStatus status,
             @RequestParam(required = false) Integer year,
             @RequestParam(required = false) Integer month,
             @RequestParam(required = false) Integer day) {
         List<DeliveryDto> response = deliveryService.getDeliveriesForStore(storeIdx, orderIdx, status, year, month, day);
         return ResponseEntity.ok(response);
+    }
+
+    // 본사 배송 지연 사유 입력
+    @PatchMapping("/head/{deliveryIdx}/delayreason")
+    public ResponseEntity<String> updateDelayReason(
+            @PathVariable Long deliveryIdx,
+            @RequestBody DeliveryDto.DelayReasonRequest request) {
+
+        boolean isSuccess = deliveryService.updateDelayReason(deliveryIdx, request.getDelayReason());
+
+        if (isSuccess) {
+            return ResponseEntity.ok("배송 지연 사유가 성공적으로 등록되었습니다.");
+        } else {
+            return ResponseEntity.badRequest().body("존재하지 않는 배송 정보입니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -33,6 +33,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
     List<Delivery> findByDeliveryStatus(DeliveryStatus status);
 
+    Delivery findByIdx(Long deliveryIdx);
+
     // 본사 배송 조회용
     @Query("SELECT d FROM Delivery d " +
             "JOIN FETCH d.orders o " +
@@ -52,4 +54,23 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     // 본인 가맹점 배송 현황 조회
     @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s WHERE s.idx = :storeIdx")
     List<Delivery> findAllByOrdersStoreIdx(@Param("storeIdx") Long storeIdx);
+
+    // 가맹점 배송 현황 필터 및 발주번호 검색 조회
+    @Query("SELECT d FROM Delivery d " +
+            "JOIN FETCH d.orders o " +
+            "JOIN FETCH o.store s " +
+            "WHERE s.idx = :storeIdx " +
+            "AND (:orderIdx IS NULL OR o.idx = :orderIdx) " +
+            "AND (:status IS NULL OR d.deliveryStatus = :status) " +
+            "AND (:year IS NULL OR FUNCTION('YEAR', d.departureDate) = :year) " +
+            "AND (:month IS NULL OR FUNCTION('MONTH', d.departureDate) = :month) " +
+            "AND (:day IS NULL OR FUNCTION('DAY', d.departureDate) = :day)")
+    List<Delivery> findAllByStoreFilters(
+            @Param("storeIdx") Long storeIdx,
+            @Param("orderIdx") Long orderIdx,
+            @Param("status") DeliveryStatus status,
+            @Param("year") Integer year,
+            @Param("month") Integer month,
+            @Param("day") Integer day);
 }
+

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -24,12 +24,28 @@ public class DeliveryService {
                 .collect(Collectors.toList());
     }
 
-    // 가맹점 배송 현황 조회 (필터 조건 추가 반영)
+    // 가맹점 배송 현황 조회
     public List<DeliveryDto> getDeliveriesForStore(
             Long storeIdx, Long orderIdx, DeliveryStatus status, Integer year, Integer month, Integer day) {
         return deliveryRepository.findAllByStoreFilters(storeIdx, orderIdx, status, year, month, day)
                 .stream()
                 .map(delivery -> DeliveryDto.from(delivery))
                 .collect(Collectors.toList());
+    }
+
+    // 본사 배송 지연 사유 입력 로직 (throw/Optional 제거 및 boolean 흐름 제어 적용)
+    @Transactional
+    public boolean updateDelayReason(Long deliveryIdx, String delayReason) {
+        // Optional을 사용하지 않고 직접 Entity를 조회하여 null 체크
+        Delivery delivery = deliveryRepository.findByIdx(deliveryIdx);
+
+        if (delivery == null) {
+            return false;
+        }
+
+        // 상태를 지연으로 변경
+        delivery.setDelayReason(delayReason);
+        delivery.setDeliveryStatus(DeliveryStatus.DELAY);
+        return true;
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -1,6 +1,7 @@
 package com.example.nexus.domain.delivery;
 
 import com.example.nexus.common.enums.DeliveryStatus;
+import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.delivery.model.DeliveryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,10 +24,12 @@ public class DeliveryService {
                 .collect(Collectors.toList());
     }
 
-    public List<DeliveryDto> getDeliveriesForStore(Long storeIdx) {
-        return deliveryRepository.findAllByOrdersStoreIdx(storeIdx)
+    // 가맹점 배송 현황 조회 (필터 조건 추가 반영)
+    public List<DeliveryDto> getDeliveriesForStore(
+            Long storeIdx, Long orderIdx, DeliveryStatus status, Integer year, Integer month, Integer day) {
+        return deliveryRepository.findAllByStoreFilters(storeIdx, orderIdx, status, year, month, day)
                 .stream()
-                .map(DeliveryDto::from)
+                .map(delivery -> DeliveryDto.from(delivery))
                 .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java
@@ -1,5 +1,6 @@
 package com.example.nexus.domain.delivery.model;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -22,6 +23,7 @@ public class DeliveryDto {
     public static DeliveryDto from(Delivery delivery) {
         return DeliveryDto.builder()
                 .deliveryIdx(delivery.getIdx())
+                .orderIdx(delivery.getOrders().getIdx())
                 .storeName(delivery.getOrders().getStore().getStoreName())
                 .deliveryStatus(delivery.getDeliveryStatus().name())
                 .delayReason(delivery.getDelayReason())
@@ -29,5 +31,12 @@ public class DeliveryDto {
                 .estimatedArrivalAt(delivery.getEstimatedArrivalAt())
                 .deliveredDate(delivery.getDeliveredDate())
                 .build();
+    }
+
+    // 본사 지연 사유 입력시 Request Body로 받을 정적 내부 클래스 추가
+    @Getter
+    @NoArgsConstructor
+    public static class DelayReasonRequest {
+        private String delayReason;
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 public class DeliveryDto {
 
     private Long deliveryIdx;
+    private Long orderIdx;
     private String storeName;
     private String deliveryStatus;
     private String delayReason;


### PR DESCRIPTION
## 📋 Summary
-  배송 지연 발생 시 본사에서 사유 입력 기능 구현
- 가맹점 배송 현황 조회 필터 조회 기능 추가

## 📂 변경 파일
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java`
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java`
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java`
- `backend/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java`

## ✨ 주요 변경 사항
- [ ] 본인 가맹점 Idx로 배송 현황 조회 할 수 있게 구현
- [ ] 발주 번호로 검색할 수 있게 구현
- [ ] 배송 상태로도 조회할 수 있게 구현
- [ ] 년도,월,일 로도 조회할 수 있게 구현
- [ ] service 배송현황 조회 (필터, 검색 조건 추가)
- [ ] repository 배송현황 필터 및 발주 번호 검색 조회 추가
- [ ] dto 배송현황 발주 번호로 조회할 수 있게 orderIdx 추가
- [ ] controller 에서 updateDelayReason 호출
- [ ] service 에서 deliveryIdx 로 조회해서 배송지연 입력 하고 배송상태 DELAY로 저장하게 구현
- [ ] 입력 받은 delayReason 값 Dto에 세팅


Closes #575 