### PR TITLE
[Feat] 본사 알림 기능 개선 (페이징, 무한스크롤, 자동 삭제)

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -52,11 +52,10 @@ public class DeliveryService {
 
         // 배송 지연 알림 발송
         String delayStoreName = delivery.getOrders().getStore().getStoreName();
-        Long ordersIdx = delivery.getOrders().getIdx();
         headNotificationService.create(
                 NotificationType.DELIVERY_DELAY,
                 "배송 지연 - " + delayStoreName,
-                "발주 #" + ordersIdx + " 배송이 지연되었습니다. 사유: " + delayReason);
+                delayStoreName + " 배송이 지연되었습니다. 사유: " + delayReason);
 
         return true;
     }

--- a/backend/src/main/java/com/example/nexus/domain/notification/HeadNotificationController.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/HeadNotificationController.java
@@ -28,11 +28,14 @@ public class HeadNotificationController {
     @GetMapping("/list")
     public ResponseEntity<BaseResponse> getNotifications(
             @RequestParam(required = false) NotificationType type,
+            @RequestParam(required = false) Boolean isRead,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         Slice<HeadNotificationDto.ListRes> result;
         if (type != null) {
             result = headNotificationService.getNotificationsByType(type, page, size);
+        } else if (isRead != null) {
+            result = headNotificationService.getNotificationsByReadStatus(isRead, page, size);
         } else {
             result = headNotificationService.getNotifications(page, size);
         }

--- a/backend/src/main/java/com/example/nexus/domain/notification/HeadNotificationRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/HeadNotificationRepository.java
@@ -15,6 +15,9 @@ public interface HeadNotificationRepository extends JpaRepository<HeadNotificati
     // 알림 목록 전체 조회 (최신순, 페이징)
     Slice<HeadNotification> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
+    // 알림 목록 읽음 상태별 조회 (최신순, 페이징)
+    Slice<HeadNotification> findAllByIsReadOrderByCreatedAtDesc(boolean isRead, Pageable pageable);
+
     // 알림 목록 타입별 필터 조회 (최신순, 페이징)
     Slice<HeadNotification> findAllByTypeOrderByCreatedAtDesc(NotificationType type, Pageable pageable);
 

--- a/backend/src/main/java/com/example/nexus/domain/notification/HeadNotificationRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/HeadNotificationRepository.java
@@ -31,4 +31,14 @@ public interface HeadNotificationRepository extends JpaRepository<HeadNotificati
 
     // 중복 알림 방지: 동일 타입 + 제목 + 특정 시간 이후 존재 여부 확인
     boolean existsByTypeAndTitleAndCreatedAtAfter(NotificationType type, String title, LocalDateTime after);
+
+    // 읽은 알림 중 특정 일자 이전 삭제
+    @Modifying
+    @Query("DELETE FROM HeadNotification n WHERE n.isRead = true AND n.createdAt < :before")
+    void deleteReadBefore(LocalDateTime before);
+
+    // 안 읽은 알림 중 특정 일자 이전 삭제
+    @Modifying
+    @Query("DELETE FROM HeadNotification n WHERE n.isRead = false AND n.createdAt < :before")
+    void deleteUnreadBefore(LocalDateTime before);
 }

--- a/backend/src/main/java/com/example/nexus/domain/notification/HeadNotificationService.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/HeadNotificationService.java
@@ -28,6 +28,14 @@ public class HeadNotificationService {
     }
 
     /**
+     * 알림 목록 조회 (읽음 상태별)
+     */
+    public Slice<HeadNotificationDto.ListRes> getNotificationsByReadStatus(boolean isRead, int page, int size) {
+        return headNotificationRepository.findAllByIsReadOrderByCreatedAtDesc(isRead, PageRequest.of(page, size))
+                .map(HeadNotificationDto.ListRes::from);
+    }
+
+    /**
      * 알림 목록 조회 (타입별 필터)
      */
     public Slice<HeadNotificationDto.ListRes> getNotificationsByType(NotificationType type, int page, int size) {

--- a/backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java
@@ -6,6 +6,7 @@ import com.example.nexus.domain.head.model.HeadInventory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -57,6 +58,20 @@ public class NotificationScheduler {
                 }
             }
         }
+    }
+
+    /**
+     * 오래된 알림 자동 삭제
+     * 매일 새벽 3시에 실행
+     * 읽은 알림: 30일 경과 시 삭제
+     * 안 읽은 알림: 90일 경과 시 삭제
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void deleteOldNotifications() {
+        LocalDateTime now = LocalDateTime.now();
+        headNotificationRepository.deleteReadBefore(now.minusDays(30));
+        headNotificationRepository.deleteUnreadBefore(now.minusDays(90));
     }
 
 }

--- a/frontend/src/api/notification/index.js
+++ b/frontend/src/api/notification/index.js
@@ -1,9 +1,10 @@
 import api from '@/plugins/axiosinterceptor'
 
 // 알림 목록 조회 (타입별 필터 + 페이징)
-const getNotifications = (type, page = 0, size = 20) => {
+const getNotifications = (type, page = 0, size = 20, isRead) => {
   const params = { page, size }
   if (type) params.type = type
+  if (isRead !== undefined) params.isRead = isRead
   return api.get('/notification/list', { params })
 }
 

--- a/frontend/src/components/NotificationBell.vue
+++ b/frontend/src/components/NotificationBell.vue
@@ -6,7 +6,6 @@ import { useAuthStore } from '@/stores/auth'
 import { useRouter } from 'vue-router'
 
 const open = ref(false)
-const listRef = ref(null)
 const notifStore = useNotificationStore()
 const auth = useAuthStore()
 const router = useRouter()
@@ -115,7 +114,7 @@ function onScroll(e) {
         </div>
 
         <!-- Notification list -->
-        <div ref="listRef" @scroll="onScroll" class="max-h-[420px] overflow-y-auto divide-y divide-gray-50">
+        <div @scroll="onScroll" class="max-h-[420px] overflow-y-auto divide-y divide-gray-50">
           <div v-if="unreadNotifications.length === 0" class="px-4 py-10 text-center text-gray-400 text-sm">
             새 알림이 없습니다.
           </div>
@@ -123,12 +122,12 @@ function onScroll(e) {
           <div v-for="n in unreadNotifications" :key="n.idx"
             @click="handleNotifClick(n)"
             class="flex gap-3 px-4 py-3.5 cursor-pointer transition-colors"
-            :class="n.isRead ? 'bg-white hover:bg-gray-50/50' : unreadRowClass">
+            :class="unreadRowClass"
 
             <!-- Type badge dot -->
             <div class="shrink-0 mt-0.5">
               <div class="w-2 h-2 rounded-full mt-1.5"
-                :class="n.isRead ? 'bg-gray-200' : typeColor(n.type)">
+                :class="typeColor(n.type)">
               </div>
             </div>
 
@@ -149,7 +148,7 @@ function onScroll(e) {
 
             <!-- Unread indicator -->
             <div class="shrink-0 self-center">
-              <div v-if="!n.isRead" class="w-1.5 h-1.5 rounded-full" :class="accentBadgeClass"></div>
+              <div class="w-1.5 h-1.5 rounded-full" :class="accentBadgeClass"></div>
             </div>
           </div>
 

--- a/frontend/src/components/NotificationBell.vue
+++ b/frontend/src/components/NotificationBell.vue
@@ -65,7 +65,7 @@ function typeConfig(type) {
 function onScroll(e) {
   const { scrollTop, scrollHeight, clientHeight } = e.target
   if (scrollHeight - scrollTop - clientHeight < 50) {
-    notifStore.loadMore()
+    notifStore.loadMore(20)
   }
 }
 </script>
@@ -122,7 +122,7 @@ function onScroll(e) {
           <div v-for="n in unreadNotifications" :key="n.idx"
             @click="handleNotifClick(n)"
             class="flex gap-3 px-4 py-3.5 cursor-pointer transition-colors"
-            :class="unreadRowClass"
+            :class="unreadRowClass">
 
             <!-- Type badge dot -->
             <div class="shrink-0 mt-0.5">

--- a/frontend/src/components/NotificationBell.vue
+++ b/frontend/src/components/NotificationBell.vue
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useRouter } from 'vue-router'
 
 const open = ref(false)
+const listRef = ref(null)
 const notifStore = useNotificationStore()
 const auth = useAuthStore()
 const router = useRouter()
@@ -49,6 +50,13 @@ function typeColor(type) {
 
 function typeConfig(type) {
   return notifStore.typeConfig[type] ?? { label: '알림', color: 'text-gray-600', bg: 'bg-gray-50', border: 'border-gray-200' }
+}
+
+function onScroll(e) {
+  const { scrollTop, scrollHeight, clientHeight } = e.target
+  if (scrollHeight - scrollTop - clientHeight < 50) {
+    notifStore.loadMore()
+  }
 }
 </script>
 
@@ -96,7 +104,7 @@ function typeConfig(type) {
         </div>
 
         <!-- Notification list -->
-        <div class="max-h-[420px] overflow-y-auto divide-y divide-gray-50">
+        <div ref="listRef" @scroll="onScroll" class="max-h-[420px] overflow-y-auto divide-y divide-gray-50">
           <div v-if="notifStore.notifications.length === 0" class="px-4 py-10 text-center text-gray-400 text-sm">
             새 알림이 없습니다.
           </div>
@@ -132,6 +140,11 @@ function typeConfig(type) {
             <div class="shrink-0 self-center">
               <div v-if="!n.isRead" class="w-1.5 h-1.5 rounded-full" :class="accentBadgeClass"></div>
             </div>
+          </div>
+
+          <!-- Loading indicator -->
+          <div v-if="notifStore.loading" class="px-4 py-3 text-center text-xs text-gray-400">
+            불러오는 중...
           </div>
         </div>
 

--- a/frontend/src/components/NotificationBell.vue
+++ b/frontend/src/components/NotificationBell.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { Bell } from 'lucide-vue-next'
 import { useNotificationStore } from '@/stores/notification'
 import { useAuthStore } from '@/stores/auth'
@@ -15,11 +15,20 @@ const isStoreOwnerRole = computed(() => auth.isStoreOwner)
 const accentBadgeClass = computed(() => isStoreOwnerRole.value ? 'bg-blue-500' : 'bg-[#F37321]')
 const unreadRowClass = computed(() => isStoreOwnerRole.value ? 'bg-blue-50/30 hover:bg-blue-50/60' : 'bg-orange-50/30 hover:bg-orange-50/60')
 
+// 읽지 않은 알림만 필터링하여 드롭다운에 표시
+const unreadNotifications = computed(() => notifStore.notifications.filter(n => !n.isRead))
+
 // 마운트 시 알림 조회 + SSE 구독
 onMounted(async () => {
-  await notifStore.fetchNotifications()
   await notifStore.fetchUnreadCount()
   notifStore.subscribe()
+})
+
+// 드롭다운 열릴 때 전체 알림 조회
+watch(open, async (isOpen) => {
+  if (isOpen) {
+    await notifStore.fetchNotifications(null, 20)
+  }
 })
 
 // 언마운트 시 SSE 해제
@@ -27,12 +36,14 @@ onBeforeUnmount(() => {
   notifStore.unsubscribe()
 })
 
-function markAll() {
-  notifStore.markAllRead()
+async function markAll() {
+  await notifStore.markAllRead()
 }
 
 function handleNotifClick(n) {
-  if (!n.isRead) notifStore.markRead(n.idx)
+  if (!n.isRead) {
+    notifStore.markRead(n.idx)
+  }
   open.value = false
   const path = auth.isAdmin ? '/notification' : '/store-notification'
   router.push(path)
@@ -105,11 +116,11 @@ function onScroll(e) {
 
         <!-- Notification list -->
         <div ref="listRef" @scroll="onScroll" class="max-h-[420px] overflow-y-auto divide-y divide-gray-50">
-          <div v-if="notifStore.notifications.length === 0" class="px-4 py-10 text-center text-gray-400 text-sm">
+          <div v-if="unreadNotifications.length === 0" class="px-4 py-10 text-center text-gray-400 text-sm">
             새 알림이 없습니다.
           </div>
 
-          <div v-for="n in notifStore.notifications" :key="n.idx"
+          <div v-for="n in unreadNotifications" :key="n.idx"
             @click="handleNotifClick(n)"
             class="flex gap-3 px-4 py-3.5 cursor-pointer transition-colors"
             :class="n.isRead ? 'bg-white hover:bg-gray-50/50' : unreadRowClass">
@@ -150,7 +161,7 @@ function onScroll(e) {
 
         <!-- Panel footer -->
         <div class="px-4 py-2.5 border-t border-gray-100 bg-gray-50/60">
-          <p class="text-[11px] text-gray-400 text-center">전체 {{ notifStore.notifications.length }}건</p>
+          <p class="text-[11px] text-gray-400 text-center">전체 {{ unreadNotifications.length }}건</p>
         </div>
       </div>
     </transition>

--- a/frontend/src/stores/notification.js
+++ b/frontend/src/stores/notification.js
@@ -12,13 +12,16 @@ export const useNotificationStore = defineStore('notification', () => {
 
   const loading = ref(false)
 
+  const currentIsRead = ref(undefined)
+
   // 알림 목록 조회 (첫 페이지)
-  async function fetchNotifications(type = null, size = 10) {
+  async function fetchNotifications(type = null, size = 10, isRead = undefined) {
     currentType.value = type
+    currentIsRead.value = isRead
     currentPage.value = 0
-    const res = await notificationApi.getNotifications(type, 0, size)
+    const res = await notificationApi.getNotifications(type, 0, size, isRead)
     notifications.value = res.data.result.content
-    hasNext.value = res.data.result.hasNext
+    hasNext.value = !res.data.result.last
   }
 
   // 알림 목록 추가 로드 (다음 페이지)
@@ -26,9 +29,9 @@ export const useNotificationStore = defineStore('notification', () => {
     if (!hasNext.value || loading.value) return
     loading.value = true
     currentPage.value++
-    const res = await notificationApi.getNotifications(currentType.value, currentPage.value, size)
+    const res = await notificationApi.getNotifications(currentType.value, currentPage.value, size, currentIsRead.value)
     notifications.value.push(...res.data.result.content)
-    hasNext.value = res.data.result.hasNext
+    hasNext.value = !res.data.result.last
     loading.value = false
   }
 

--- a/frontend/src/stores/notification.js
+++ b/frontend/src/stores/notification.js
@@ -10,22 +10,26 @@ export const useNotificationStore = defineStore('notification', () => {
   const currentType = ref(null)
   let eventSource = null
 
+  const loading = ref(false)
+
   // 알림 목록 조회 (첫 페이지)
-  async function fetchNotifications(type = null) {
+  async function fetchNotifications(type = null, size = 10) {
     currentType.value = type
     currentPage.value = 0
-    const res = await notificationApi.getNotifications(type, 0, 20)
+    const res = await notificationApi.getNotifications(type, 0, size)
     notifications.value = res.data.result.content
     hasNext.value = res.data.result.hasNext
   }
 
   // 알림 목록 추가 로드 (다음 페이지)
-  async function loadMore() {
-    if (!hasNext.value) return
+  async function loadMore(size = 10) {
+    if (!hasNext.value || loading.value) return
+    loading.value = true
     currentPage.value++
-    const res = await notificationApi.getNotifications(currentType.value, currentPage.value, 20)
+    const res = await notificationApi.getNotifications(currentType.value, currentPage.value, size)
     notifications.value.push(...res.data.result.content)
     hasNext.value = res.data.result.hasNext
+    loading.value = false
   }
 
   // 미읽음 개수 조회
@@ -98,6 +102,7 @@ export const useNotificationStore = defineStore('notification', () => {
     notifications,
     unreadCount,
     hasNext,
+    loading,
     fetchNotifications,
     loadMore,
     fetchUnreadCount,

--- a/frontend/src/views/hq/HqNotificationView.vue
+++ b/frontend/src/views/hq/HqNotificationView.vue
@@ -1,9 +1,14 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { Bell } from 'lucide-vue-next'
 import { useNotificationStore } from '@/stores/notification'
 
 const store = useNotificationStore()
+
+// 페이지 진입 시 전체 알림 목록 조회
+onMounted(() => {
+  store.fetchNotifications(null, 20)
+})
 
 // 알림 타입별 필터 탭 목록
 const tabs = [
@@ -20,7 +25,7 @@ const activeTab = ref(null)
 // 탭 전환 시 해당 타입의 알림 목록 조회
 async function switchTab(type) {
   activeTab.value = type
-  await store.fetchNotifications(type)
+  await store.fetchNotifications(type, 20)
 }
 
 // 전체 읽음 처리
@@ -36,6 +41,14 @@ async function handleClick(n) {
 // 알림 타입별 스타일 반환 (fallback 포함)
 function typeConfig(type) {
   return store.typeConfig[type] ?? { label: type, color: 'text-gray-600', bg: 'bg-gray-50', border: 'border-gray-200' }
+}
+
+// 무한스크롤: 스크롤 하단 도달 시 다음 페이지 로드
+function onScroll(e) {
+  const { scrollTop, scrollHeight, clientHeight } = e.target
+  if (scrollHeight - scrollTop - clientHeight < 50) {
+    store.loadMore(20)
+  }
 }
 </script>
 
@@ -69,7 +82,7 @@ function typeConfig(type) {
     </div>
 
     <!-- List -->
-    <div v-if="store.notifications.length > 0" class="flex flex-col gap-2">
+    <div v-if="store.notifications.length > 0" @scroll="onScroll" class="flex flex-col gap-2 max-h-[700px] overflow-y-auto">
       <button
         v-for="n in store.notifications"
         :key="n.idx"
@@ -100,14 +113,10 @@ function typeConfig(type) {
         </div>
       </button>
 
-      <!-- 더 보기 -->
-      <button
-        v-if="store.hasNext"
-        @click="store.loadMore()"
-        class="w-full py-3 text-sm text-gray-500 hover:text-gray-700 font-medium"
-      >
-        더 보기
-      </button>
+      <!-- 로딩 인디케이터 -->
+      <div v-if="store.loading" class="py-3 text-center text-sm text-gray-400">
+        불러오는 중...
+      </div>
     </div>
 
     <!-- Empty -->


### PR DESCRIPTION
## Summary                                                
- 본사 알림 페이지 페이징/무한스크롤 적용 및 NotificationBell 드롭다운 개선, 오래된 알림 자동 삭제 스케줄러 추가

## 변경 파일
- `HeadNotificationController.java`
- `HeadNotificationService.java`
- `HeadNotificationRepository.java`
- `NotificationScheduler.java`
- `DeliveryService.java`
- `frontend/src/api/notification/index.js`
- `frontend/src/stores/notification.js`
- `frontend/src/views/hq/HqNotificationView.vue`
- `frontend/src/components/NotificationBell.vue`

## 주요 변경 사항
- HqNotificationView 무한스크롤 적용 및 리스트 레이아웃 7개 고정
- Slice 응답 hasNext → !last로 페이징 판단 수정
- 알림 목록 조회 API에 isRead 필터 파라미터 추가
- NotificationBell 드롭다운 전체 알림 조회 후 읽지 않은 알림만 표시
- 배송 지연 알림 내용에 발주 번호 대신 가맹점 이름 표시
- 오래된 알림 자동 삭제 스케줄러 추가 (읽음 30일, 미읽음 90일)

## Test Plan
- [ ] 본사 알림 페이지에서 스크롤 시 20개씩 추가 로드 확인
- [ ] 탭별 필터(전체/재고부족/유통기한/비정상감지/배송지연) 무한스크롤 동작 확인
- [ ] NotificationBell 드롭다운에서 읽지 않은 알림만 표시되는지 확인
- [ ] 알림 읽음 처리 시 드롭다운에서 즉시 제외되는지 확인
- [ ] 배송 지연 알림 내용에 가맹점 이름 표시 확인