### PR TITLE
[Chore] 발주 관련 미사용 코드 제거 및 일관성 개선   

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -101,8 +101,8 @@ public class OrdersService {
             spec = spec.and(OrdersSpecification.keywordLike(keyword));
         }
 
-        Danger danger = dangerRepository.findById(1L).orElse(null);
-        int period = danger != null ? danger.getPeriod() : 3;
+        int period = dangerRepository.findById(1L)
+                .map(Danger::getPeriod).orElse(3);
 
         return ordersRepository.findAll(spec, pageable).map(orders -> {
             LocalDateTime since = orders.getCreatedAt().minusMonths(period);
@@ -222,9 +222,10 @@ public class OrdersService {
      * 예: 평균 10개, 이번 30개, 기준 200% → (30-10)*100/10 = 200% → 이상 발주
      */
     private boolean evaluateDanger(Long storeIdx, int totalQty, LocalDateTime baseTime, Long excludeIdx) {
-        Danger danger = dangerRepository.findById(1L).orElse(null);
-        int dangerRatio = danger != null ? danger.getRatio() : 200;
-        int period = danger != null ? danger.getPeriod() : 3;
+        Danger danger = dangerRepository.findById(1L)
+                .orElse(Danger.builder().ratio(200).period(3).build());
+        int dangerRatio = danger.getRatio();
+        int period = danger.getPeriod();
 
         LocalDateTime since = baseTime.minusMonths(period);
         Integer avgQty = ordersRepository.findAvgQtyByStoreAndPeriod(storeIdx, since, excludeIdx);

--- a/frontend/src/api/orders/index.js
+++ b/frontend/src/api/orders/index.js
@@ -49,10 +49,6 @@ const rejectDangerOrder = (ordersIdx) => {
   return api.put(`/orders/${ordersIdx}/reject`)
 }
 
-const getStoreOrderList = () => {
-  return api.get('/orders/store/list')
-}
-
 const getStoreOrderListPaged = (page = 0, size = 10) => {
   return api.get('/orders/store/list/paged', { params: { page, size } })
 }
@@ -94,7 +90,6 @@ export default {
   approveAllConfirmed,
   approveDangerOrder,
   rejectDangerOrder,
-  getStoreOrderList,
   getStoreOrderListPaged,
   getStorePendingOrders,
   confirmStoreOrder,

--- a/frontend/src/components/orders/orderUtils.js
+++ b/frontend/src/components/orders/orderUtils.js
@@ -37,6 +37,7 @@ export const productPrices = {
 }
 
 export const ORDER_STATUS_LABEL = {
+  WAITING: '제안중',
   CONFIRMED: '확정',
   APPROVE: '승인',
   REJECT: '거절',
@@ -50,6 +51,7 @@ export const ORDER_TYPE_LABEL = {
 
 export function storeStatusClass(status) {
   const map = {
+    WAITING:   'bg-blue-50 text-blue-600 border border-blue-200',
     CONFIRMED: 'bg-green-50 text-green-700 border border-green-200',
     APPROVE:   'bg-blue-50 text-blue-600 border border-blue-200',
     REJECT:    'bg-red-50 text-red-600 border border-red-200',


### PR DESCRIPTION
## Summary                                                
- 발주 API/유틸 코드 정리 및 일관성 개선

## 변경 파일
- frontend/src/api/orders/index.js
- frontend/src/components/orders/orderUtils.js
- backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java

## 주요 변경 사항
- 미사용 `getStoreOrderList` API 함수 제거 (대응 백엔드 엔드포인트 없음)
- `ORDER_STATUS_LABEL` 및 `storeStatusClass`에 누락된 WAITING 상태 매핑 추가
- `OrdersService`의 `dangerRepository.findById` null 체크 패턴을 Optional 활용으로 개선

## Test Plan
- [ ] 가맹점 발주 목록 조회 정상 동작 확인
- [ ] 발주 상태 라벨 '제안중' 정상 표시 확인
- [ ] 이상 발주 판정 로직 정상 동작 확인