### PR TITLE
[Feat] #96, #102, #162, #166, #168, #172, #174, #176 - 가맹점 알림 인프라 및 배송 상태 관리 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ k8s/db-statefulset.yaml
 k8s/db-service.yaml
 frontend/.env.development
 
-docs/SSE_알림_구현_설명.md
+docs/

--- a/backend/src/main/java/com/example/nexus/common/enums/NotificationType.java
+++ b/backend/src/main/java/com/example/nexus/common/enums/NotificationType.java
@@ -14,5 +14,6 @@ public enum NotificationType {
     EXPIRY,         // 유통기한 임박
     LOW_STOCK,      // 재고 부족 (본사)
     ABNORMAL_ORDER, // 비정상 발주 감지
-    DELIVERY_DELAY  // 배송 지연 (본사)
+    DELIVERY_DELAY, // 배송 지연 (본사)
+    DELIVERY_START  // 배송 시작 (가맹점)
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
@@ -39,6 +39,17 @@ public class DeliveryController {
         return ResponseEntity.ok(response);
     }
 
+    // 본사 배송 승인 (READY → START + 점주 배송 시작 알림)
+    @PatchMapping("/head/{deliveryIdx}/approve")
+    public ResponseEntity<String> approveDelivery(@PathVariable Long deliveryIdx) {
+        boolean isSuccess = deliveryService.approveDelivery(deliveryIdx);
+        if (isSuccess) {
+            return ResponseEntity.ok("배송이 승인되었습니다.");
+        } else {
+            return ResponseEntity.badRequest().body("승인할 수 없는 배송 상태입니다.");
+        }
+    }
+
     // 본사 배송 지연 사유 입력
     @PatchMapping("/head/{deliveryIdx}/delayreason")
     public ResponseEntity<String> updateDelayReason(

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -35,6 +35,17 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
     Delivery findByIdx(Long deliveryIdx);
 
+    // 배송 상태 자동 전환용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
+    List<Delivery> findByDeliveryStatusAndDepartureDateBefore(DeliveryStatus status, LocalDateTime before);
+
+    // 배송 지연 자동 감지용 - 예상도착일 초과 + 미완료 배송 조회
+    @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s " +
+            "WHERE d.estimatedArrivalAt < :now " +
+            "AND d.deliveryStatus NOT IN (:excludeStatuses)")
+    List<Delivery> findOverdueDeliveries(
+            @Param("now") LocalDateTime now,
+            @Param("excludeStatuses") List<DeliveryStatus> excludeStatuses);
+
     // 본사 배송 조회용
     @Query("SELECT d FROM Delivery d " +
             "JOIN FETCH d.orders o " +

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -5,6 +5,7 @@ import com.example.nexus.common.enums.NotificationType;
 import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.delivery.model.DeliveryDto;
 import com.example.nexus.domain.notification.HeadNotificationService;
+import com.example.nexus.domain.notification.StoreNotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 public class DeliveryService {
     private final DeliveryRepository deliveryRepository;
     private final HeadNotificationService headNotificationService;
+    private final StoreNotificationService storeNotificationService;
 
     public List<DeliveryDto> getDeliveriesByHead(
             String storeName, DeliveryStatus status, Integer year, Integer month, Integer day) {
@@ -50,12 +52,19 @@ public class DeliveryService {
         delivery.setDelayReason(delayReason);
         delivery.setDeliveryStatus(DeliveryStatus.DELAY);
 
-        // 배송 지연 알림 발송
+        // 배송 지연 알림 발송 (본사)
         String delayStoreName = delivery.getOrders().getStore().getStoreName();
         headNotificationService.create(
                 NotificationType.DELIVERY_DELAY,
                 "배송 지연 - " + delayStoreName,
                 delayStoreName + " 배송이 지연되었습니다. 사유: " + delayReason);
+
+        // 배송 지연 알림 발송 (가맹점, NOTIFY_016)
+        storeNotificationService.create(
+                NotificationType.DELIVERY_DELAY,
+                "배송 지연 안내",
+                "배송이 지연되었습니다. 사유: " + delayReason,
+                delivery.getOrders().getStore());
 
         return true;
     }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -10,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.nexus.domain.orders.model.Orders;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,6 +23,18 @@ public class DeliveryService {
     private final DeliveryRepository deliveryRepository;
     private final HeadNotificationService headNotificationService;
     private final StoreNotificationService storeNotificationService;
+
+    // 발주 승인 시 배송 생성 (READY 상태)
+    @Transactional
+    public void createDelivery(Orders orders) {
+        Delivery delivery = Delivery.builder()
+                .deliveryStatus(DeliveryStatus.READY)
+                .departureDate(LocalDateTime.now())
+                .estimatedArrivalAt(LocalDateTime.now().plusDays(1))
+                .orders(orders)
+                .build();
+        deliveryRepository.save(delivery);
+    }
 
     public List<DeliveryDto> getDeliveriesByHead(
             String storeName, DeliveryStatus status, Integer year, Integer month, Integer day) {

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -36,6 +36,27 @@ public class DeliveryService {
         deliveryRepository.save(delivery);
     }
 
+    // 배송 승인: READY → START + 점주 배송 시작 알림 (NOTIFY_014)
+    @Transactional
+    public boolean approveDelivery(Long deliveryIdx) {
+        Delivery delivery = deliveryRepository.findByIdx(deliveryIdx);
+        if (delivery == null || delivery.getDeliveryStatus() != DeliveryStatus.READY) {
+            return false;
+        }
+
+        delivery.setDeliveryStatus(DeliveryStatus.START);
+
+        String storeName = delivery.getOrders().getStore().getStoreName();
+        storeNotificationService.create(
+                NotificationType.DELIVERY_START,
+                "배송 시작 안내",
+                "주문하신 상품의 배송이 시작되었습니다. 예상 도착일: "
+                        + delivery.getEstimatedArrivalAt().toLocalDate(),
+                delivery.getOrders().getStore());
+
+        return true;
+    }
+
     public List<DeliveryDto> getDeliveriesByHead(
             String storeName, DeliveryStatus status, Integer year, Integer month, Integer day) {
         return deliveryRepository.findAllByFilters(storeName, status, year, month, day)

--- a/backend/src/main/java/com/example/nexus/domain/delivery/model/Delivery.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/model/Delivery.java
@@ -3,10 +3,7 @@ package com.example.nexus.domain.delivery.model;
 import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.domain.orders.model.Orders;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -17,6 +14,7 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class Delivery {
 
     @Id
@@ -37,7 +35,7 @@ public class Delivery {
     @Column(name = "est_des_date", nullable = false)
     private LocalDateTime estimatedArrivalAt;
 
-    @Column(name = "delivered_date", nullable = false)
+    @Column(name = "delivered_date")
     private LocalDateTime deliveredDate;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/example/nexus/domain/inventory/InventoryMovementService.java
+++ b/backend/src/main/java/com/example/nexus/domain/inventory/InventoryMovementService.java
@@ -8,6 +8,7 @@ import com.example.nexus.domain.inventory.model.InventoryMovement;
 import com.example.nexus.domain.inventory.model.InventoryMovementDto;
 import com.example.nexus.domain.notification.HeadNotificationRepository;
 import com.example.nexus.domain.notification.HeadNotificationService;
+import com.example.nexus.domain.notification.StoreNotificationService;
 import com.example.nexus.domain.product.ProductRepository;
 import com.example.nexus.domain.product.model.Product;
 import com.example.nexus.domain.store.StoreInventoryRepository;
@@ -32,6 +33,7 @@ public class InventoryMovementService {
     private final StoreRepository storeRepository;
     private final HeadNotificationService headNotificationService;
     private final HeadNotificationRepository headNotificationRepository;
+    private final StoreNotificationService storeNotificationService;
 
     @Transactional
     public InventoryMovementDto.MovementRes inbound(InventoryMovementDto.InboundReq req) {
@@ -78,6 +80,13 @@ public class InventoryMovementService {
                         "현재 수량: " + headInventory.getCount() + product.getProductUnit()
                                 + " (최소 기준: " + product.getMinStock() + product.getProductUnit() + ")");
             }
+
+            // 가맹점 재고 부족 알림 (NOTIFY_009)
+            storeNotificationService.create(
+                    NotificationType.LOW_STOCK,
+                    title,
+                    product.getProductName() + " 재고가 부족합니다. 본사에 발주를 요청해주세요.",
+                    store);
         }
 
         StoreInventory storeInventory = new StoreInventory(

--- a/backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java
@@ -3,6 +3,8 @@ package com.example.nexus.domain.notification;
 import com.example.nexus.common.enums.NotificationType;
 import com.example.nexus.domain.head.HeadInventoryRepository;
 import com.example.nexus.domain.head.model.HeadInventory;
+import com.example.nexus.domain.store.StoreInventoryRepository;
+import com.example.nexus.domain.store.model.StoreInventory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -18,6 +20,9 @@ public class NotificationScheduler {
     private final HeadInventoryRepository headInventoryRepository;
     private final HeadNotificationService headNotificationService;
     private final HeadNotificationRepository headNotificationRepository;
+    private final StoreInventoryRepository storeInventoryRepository;
+    private final StoreNotificationService storeNotificationService;
+    private final StoreNotificationRepository storeNotificationRepository;
 
     /**
      * 유통기한 임박 알림
@@ -58,6 +63,28 @@ public class NotificationScheduler {
                 }
             }
         }
+
+        // 가맹점 재고 유통기한 임박 알림 (NOTIFY_008)
+        List<StoreInventory> storeInventories = storeInventoryRepository.findAllByCountGreaterThan(0);
+
+        for (StoreInventory storeInventory : storeInventories) {
+            int shelfLifeDays = Integer.parseInt(storeInventory.getProduct().getDangerDays());
+            LocalDateTime expiryDate = storeInventory.getManufacturedDate().plusDays(shelfLifeDays);
+            long daysUntilExpiry = java.time.Duration.between(now, expiryDate).toDays();
+
+            if (daysUntilExpiry <= alertDays && daysUntilExpiry >= 0) {
+                String productName = storeInventory.getProduct().getProductName();
+                String title = "유통기한 임박 - " + productName;
+                String content = "유통기한 " + daysUntilExpiry + "일 이내입니다. (만료일: "
+                        + expiryDate.toLocalDate() + ")";
+
+                boolean exists = storeNotificationRepository.existsByTypeAndTitleAndStore_IdxAndCreatedAtAfter(
+                        NotificationType.EXPIRY, title, storeInventory.getStore().getIdx(), now.toLocalDate().atStartOfDay());
+                if (!exists) {
+                    storeNotificationService.create(NotificationType.EXPIRY, title, content, storeInventory.getStore());
+                }
+            }
+        }
     }
 
     /**
@@ -72,6 +99,8 @@ public class NotificationScheduler {
         LocalDateTime now = LocalDateTime.now();
         headNotificationRepository.deleteReadBefore(now.minusDays(30));
         headNotificationRepository.deleteUnreadBefore(now.minusDays(90));
+        storeNotificationRepository.deleteReadBefore(now.minusDays(30));
+        storeNotificationRepository.deleteUnreadBefore(now.minusDays(90));
     }
 
 }

--- a/backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java
@@ -1,6 +1,9 @@
 package com.example.nexus.domain.notification;
 
+import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.common.enums.NotificationType;
+import com.example.nexus.domain.delivery.DeliveryRepository;
+import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.head.HeadInventoryRepository;
 import com.example.nexus.domain.head.model.HeadInventory;
 import com.example.nexus.domain.store.StoreInventoryRepository;
@@ -23,6 +26,7 @@ public class NotificationScheduler {
     private final StoreInventoryRepository storeInventoryRepository;
     private final StoreNotificationService storeNotificationService;
     private final StoreNotificationRepository storeNotificationRepository;
+    private final DeliveryRepository deliveryRepository;
 
     /**
      * 유통기한 임박 알림
@@ -84,6 +88,71 @@ public class NotificationScheduler {
                     storeNotificationService.create(NotificationType.EXPIRY, title, content, storeInventory.getStore());
                 }
             }
+        }
+    }
+
+    /**
+     * 배송 상태 자동 전환
+     * 10분마다 실행
+     * START + 1시간 경과 → DELIVERYING
+     * START + 1일 경과 → DELIVERED + 점주 배송 완료 알림 (NOTIFY_015)
+     */
+    @Scheduled(cron = "0 */10 * * * *")
+    @Transactional
+    public void updateDeliveryStatus() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // START + 1일 경과 → DELIVERED (먼저 체크하여 1시간/1일 모두 경과한 건은 바로 완료 처리)
+        List<Delivery> toDeliver = deliveryRepository.findByDeliveryStatusAndDepartureDateBefore(
+                DeliveryStatus.START, now.minusDays(1));
+        for (Delivery delivery : toDeliver) {
+            delivery.setDeliveryStatus(DeliveryStatus.DELIVERED);
+            delivery.setDeliveredDate(now);
+
+            // 점주 배송 완료 알림 (NOTIFY_015)
+            storeNotificationService.create(
+                    NotificationType.DELIVERED,
+                    "배송 완료 안내",
+                    "주문하신 상품의 배송이 완료되었습니다.",
+                    delivery.getOrders().getStore());
+        }
+
+        // START + 1시간 경과 → DELIVERYING
+        List<Delivery> toDelivering = deliveryRepository.findByDeliveryStatusAndDepartureDateBefore(
+                DeliveryStatus.START, now.minusHours(1));
+        for (Delivery delivery : toDelivering) {
+            delivery.setDeliveryStatus(DeliveryStatus.DELIVERYING);
+        }
+    }
+
+    /**
+     * 배송 지연 자동 감지
+     * 매일 오전 8시에 실행
+     * 예상도착일 초과 + 미완료 배송 → 점주/운영자 알림 (NOTIFY_016)
+     */
+    @Scheduled(cron = "0 0 8 * * *")
+    @Transactional
+    public void checkDeliveryDelay() {
+        LocalDateTime now = LocalDateTime.now();
+
+        List<Delivery> overdueDeliveries = deliveryRepository.findOverdueDeliveries(
+                now, List.of(DeliveryStatus.DELIVERED, DeliveryStatus.DELAY));
+
+        for (Delivery delivery : overdueDeliveries) {
+            String storeName = delivery.getOrders().getStore().getStoreName();
+
+            // 본사 알림
+            headNotificationService.create(
+                    NotificationType.DELIVERY_DELAY,
+                    "배송 지연 감지 - " + storeName,
+                    storeName + " 배송이 예상 도착일(" + delivery.getEstimatedArrivalAt().toLocalDate() + ")을 초과했습니다.");
+
+            // 가맹점 알림
+            storeNotificationService.create(
+                    NotificationType.DELIVERY_DELAY,
+                    "배송 지연 안내",
+                    "예상 도착일(" + delivery.getEstimatedArrivalAt().toLocalDate() + ")이 초과되었습니다. 본사에서 확인 중입니다.",
+                    delivery.getOrders().getStore());
         }
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationController.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationController.java
@@ -1,0 +1,61 @@
+package com.example.nexus.domain.notification;
+
+import com.example.nexus.common.enums.NotificationType;
+import com.example.nexus.common.model.BaseResponse;
+import com.example.nexus.domain.notification.model.StoreNotificationDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/store/notification")
+@RequiredArgsConstructor
+public class StoreNotificationController {
+
+    private final StoreNotificationService storeNotificationService;
+    private final StoreSseEmitterService storeSseEmitterService;
+
+    @GetMapping("/list")
+    public ResponseEntity<BaseResponse> getNotifications(
+            @RequestParam Long storeIdx,
+            @RequestParam(required = false) NotificationType type,
+            @RequestParam(required = false) Boolean isRead,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Slice<StoreNotificationDto.ListRes> result;
+        if (type != null) {
+            result = storeNotificationService.getNotificationsByType(storeIdx, type, page, size);
+        } else if (isRead != null) {
+            result = storeNotificationService.getNotificationsByReadStatus(storeIdx, isRead, page, size);
+        } else {
+            result = storeNotificationService.getNotifications(storeIdx, page, size);
+        }
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    @GetMapping("/unread/count")
+    public ResponseEntity<BaseResponse> getUnreadCount(@RequestParam Long storeIdx) {
+        StoreNotificationDto.UnreadCountRes result = storeNotificationService.getUnreadCount(storeIdx);
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    @PutMapping("/{notificationIdx}/read")
+    public ResponseEntity<BaseResponse> markAsRead(@PathVariable Long notificationIdx) {
+        storeNotificationService.markAsRead(notificationIdx);
+        return ResponseEntity.ok(BaseResponse.success("success"));
+    }
+
+    @PutMapping("/read/all")
+    public ResponseEntity<BaseResponse> markAllAsRead(@RequestParam Long storeIdx) {
+        storeNotificationService.markAllAsRead(storeIdx);
+        return ResponseEntity.ok(BaseResponse.success("success"));
+    }
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@RequestParam Long storeIdx) {
+        return storeSseEmitterService.subscribe(storeIdx);
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationController.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationController.java
@@ -18,6 +18,15 @@ public class StoreNotificationController {
     private final StoreNotificationService storeNotificationService;
     private final StoreSseEmitterService storeSseEmitterService;
 
+    /**
+     * 알림 목록 조회
+     *
+     * @param storeIdx 가맹점 ID
+     * @param type     알림 타입 필터 (선택)
+     * @param isRead   읽음 상태 필터 (선택)
+     * @param page     페이지 번호
+     * @param size     페이지 크기
+     */
     @GetMapping("/list")
     public ResponseEntity<BaseResponse> getNotifications(
             @RequestParam Long storeIdx,
@@ -36,24 +45,38 @@ public class StoreNotificationController {
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
+    /**
+     * 미읽음 알림 개수 조회
+     */
     @GetMapping("/unread/count")
     public ResponseEntity<BaseResponse> getUnreadCount(@RequestParam Long storeIdx) {
         StoreNotificationDto.UnreadCountRes result = storeNotificationService.getUnreadCount(storeIdx);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
+    /**
+     * 단건 읽음 처리
+     *
+     * @param notificationIdx 알림 ID
+     */
     @PutMapping("/{notificationIdx}/read")
     public ResponseEntity<BaseResponse> markAsRead(@PathVariable Long notificationIdx) {
         storeNotificationService.markAsRead(notificationIdx);
         return ResponseEntity.ok(BaseResponse.success("success"));
     }
 
+    /**
+     * 전체 읽음 처리
+     */
     @PutMapping("/read/all")
     public ResponseEntity<BaseResponse> markAllAsRead(@RequestParam Long storeIdx) {
         storeNotificationService.markAllAsRead(storeIdx);
         return ResponseEntity.ok(BaseResponse.success("success"));
     }
 
+    /**
+     * SSE 구독 (실시간 알림 수신)
+     */
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@RequestParam Long storeIdx) {
         return storeSseEmitterService.subscribe(storeIdx);

--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationRepository.java
@@ -12,24 +12,32 @@ import java.time.LocalDateTime;
 
 public interface StoreNotificationRepository extends JpaRepository<StoreNotification, Long> {
 
+    // 알림 목록 전체 조회 (가맹점별, 최신순, 페이징)
     Slice<StoreNotification> findAllByStore_IdxOrderByCreatedAtDesc(Long storeIdx, Pageable pageable);
 
+    // 알림 목록 읽음 상태별 조회 (가맹점별, 최신순, 페이징)
     Slice<StoreNotification> findAllByStore_IdxAndIsReadOrderByCreatedAtDesc(Long storeIdx, boolean isRead, Pageable pageable);
 
+    // 알림 목록 타입별 필터 조회 (가맹점별, 최신순, 페이징)
     Slice<StoreNotification> findAllByStore_IdxAndTypeOrderByCreatedAtDesc(Long storeIdx, NotificationType type, Pageable pageable);
 
+    // 미읽음 알림 개수 조회 (가맹점별)
     long countByStore_IdxAndIsReadFalse(Long storeIdx);
 
+    // 전체 읽음 처리 (가맹점별, 미읽음 → 읽음 일괄 업데이트)
     @Modifying
     @Query("UPDATE StoreNotification n SET n.isRead = true WHERE n.store.idx = :storeIdx AND n.isRead = false")
     void markAllAsReadByStoreIdx(Long storeIdx);
 
+    // 중복 알림 방지: 동일 타입 + 제목 + 가맹점 + 특정 시간 이후 존재 여부 확인
     boolean existsByTypeAndTitleAndStore_IdxAndCreatedAtAfter(NotificationType type, String title, Long storeIdx, LocalDateTime after);
 
+    // 읽은 알림 중 특정 일자 이전 삭제
     @Modifying
     @Query("DELETE FROM StoreNotification n WHERE n.isRead = true AND n.createdAt < :before")
     void deleteReadBefore(LocalDateTime before);
 
+    // 안 읽은 알림 중 특정 일자 이전 삭제
     @Modifying
     @Query("DELETE FROM StoreNotification n WHERE n.isRead = false AND n.createdAt < :before")
     void deleteUnreadBefore(LocalDateTime before);

--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationRepository.java
@@ -1,0 +1,36 @@
+package com.example.nexus.domain.notification;
+
+import com.example.nexus.common.enums.NotificationType;
+import com.example.nexus.domain.notification.model.StoreNotification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+
+public interface StoreNotificationRepository extends JpaRepository<StoreNotification, Long> {
+
+    Slice<StoreNotification> findAllByStore_IdxOrderByCreatedAtDesc(Long storeIdx, Pageable pageable);
+
+    Slice<StoreNotification> findAllByStore_IdxAndIsReadOrderByCreatedAtDesc(Long storeIdx, boolean isRead, Pageable pageable);
+
+    Slice<StoreNotification> findAllByStore_IdxAndTypeOrderByCreatedAtDesc(Long storeIdx, NotificationType type, Pageable pageable);
+
+    long countByStore_IdxAndIsReadFalse(Long storeIdx);
+
+    @Modifying
+    @Query("UPDATE StoreNotification n SET n.isRead = true WHERE n.store.idx = :storeIdx AND n.isRead = false")
+    void markAllAsReadByStoreIdx(Long storeIdx);
+
+    boolean existsByTypeAndTitleAndStore_IdxAndCreatedAtAfter(NotificationType type, String title, Long storeIdx, LocalDateTime after);
+
+    @Modifying
+    @Query("DELETE FROM StoreNotification n WHERE n.isRead = true AND n.createdAt < :before")
+    void deleteReadBefore(LocalDateTime before);
+
+    @Modifying
+    @Query("DELETE FROM StoreNotification n WHERE n.isRead = false AND n.createdAt < :before")
+    void deleteUnreadBefore(LocalDateTime before);
+}

--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationService.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationService.java
@@ -1,0 +1,69 @@
+package com.example.nexus.domain.notification;
+
+import com.example.nexus.common.enums.NotificationType;
+import com.example.nexus.domain.notification.model.StoreNotification;
+import com.example.nexus.domain.notification.model.StoreNotificationDto;
+import com.example.nexus.domain.store.model.Store;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreNotificationService {
+
+    private final StoreNotificationRepository storeNotificationRepository;
+    private final StoreSseEmitterService storeSseEmitterService;
+
+    public Slice<StoreNotificationDto.ListRes> getNotifications(Long storeIdx, int page, int size) {
+        return storeNotificationRepository.findAllByStore_IdxOrderByCreatedAtDesc(storeIdx, PageRequest.of(page, size))
+                .map(StoreNotificationDto.ListRes::from);
+    }
+
+    public Slice<StoreNotificationDto.ListRes> getNotificationsByReadStatus(Long storeIdx, boolean isRead, int page, int size) {
+        return storeNotificationRepository.findAllByStore_IdxAndIsReadOrderByCreatedAtDesc(storeIdx, isRead, PageRequest.of(page, size))
+                .map(StoreNotificationDto.ListRes::from);
+    }
+
+    public Slice<StoreNotificationDto.ListRes> getNotificationsByType(Long storeIdx, NotificationType type, int page, int size) {
+        return storeNotificationRepository.findAllByStore_IdxAndTypeOrderByCreatedAtDesc(storeIdx, type, PageRequest.of(page, size))
+                .map(StoreNotificationDto.ListRes::from);
+    }
+
+    public StoreNotificationDto.UnreadCountRes getUnreadCount(Long storeIdx) {
+        long count = storeNotificationRepository.countByStore_IdxAndIsReadFalse(storeIdx);
+        return StoreNotificationDto.UnreadCountRes.builder().count(count).build();
+    }
+
+    @Transactional
+    public void markAsRead(Long notificationIdx) {
+        StoreNotification notification = storeNotificationRepository.findById(notificationIdx)
+                .orElseThrow(() -> new IllegalArgumentException("알림을 찾을 수 없습니다."));
+        notification.markAsRead();
+    }
+
+    @Transactional
+    public void markAllAsRead(Long storeIdx) {
+        storeNotificationRepository.markAllAsReadByStoreIdx(storeIdx);
+    }
+
+    @Transactional
+    public StoreNotification create(NotificationType type, String title, String content, Store store) {
+        StoreNotification notification = StoreNotification.builder()
+                .type(type)
+                .title(title)
+                .content(content)
+                .isRead(false)
+                .createdAt(LocalDateTime.now())
+                .store(store)
+                .build();
+        StoreNotification saved = storeNotificationRepository.save(notification);
+        storeSseEmitterService.send(store.getIdx(), StoreNotificationDto.ListRes.from(saved));
+        return saved;
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationService.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationService.java
@@ -20,26 +20,41 @@ public class StoreNotificationService {
     private final StoreNotificationRepository storeNotificationRepository;
     private final StoreSseEmitterService storeSseEmitterService;
 
+    /**
+     * 알림 목록 조회 (전체)
+     */
     public Slice<StoreNotificationDto.ListRes> getNotifications(Long storeIdx, int page, int size) {
         return storeNotificationRepository.findAllByStore_IdxOrderByCreatedAtDesc(storeIdx, PageRequest.of(page, size))
                 .map(StoreNotificationDto.ListRes::from);
     }
 
+    /**
+     * 알림 목록 조회 (읽음 상태별)
+     */
     public Slice<StoreNotificationDto.ListRes> getNotificationsByReadStatus(Long storeIdx, boolean isRead, int page, int size) {
         return storeNotificationRepository.findAllByStore_IdxAndIsReadOrderByCreatedAtDesc(storeIdx, isRead, PageRequest.of(page, size))
                 .map(StoreNotificationDto.ListRes::from);
     }
 
+    /**
+     * 알림 목록 조회 (타입별 필터)
+     */
     public Slice<StoreNotificationDto.ListRes> getNotificationsByType(Long storeIdx, NotificationType type, int page, int size) {
         return storeNotificationRepository.findAllByStore_IdxAndTypeOrderByCreatedAtDesc(storeIdx, type, PageRequest.of(page, size))
                 .map(StoreNotificationDto.ListRes::from);
     }
 
+    /**
+     * 미읽음 알림 개수 조회
+     */
     public StoreNotificationDto.UnreadCountRes getUnreadCount(Long storeIdx) {
         long count = storeNotificationRepository.countByStore_IdxAndIsReadFalse(storeIdx);
         return StoreNotificationDto.UnreadCountRes.builder().count(count).build();
     }
 
+    /**
+     * 단건 읽음 처리
+     */
     @Transactional
     public void markAsRead(Long notificationIdx) {
         StoreNotification notification = storeNotificationRepository.findById(notificationIdx)
@@ -47,11 +62,17 @@ public class StoreNotificationService {
         notification.markAsRead();
     }
 
+    /**
+     * 전체 읽음 처리
+     */
     @Transactional
     public void markAllAsRead(Long storeIdx) {
         storeNotificationRepository.markAllAsReadByStoreIdx(storeIdx);
     }
 
+    /**
+     * 알림 생성 + SSE 실시간 전송
+     */
     @Transactional
     public StoreNotification create(NotificationType type, String title, String content, Store store) {
         StoreNotification notification = StoreNotification.builder()

--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreSseEmitterService.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreSseEmitterService.java
@@ -15,6 +15,9 @@ public class StoreSseEmitterService {
 
     private final Map<Long, List<SseEmitter>> emitterMap = new ConcurrentHashMap<>();
 
+    /**
+     * SSE 연결 생성 (가맹점별, 타임아웃: 30분)
+     */
     public SseEmitter subscribe(Long storeIdx) {
         SseEmitter emitter = new SseEmitter(30 * 60 * 1000L);
 
@@ -42,6 +45,9 @@ public class StoreSseEmitterService {
         return emitter;
     }
 
+    /**
+     * 특정 가맹점 구독자에게 알림 전송
+     */
     public void send(Long storeIdx, StoreNotificationDto.ListRes notification) {
         List<SseEmitter> emitters = emitterMap.get(storeIdx);
         if (emitters == null) return;

--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreSseEmitterService.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreSseEmitterService.java
@@ -1,0 +1,57 @@
+package com.example.nexus.domain.notification;
+
+import com.example.nexus.domain.notification.model.StoreNotificationDto;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Service
+public class StoreSseEmitterService {
+
+    private final Map<Long, List<SseEmitter>> emitterMap = new ConcurrentHashMap<>();
+
+    public SseEmitter subscribe(Long storeIdx) {
+        SseEmitter emitter = new SseEmitter(30 * 60 * 1000L);
+
+        emitterMap.computeIfAbsent(storeIdx, k -> new CopyOnWriteArrayList<>()).add(emitter);
+
+        Runnable remove = () -> {
+            List<SseEmitter> emitters = emitterMap.get(storeIdx);
+            if (emitters != null) {
+                emitters.remove(emitter);
+                if (emitters.isEmpty()) {
+                    emitterMap.remove(storeIdx);
+                }
+            }
+        };
+        emitter.onCompletion(remove);
+        emitter.onTimeout(remove);
+        emitter.onError(e -> remove.run());
+
+        try {
+            emitter.send(SseEmitter.event().name("connect").data("connected"));
+        } catch (IOException e) {
+            remove.run();
+        }
+
+        return emitter;
+    }
+
+    public void send(Long storeIdx, StoreNotificationDto.ListRes notification) {
+        List<SseEmitter> emitters = emitterMap.get(storeIdx);
+        if (emitters == null) return;
+
+        for (SseEmitter emitter : emitters) {
+            try {
+                emitter.send(SseEmitter.event().name("notification").data(notification));
+            } catch (IOException e) {
+                emitters.remove(emitter);
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/notification/model/StoreNotification.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/model/StoreNotification.java
@@ -1,20 +1,18 @@
-package com.example.nexus.domain.store.model;
+package com.example.nexus.domain.notification.model;
 
 import com.example.nexus.common.enums.NotificationType;
+import com.example.nexus.domain.store.model.Store;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "store_notification")
-@Setter
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class StoreNotification {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,6 +23,12 @@ public class StoreNotification {
     @Column(name = "type", nullable = false)
     private NotificationType type;
 
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
     @Column(name = "is_read", nullable = false)
     private boolean isRead;
 
@@ -34,4 +38,8 @@ public class StoreNotification {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_idx", nullable = false)
     private Store store;
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/notification/model/StoreNotificationDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/model/StoreNotificationDto.java
@@ -1,0 +1,40 @@
+package com.example.nexus.domain.notification.model;
+
+import com.example.nexus.common.enums.NotificationType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class StoreNotificationDto {
+
+    @Getter
+    @Builder
+    public static class ListRes {
+        private Long idx;
+        private NotificationType type;
+        private String title;
+        private String content;
+        @JsonProperty("isRead")
+        private boolean isRead;
+        private LocalDateTime createdAt;
+
+        public static ListRes from(StoreNotification entity) {
+            return ListRes.builder()
+                    .idx(entity.getIdx())
+                    .type(entity.getType())
+                    .title(entity.getTitle())
+                    .content(entity.getContent())
+                    .isRead(entity.isRead())
+                    .createdAt(entity.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class UnreadCountRes {
+        private long count;
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -7,6 +7,7 @@ import com.example.nexus.common.exception.BaseException;
 import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.domain.inventory.InventoryMovementService;
 import com.example.nexus.domain.inventory.model.InventoryMovementDto;
+import com.example.nexus.domain.delivery.DeliveryService;
 import com.example.nexus.domain.notification.HeadNotificationService;
 import com.example.nexus.domain.notification.StoreNotificationService;
 import com.example.nexus.domain.orders.model.*;
@@ -42,6 +43,7 @@ public class OrdersService {
     private final InventoryMovementService inventoryMovementService;
     private final HeadNotificationService headNotificationService;
     private final StoreNotificationService storeNotificationService;
+    private final DeliveryService deliveryService;
 
     // 자동 발주 제안 검색 조회 (AUTO + WAITING 상태 대상)
     // 매장명 키워드 검색 + 페이징 처리
@@ -175,6 +177,7 @@ public class OrdersService {
 
         applyOutboundForOrder(orders, "발주 승인(이상) ordersIdx=");
         orders.approve();
+        deliveryService.createDelivery(orders);
     }
 
     // 본사 - 이상 발주 개별 반려
@@ -198,6 +201,7 @@ public class OrdersService {
         for (Orders orders : confirmedOrders) {
             applyOutboundForOrder(orders, "발주 일괄승인 ordersIdx=");
             orders.approve();
+            deliveryService.createDelivery(orders);
         }
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -8,6 +8,7 @@ import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.domain.inventory.InventoryMovementService;
 import com.example.nexus.domain.inventory.model.InventoryMovementDto;
 import com.example.nexus.domain.notification.HeadNotificationService;
+import com.example.nexus.domain.notification.StoreNotificationService;
 import com.example.nexus.domain.orders.model.*;
 import com.example.nexus.domain.product.ProductRepository;
 import com.example.nexus.domain.product.model.Product;
@@ -40,6 +41,7 @@ public class OrdersService {
     private final ProductRepository productRepository;
     private final InventoryMovementService inventoryMovementService;
     private final HeadNotificationService headNotificationService;
+    private final StoreNotificationService storeNotificationService;
 
     // 자동 발주 제안 검색 조회 (AUTO + WAITING 상태 대상)
     // 매장명 키워드 검색 + 페이징 처리
@@ -272,6 +274,13 @@ public class OrdersService {
                     NotificationType.ABNORMAL_ORDER,
                     "비정상 발주 감지 - " + store.getStoreName(),
                     "수동 발주 수량 " + totalQty + "개 (평균 대비 초과)");
+
+            // 가맹점 비정상 발주 재확인 요청 알림 (NOTIFY_010)
+            storeNotificationService.create(
+                    NotificationType.ABNORMAL_ORDER,
+                    "발주 수량 재확인 요청",
+                    "발주 수량 " + totalQty + "개가 평균 대비 비정상으로 감지되었습니다. 발주 내역을 확인해주세요.",
+                    store);
         }
 
         // 5. Orders 저장
@@ -336,6 +345,13 @@ public class OrdersService {
                     NotificationType.ABNORMAL_ORDER,
                     "비정상 발주 감지 - " + store.getStoreName(),
                     "발주 확정 수량 " + totalQty + "개 (평균 대비 초과)");
+
+            // 가맹점 비정상 발주 재확인 요청 알림 (NOTIFY_010)
+            storeNotificationService.create(
+                    NotificationType.ABNORMAL_ORDER,
+                    "발주 수량 재확인 요청",
+                    "발주 확정 수량 " + totalQty + "개가 평균 대비 비정상으로 감지되었습니다. 발주 내역을 확인해주세요.",
+                    store);
         }
 
         orders.confirm();

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreInventoryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreInventoryRepository.java
@@ -21,4 +21,7 @@ public interface StoreInventoryRepository extends JpaRepository<StoreInventory, 
     Optional<StoreInventory> findByStore_IdxAndProduct_IdxAndManufacturedDate(Long storeIdx, Long productIdx, LocalDateTime manufacturedDate);
 
     List<StoreInventory> findByStore_IdxAndProduct_IdxOrderByManufacturedDateAsc(Long storeIdx, Long productIdx);
+
+    // 유통기한 임박 알림용 - 재고 수량이 0보다 큰 가맹점 재고 조회
+    List<StoreInventory> findAllByCountGreaterThan(int count);
 }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreNotificationRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreNotificationRepository.java
@@ -1,7 +1,0 @@
-package com.example.nexus.domain.store;
-
-import com.example.nexus.domain.store.model.StoreNotification;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface StoreNotificationRepository extends JpaRepository<StoreNotification, Long> {
-}


### PR DESCRIPTION
## Summary                                                
- 가맹점 알림 시스템 백엔드 전체 구현 (인프라, 트리거 연동, 배송 생성/승인/자동 전환)

## 변경 파일
- `StoreNotification.java` (notification 패키지로 이동 + title/content 추가)
- `StoreNotificationDto.java` (신규)
- `StoreNotificationRepository.java` (신규)
- `StoreNotificationService.java` (신규)
- `StoreNotificationController.java` (신규)
- `StoreSseEmitterService.java` (신규)
- `NotificationType.java` (DELIVERY_START 추가)
- `NotificationScheduler.java` (가맹점 유통기한 알림, 배송 자동 전환, 배송 지연 감지 추가)
- `InventoryMovementService.java` (가맹점 재고 부족 알림 추가)
- `OrdersService.java` (가맹점 비정상 발주 알림 + 배송 생성 연결)
- `DeliveryService.java` (createDelivery, approveDelivery 추가 + 가맹점 지연 알림)
- `DeliveryController.java` (배송 승인 API 추가)
- `DeliveryRepository.java` (상태+시간 기반 조회, 지연 감지 쿼리 추가)
- `Delivery.java` (@Builder 추가, deliveredDate nullable 변경)
- `StoreInventoryRepository.java` (findAllByCountGreaterThan 추가)
- `store/StoreNotificationRepository.java` (삭제)

## 주요 변경 사항
- 가맹점 알림 인프라 구축 (Entity, DTO, Repository, Service, Controller, storeIdx별 SSE)
- 기존 본사 트리거에 가맹점 알림 발송 추가 (NOTIFY_008 유통기한, 009 재고 부족, 010 비정상 발주, 016 배송 지연)
- 발주 승인 시 Delivery 자동 생성 (READY 상태)
- 배송 승인 API (READY → START + NOTIFY_014 점주 알림)
- 배송 상태 자동 전환 스케줄러 (START +1시간 → DELIVERYING, +1일 → DELIVERED + NOTIFY_015 점주 알림)
- 예상도착일 초과 배송 자동 지연 감지 및 점주/운영자 알림

## DB & Infrastructure
- `store_notification` 테이블에 `title`, `content` 컬럼 추가
- `delivery` 테이블 `delivered_date` 컬럼 nullable로 변경

## Test Plan
- [ ] 가맹점 알림 목록 조회/읽음 처리 API 정상 동작 확인
- [ ] SSE 구독 후 알림 실시간 수신 확인
- [ ] 발주 승인 시 배송 레코드 READY 상태로 생성 확인
- [ ] 배송 승인 시 START 전환 및 점주 알림 발송 확인
- [ ] 스케줄러 배송 상태 자동 전환 확인 (DELIVERYING, DELIVERED)
- [ ] 배송 지연 자동 감지 및 알림 발송 확인

## Issue
- Closes #96
- Closes #102 
- Closes #162 
- Closes #166 
- Closes #168,
- Closes #172,
- Closes #174
- Closes #176