### PR TITLE
[Chore] Ingress에 TLS/SSL 설정 추가

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -5,8 +5,14 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - www.nexusscm.kro.kr
+      secretName: nexus-tls
   rules:
     - host: www.nexusscm.kro.kr
       http:


### PR DESCRIPTION
## Summary
- Ingress에 TLS 인증서 및 SSL 리다이렉트 설정을 추가하여 HTTPS 통신 적용                                                                                                                                                          
                
## 변경 파일
- `k8s/ingress.yaml`

## 주요 변경 사항
- ssl-redirect, force-ssl-redirect 어노테이션 추가
- TLS 블록 추가 (호스트: www.nexusscm.kro.kr, Secret: nexus-tls)

## DB & Infrastructure
- DB 스키마 변경 없음
- `nexus-tls` Secret 사전 생성 필요

## Test Plan
- [x] HTTPS 접속 확인 (https://www.nexusscm.kro.kr)
- [x] HTTP → HTTPS 리다이렉트 동작 확인