### PR TITLE
[Feat] #107, #167 - 가맹점 알림 프론트엔드 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationController.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationController.java
@@ -3,10 +3,12 @@ package com.example.nexus.domain.notification;
 import com.example.nexus.common.enums.NotificationType;
 import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.domain.notification.model.StoreNotificationDto;
+import com.example.nexus.domain.user.model.AuthUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -16,48 +18,52 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class StoreNotificationController {
 
     private final StoreNotificationService storeNotificationService;
-    private final StoreSseEmitterService storeSseEmitterService;
 
     /**
-     * 알림 목록 조회
+     * 가맹점 알림 목록 조회
      *
-     * @param storeIdx 가맹점 ID
-     * @param type     알림 타입 필터 (선택)
-     * @param isRead   읽음 상태 필터 (선택)
-     * @param page     페이지 번호
-     * @param size     페이지 크기
+     * @param authUserDetails 인증된 사용자 정보
+     * @param type 알림 타입 필터 (선택)
+     * @param isRead 읽음 상태 필터 (선택)
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 20)
+     * @return ResponseEntity 가맹점 알림 목록 (페이징)
      */
     @GetMapping("/list")
     public ResponseEntity<BaseResponse> getNotifications(
-            @RequestParam Long storeIdx,
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
             @RequestParam(required = false) NotificationType type,
             @RequestParam(required = false) Boolean isRead,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         Slice<StoreNotificationDto.ListRes> result;
         if (type != null) {
-            result = storeNotificationService.getNotificationsByType(storeIdx, type, page, size);
+            result = storeNotificationService.getNotificationsByType(authUserDetails, type, page, size);
         } else if (isRead != null) {
-            result = storeNotificationService.getNotificationsByReadStatus(storeIdx, isRead, page, size);
+            result = storeNotificationService.getNotificationsByReadStatus(authUserDetails, isRead, page, size);
         } else {
-            result = storeNotificationService.getNotifications(storeIdx, page, size);
+            result = storeNotificationService.getNotifications(authUserDetails, page, size);
         }
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
     /**
-     * 미읽음 알림 개수 조회
+     * 가맹점 미읽음 알림 개수 조회
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity 미읽음 알림 개수
      */
     @GetMapping("/unread/count")
-    public ResponseEntity<BaseResponse> getUnreadCount(@RequestParam Long storeIdx) {
-        StoreNotificationDto.UnreadCountRes result = storeNotificationService.getUnreadCount(storeIdx);
+    public ResponseEntity<BaseResponse> getUnreadCount(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        StoreNotificationDto.UnreadCountRes result = storeNotificationService.getUnreadCount(authUserDetails);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
     /**
-     * 단건 읽음 처리
+     * 가맹점 알림 단건 읽음 처리
      *
-     * @param notificationIdx 알림 ID
+     * @param notificationIdx 읽음 처리할 알림의 고유 ID
+     * @return ResponseEntity 처리 결과 메시지
      */
     @PutMapping("/{notificationIdx}/read")
     public ResponseEntity<BaseResponse> markAsRead(@PathVariable Long notificationIdx) {
@@ -66,19 +72,25 @@ public class StoreNotificationController {
     }
 
     /**
-     * 전체 읽음 처리
+     * 가맹점 알림 전체 읽음 처리
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return ResponseEntity 처리 결과 메시지
      */
     @PutMapping("/read/all")
-    public ResponseEntity<BaseResponse> markAllAsRead(@RequestParam Long storeIdx) {
-        storeNotificationService.markAllAsRead(storeIdx);
+    public ResponseEntity<BaseResponse> markAllAsRead(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        storeNotificationService.markAllAsRead(authUserDetails);
         return ResponseEntity.ok(BaseResponse.success("success"));
     }
 
     /**
-     * SSE 구독 (실시간 알림 수신)
+     * 가맹점 SSE 구독 (실시간 알림 수신)
+     *
+     * @param authUserDetails 인증된 사용자 정보
+     * @return SseEmitter SSE 연결
      */
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@RequestParam Long storeIdx) {
-        return storeSseEmitterService.subscribe(storeIdx);
+    public SseEmitter subscribe(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
+        return storeNotificationService.subscribe(authUserDetails);
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationService.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationService.java
@@ -1,14 +1,19 @@
 package com.example.nexus.domain.notification;
 
 import com.example.nexus.common.enums.NotificationType;
+import com.example.nexus.common.exception.BaseException;
+import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.domain.notification.model.StoreNotification;
 import com.example.nexus.domain.notification.model.StoreNotificationDto;
+import com.example.nexus.domain.store.StoreRepository;
 import com.example.nexus.domain.store.model.Store;
+import com.example.nexus.domain.user.model.AuthUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
 
@@ -19,36 +24,45 @@ public class StoreNotificationService {
 
     private final StoreNotificationRepository storeNotificationRepository;
     private final StoreSseEmitterService storeSseEmitterService;
+    private final StoreRepository storeRepository;
 
     /**
      * 알림 목록 조회 (전체)
      */
-    public Slice<StoreNotificationDto.ListRes> getNotifications(Long storeIdx, int page, int size) {
-        return storeNotificationRepository.findAllByStore_IdxOrderByCreatedAtDesc(storeIdx, PageRequest.of(page, size))
+    public Slice<StoreNotificationDto.ListRes> getNotifications(AuthUserDetails authUserDetails, int page, int size) {
+        Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+        return storeNotificationRepository.findAllByStore_IdxOrderByCreatedAtDesc(store.getIdx(), PageRequest.of(page, size))
                 .map(StoreNotificationDto.ListRes::from);
     }
 
     /**
      * 알림 목록 조회 (읽음 상태별)
      */
-    public Slice<StoreNotificationDto.ListRes> getNotificationsByReadStatus(Long storeIdx, boolean isRead, int page, int size) {
-        return storeNotificationRepository.findAllByStore_IdxAndIsReadOrderByCreatedAtDesc(storeIdx, isRead, PageRequest.of(page, size))
+    public Slice<StoreNotificationDto.ListRes> getNotificationsByReadStatus(AuthUserDetails authUserDetails, boolean isRead, int page, int size) {
+        Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+        return storeNotificationRepository.findAllByStore_IdxAndIsReadOrderByCreatedAtDesc(store.getIdx(), isRead, PageRequest.of(page, size))
                 .map(StoreNotificationDto.ListRes::from);
     }
 
     /**
      * 알림 목록 조회 (타입별 필터)
      */
-    public Slice<StoreNotificationDto.ListRes> getNotificationsByType(Long storeIdx, NotificationType type, int page, int size) {
-        return storeNotificationRepository.findAllByStore_IdxAndTypeOrderByCreatedAtDesc(storeIdx, type, PageRequest.of(page, size))
+    public Slice<StoreNotificationDto.ListRes> getNotificationsByType(AuthUserDetails authUserDetails, NotificationType type, int page, int size) {
+        Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+        return storeNotificationRepository.findAllByStore_IdxAndTypeOrderByCreatedAtDesc(store.getIdx(), type, PageRequest.of(page, size))
                 .map(StoreNotificationDto.ListRes::from);
     }
 
     /**
      * 미읽음 알림 개수 조회
      */
-    public StoreNotificationDto.UnreadCountRes getUnreadCount(Long storeIdx) {
-        long count = storeNotificationRepository.countByStore_IdxAndIsReadFalse(storeIdx);
+    public StoreNotificationDto.UnreadCountRes getUnreadCount(AuthUserDetails authUserDetails) {
+        Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+        long count = storeNotificationRepository.countByStore_IdxAndIsReadFalse(store.getIdx());
         return StoreNotificationDto.UnreadCountRes.builder().count(count).build();
     }
 
@@ -66,8 +80,19 @@ public class StoreNotificationService {
      * 전체 읽음 처리
      */
     @Transactional
-    public void markAllAsRead(Long storeIdx) {
-        storeNotificationRepository.markAllAsReadByStoreIdx(storeIdx);
+    public void markAllAsRead(AuthUserDetails authUserDetails) {
+        Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+        storeNotificationRepository.markAllAsReadByStoreIdx(store.getIdx());
+    }
+
+    /**
+     * SSE 구독 (실시간 알림 수신)
+     */
+    public SseEmitter subscribe(AuthUserDetails authUserDetails) {
+        Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+        return storeSseEmitterService.subscribe(store.getIdx());
     }
 
     /**

--- a/frontend/src/api/notification/store.js
+++ b/frontend/src/api/notification/store.js
@@ -1,0 +1,26 @@
+import api from '@/plugins/axiosinterceptor'
+
+// 가맹점 알림 목록 조회 (타입별 필터 + 페이징)
+const getNotifications = (type, page = 0, size = 20, isRead) => {
+  const params = { page, size }
+  if (type) params.type = type
+  if (isRead !== undefined) params.isRead = isRead
+  return api.get('/store/notification/list', { params })
+}
+
+// 미읽음 알림 개수 조회
+const getUnreadCount = () => api.get('/store/notification/unread/count')
+
+// 단건 읽음 처리
+const markAsRead = (notificationIdx) =>
+  api.put(`/store/notification/${notificationIdx}/read`)
+
+// 전체 읽음 처리
+const markAllAsRead = () => api.put('/store/notification/read/all')
+
+export default {
+  getNotifications,
+  getUnreadCount,
+  markAsRead,
+  markAllAsRead,
+}

--- a/frontend/src/components/NotificationBell.vue
+++ b/frontend/src/components/NotificationBell.vue
@@ -10,42 +10,79 @@ const notifStore = useNotificationStore()
 const auth = useAuthStore()
 const router = useRouter()
 
-const isStoreOwnerRole = computed(() => auth.isStoreOwner)
-const accentBadgeClass = computed(() => isStoreOwnerRole.value ? 'bg-blue-500' : 'bg-[#F37321]')
-const unreadRowClass = computed(() => isStoreOwnerRole.value ? 'bg-blue-50/30 hover:bg-blue-50/60' : 'bg-orange-50/30 hover:bg-orange-50/60')
+const isStore = computed(() => auth.isStoreOwner)
+const accentBadgeClass = computed(() => isStore.value ? 'bg-blue-500' : 'bg-[#F37321]')
+const unreadRowClass = computed(() => isStore.value ? 'bg-blue-50/30 hover:bg-blue-50/60' : 'bg-orange-50/30 hover:bg-orange-50/60')
 
-// 읽지 않은 알림만 필터링하여 드롭다운에 표시
-const unreadNotifications = computed(() => notifStore.notifications.filter(n => !n.isRead))
+// 역할에 따른 unreadCount
+const unreadCount = computed(() => isStore.value ? notifStore.storeUnreadCount : notifStore.unreadCount)
+
+// 역할에 따른 알림 목록 (읽지 않은 것만)
+const unreadNotifications = computed(() => {
+  const list = isStore.value ? notifStore.storeNotifications : notifStore.notifications
+  return list.filter(n => !n.isRead)
+})
 
 // 마운트 시 알림 조회 + SSE 구독
 onMounted(async () => {
-  await notifStore.fetchUnreadCount()
-  notifStore.subscribe()
+  if (isStore.value) {
+    await notifStore.storeFetchUnreadCount()
+    notifStore.storeSubscribe()
+  } else {
+    await notifStore.fetchUnreadCount()
+    notifStore.subscribe()
+  }
 })
 
-// 드롭다운 열릴 때 전체 알림 조회
+// 드롭다운 열릴 때 알림 조회
 watch(open, async (isOpen) => {
   if (isOpen) {
-    await notifStore.fetchNotifications(null, 20)
+    if (isStore.value) {
+      await notifStore.storeFetchNotifications(null, 20)
+    } else {
+      await notifStore.fetchNotifications(null, 20)
+    }
   }
 })
 
 // 언마운트 시 SSE 해제
 onBeforeUnmount(() => {
-  notifStore.unsubscribe()
+  if (isStore.value) {
+    notifStore.storeUnsubscribe()
+  } else {
+    notifStore.unsubscribe()
+  }
 })
 
 async function markAll() {
-  await notifStore.markAllRead()
+  if (isStore.value) {
+    await notifStore.storeMarkAllRead()
+  } else {
+    await notifStore.markAllRead()
+  }
 }
 
 function handleNotifClick(n) {
   if (!n.isRead) {
-    notifStore.markRead(n.idx)
+    if (isStore.value) {
+      notifStore.storeMarkRead(n.idx)
+    } else {
+      notifStore.markRead(n.idx)
+    }
   }
   open.value = false
-  const path = auth.isAdmin ? '/notification' : '/store-notification'
-  router.push(path)
+  router.push(isStore.value ? '/store-notification' : '/notification')
+}
+
+function onScroll(e) {
+  const { scrollTop, scrollHeight, clientHeight } = e.target
+  if (scrollHeight - scrollTop - clientHeight < 50) {
+    if (isStore.value) {
+      notifStore.storeLoadMore(20)
+    } else {
+      notifStore.loadMore(20)
+    }
+  }
 }
 
 function typeColor(type) {
@@ -54,19 +91,14 @@ function typeColor(type) {
     LOW_STOCK: 'bg-amber-500',
     ABNORMAL_ORDER: 'bg-red-500',
     DELIVERY_DELAY: 'bg-blue-500',
+    DELIVERY_START: 'bg-green-500',
+    DELIVERED: 'bg-green-500',
   }
   return map[type] ?? 'bg-gray-300'
 }
 
 function typeConfig(type) {
   return notifStore.typeConfig[type] ?? { label: '알림', color: 'text-gray-600', bg: 'bg-gray-50', border: 'border-gray-200' }
-}
-
-function onScroll(e) {
-  const { scrollTop, scrollHeight, clientHeight } = e.target
-  if (scrollHeight - scrollTop - clientHeight < 50) {
-    notifStore.loadMore(20)
-  }
 }
 </script>
 
@@ -79,10 +111,10 @@ function onScroll(e) {
     <button @click="open = !open"
       class="relative flex items-center justify-center w-9 h-9 rounded hover:bg-gray-100 transition-colors z-50">
       <Bell class="w-4.5 h-4.5 text-gray-500" />
-      <span v-if="notifStore.unreadCount > 0"
+      <span v-if="unreadCount > 0"
         class="absolute top-1 right-1 min-w-[16px] h-4 flex items-center justify-center text-[10px] font-black text-white rounded-full px-1 leading-none"
         :class="accentBadgeClass">
-        {{ notifStore.unreadCount > 9 ? '9+' : notifStore.unreadCount }}
+        {{ unreadCount > 9 ? '9+' : unreadCount }}
       </span>
     </button>
 
@@ -101,13 +133,13 @@ function onScroll(e) {
         <div class="px-4 py-3 border-b border-gray-100 flex items-center justify-between bg-gray-50/60">
           <div class="flex items-center gap-2">
             <span class="text-sm font-bold text-gray-900">알림</span>
-            <span v-if="notifStore.unreadCount > 0"
+            <span v-if="unreadCount > 0"
               class="text-[11px] font-bold px-1.5 py-0.5 text-white rounded"
               :class="accentBadgeClass">
-              {{ notifStore.unreadCount }}
+              {{ unreadCount }}
             </span>
           </div>
-          <button v-if="notifStore.unreadCount > 0" @click="markAll"
+          <button v-if="unreadCount > 0" @click="markAll"
             class="text-xs text-gray-400 hover:text-gray-700 font-medium transition-colors">
             모두 읽음
           </button>
@@ -153,7 +185,7 @@ function onScroll(e) {
           </div>
 
           <!-- Loading indicator -->
-          <div v-if="notifStore.loading" class="px-4 py-3 text-center text-xs text-gray-400">
+          <div v-if="notifStore.loading || notifStore.storeLoading" class="px-4 py-3 text-center text-xs text-gray-400">
             불러오는 중...
           </div>
         </div>

--- a/frontend/src/stores/notification.js
+++ b/frontend/src/stores/notification.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import notificationApi from '@/api/notification'
+import storeNotificationApi from '@/api/notification/store'
 
 export const useNotificationStore = defineStore('notification', () => {
   const notifications = ref([])
@@ -93,15 +94,88 @@ export const useNotificationStore = defineStore('notification', () => {
     return `${d}일 전`
   }
 
+  // === 가맹점 알림 ===
+  const storeNotifications = ref([])
+  const storeUnreadCount = ref(0)
+  const storeHasNext = ref(false)
+  const storeCurrentPage = ref(0)
+  const storeCurrentType = ref(null)
+  const storeCurrentIsRead = ref(undefined)
+  const storeLoading = ref(false)
+  let storeEventSource = null
+
+  async function storeFetchNotifications(type = null, size = 10, isRead = undefined) {
+    storeCurrentType.value = type
+    storeCurrentIsRead.value = isRead
+    storeCurrentPage.value = 0
+    const res = await storeNotificationApi.getNotifications(type, 0, size, isRead)
+    storeNotifications.value = res.data.result.content
+    storeHasNext.value = !res.data.result.last
+  }
+
+  async function storeLoadMore(size = 10) {
+    if (!storeHasNext.value || storeLoading.value) return
+    storeLoading.value = true
+    storeCurrentPage.value++
+    const res = await storeNotificationApi.getNotifications(storeCurrentType.value, storeCurrentPage.value, size, storeCurrentIsRead.value)
+    storeNotifications.value.push(...res.data.result.content)
+    storeHasNext.value = !res.data.result.last
+    storeLoading.value = false
+  }
+
+  async function storeFetchUnreadCount() {
+    const res = await storeNotificationApi.getUnreadCount()
+    storeUnreadCount.value = res.data.result.count
+  }
+
+  async function storeMarkRead(idx) {
+    await storeNotificationApi.markAsRead(idx)
+    const n = storeNotifications.value.find(n => n.idx === idx)
+    if (n) n.isRead = true
+    storeUnreadCount.value = Math.max(0, storeUnreadCount.value - 1)
+  }
+
+  async function storeMarkAllRead() {
+    await storeNotificationApi.markAllAsRead()
+    storeNotifications.value.forEach(n => { n.isRead = true })
+    storeUnreadCount.value = 0
+  }
+
+  function storeSubscribe() {
+    if (storeEventSource) return
+    const baseUrl = import.meta.env.VITE_API_URL || '/api'
+    storeEventSource = new EventSource(`${baseUrl}/store/notification/subscribe`)
+
+    storeEventSource.addEventListener('notification', (event) => {
+      const notification = JSON.parse(event.data)
+      storeNotifications.value.unshift(notification)
+      storeUnreadCount.value++
+    })
+
+    storeEventSource.onerror = () => {
+      // 연결 끊기면 브라우저가 자동 재연결 시도
+    }
+  }
+
+  function storeUnsubscribe() {
+    if (storeEventSource) {
+      storeEventSource.close()
+      storeEventSource = null
+    }
+  }
+
   // 알림 타입별 스타일 (백엔드 NotificationType enum 기준)
   const typeConfig = {
     EXPIRY:         { label: '유통기한',    color: 'text-amber-600',  bg: 'bg-amber-50',   border: 'border-amber-200'  },
     LOW_STOCK:      { label: '재고 부족',   color: 'text-amber-600',  bg: 'bg-amber-50',   border: 'border-amber-200'  },
     ABNORMAL_ORDER: { label: '비정상 감지', color: 'text-red-600',    bg: 'bg-red-50',     border: 'border-red-200'    },
     DELIVERY_DELAY: { label: '배송 지연',   color: 'text-blue-600',   bg: 'bg-blue-50',    border: 'border-blue-200'   },
+    DELIVERY_START: { label: '배송 시작',   color: 'text-green-600',  bg: 'bg-green-50',   border: 'border-green-200'  },
+    DELIVERED:      { label: '배송 완료',   color: 'text-green-600',  bg: 'bg-green-50',   border: 'border-green-200'  },
   }
 
   return {
+    // 본사
     notifications,
     unreadCount,
     hasNext,
@@ -113,6 +187,19 @@ export const useNotificationStore = defineStore('notification', () => {
     markAllRead,
     subscribe,
     unsubscribe,
+    // 가맹점
+    storeNotifications,
+    storeUnreadCount,
+    storeHasNext,
+    storeLoading,
+    storeFetchNotifications,
+    storeLoadMore,
+    storeFetchUnreadCount,
+    storeMarkRead,
+    storeMarkAllRead,
+    storeSubscribe,
+    storeUnsubscribe,
+    // 공통
     relativeTime,
     typeConfig,
   }

--- a/frontend/src/views/store/StoreNotificationView.vue
+++ b/frontend/src/views/store/StoreNotificationView.vue
@@ -28,7 +28,7 @@
     </div>
 
     <!-- List -->
-    <div v-if="filtered.length > 0" class="flex flex-col gap-2">
+    <div v-if="filtered.length > 0" @scroll="onScroll" class="flex flex-col gap-2 max-h-[700px] overflow-y-auto">
       <button
         v-for="n in filtered"
         :key="n.idx"
@@ -59,15 +59,9 @@
         </div>
       </button>
 
-      <!-- Load more -->
-      <div v-if="store.storeHasNext" class="flex justify-center py-4">
-        <button
-          @click="store.storeLoadMore()"
-          :disabled="store.storeLoading"
-          class="text-sm text-blue-600 hover:underline font-medium cursor-pointer disabled:opacity-50"
-        >
-          {{ store.storeLoading ? '로딩 중...' : '더 보기' }}
-        </button>
+      <!-- 로딩 인디케이터 -->
+      <div v-if="store.storeLoading" class="py-3 text-center text-sm text-gray-400">
+        불러오는 중...
       </div>
     </div>
 
@@ -115,6 +109,13 @@ function changeTab(tabValue) {
 
 function typeStyle(type) {
   return store.typeConfig[type] ?? { label: '알림', color: 'text-gray-600', bg: 'bg-gray-50', border: 'border-gray-200' }
+}
+
+function onScroll(e) {
+  const { scrollTop, scrollHeight, clientHeight } = e.target
+  if (scrollHeight - scrollTop - clientHeight < 50) {
+    store.storeLoadMore(20)
+  }
 }
 
 onMounted(() => {

--- a/frontend/src/views/store/StoreNotificationView.vue
+++ b/frontend/src/views/store/StoreNotificationView.vue
@@ -4,8 +4,8 @@
     <div class="flex items-center justify-between mb-5">
       <h1 class="text-xl font-bold text-gray-900">알림</h1>
       <button
-        v-if="unreadCount > 0"
-        @click="store.markAllRead('STORE_OWNER')"
+        v-if="store.storeUnreadCount > 0"
+        @click="store.storeMarkAllRead()"
         class="text-sm text-blue-600 hover:underline font-medium cursor-pointer"
       >
         전체 읽음 처리
@@ -17,7 +17,7 @@
       <button
         v-for="tab in tabs"
         :key="tab.value"
-        @click="activeTab = tab.value"
+        @click="changeTab(tab.value)"
         class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px cursor-pointer"
         :class="activeTab === tab.value
           ? 'border-blue-500 text-blue-600'
@@ -31,10 +31,10 @@
     <div v-if="filtered.length > 0" class="flex flex-col gap-2">
       <button
         v-for="n in filtered"
-        :key="n.id"
-        @click="store.markRead(n.id)"
+        :key="n.idx"
+        @click="store.storeMarkRead(n.idx)"
         class="w-full flex gap-3 p-4 rounded-lg border transition-colors text-left"
-        :class="n.read
+        :class="n.isRead
           ? 'bg-white border-gray-100 hover:bg-gray-50'
           : 'bg-blue-50/40 border-blue-100 hover:bg-blue-50/70'"
       >
@@ -42,9 +42,9 @@
         <div class="shrink-0 pt-0.5">
           <span
             class="inline-block text-[11px] font-semibold px-2 py-0.5 rounded-full border"
-            :class="[typeConfig(n.type).color, typeConfig(n.type).bg, typeConfig(n.type).border]"
+            :class="[typeStyle(n.type).color, typeStyle(n.type).bg, typeStyle(n.type).border]"
           >
-            {{ typeConfig(n.type).label }}
+            {{ typeStyle(n.type).label }}
           </span>
         </div>
 
@@ -52,12 +52,23 @@
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 mb-0.5">
             <span class="text-sm font-semibold text-gray-900">{{ n.title }}</span>
-            <span v-if="!n.read" class="w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0"></span>
+            <span v-if="!n.isRead" class="w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0"></span>
           </div>
-          <p class="text-sm text-gray-600 leading-snug">{{ n.body }}</p>
-          <p class="text-xs text-gray-400 mt-1">{{ store.relativeTime(n.time) }}</p>
+          <p class="text-sm text-gray-600 leading-snug">{{ n.content }}</p>
+          <p class="text-xs text-gray-400 mt-1">{{ store.relativeTime(n.createdAt) }}</p>
         </div>
       </button>
+
+      <!-- Load more -->
+      <div v-if="store.storeHasNext" class="flex justify-center py-4">
+        <button
+          @click="store.storeLoadMore()"
+          :disabled="store.storeLoading"
+          class="text-sm text-blue-600 hover:underline font-medium cursor-pointer disabled:opacity-50"
+        >
+          {{ store.storeLoading ? '로딩 중...' : '더 보기' }}
+        </button>
+      </div>
     </div>
 
     <!-- Empty -->
@@ -69,39 +80,45 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { Bell } from 'lucide-vue-next'
 import { useNotificationStore } from '@/stores/notification'
 
 const store = useNotificationStore()
 
 const tabs = [
-  { label: '전체',    value: 'all' },
-  { label: '발주',    value: 'order' },
-  { label: '배송',    value: 'delivery' },
-  { label: '자동발주', value: 'auto' },
-  { label: '정산',    value: 'settlement' },
+  { label: '전체',   value: null },
+  { label: '재고',   value: 'stock' },
+  { label: '발주',   value: 'order' },
+  { label: '배송',   value: 'delivery' },
 ]
 
-const activeTab = ref('all')
-
-const storeNotifications = computed(() => store.forRole('STORE_OWNER'))
-const unreadCount = computed(() => store.unreadCount('STORE_OWNER'))
+const activeTab = ref(null)
 
 const tabTypeMap = {
-  order:      ['order_approved', 'order_rejected'],
-  delivery:   ['delivery_update'],
-  auto:       ['auto_order'],
-  settlement: ['settlement'],
+  stock:    ['EXPIRY', 'LOW_STOCK'],
+  order:    ['ABNORMAL_ORDER'],
+  delivery: ['DELIVERY_DELAY', 'DELIVERY_START'],
 }
 
 const filtered = computed(() => {
-  if (activeTab.value === 'all') return storeNotifications.value
+  if (activeTab.value === null) return store.storeNotifications
   const types = tabTypeMap[activeTab.value] ?? []
-  return storeNotifications.value.filter(n => types.includes(n.type))
+  return store.storeNotifications.filter(n => types.includes(n.type))
 })
 
-function typeConfig(type) {
+function changeTab(tabValue) {
+  activeTab.value = tabValue
+  // 탭 변경 시 전체 목록 재조회 (백엔드 단일 type 필터 제한으로 프론트 필터링)
+  store.storeFetchNotifications(null)
+}
+
+function typeStyle(type) {
   return store.typeConfig[type] ?? { label: '알림', color: 'text-gray-600', bg: 'bg-gray-50', border: 'border-gray-200' }
 }
+
+onMounted(() => {
+  store.storeFetchNotifications()
+  store.storeFetchUnreadCount()
+})
 </script>


### PR DESCRIPTION
## Summary                                                
- 가맹점 알림 프론트엔드 전체 구현 (API 연동, SSE 실시간 알림, 목록 조회/필터/읽음 처리)

## 변경 파일
- frontend/src/api/notification/store.js
- frontend/src/stores/notification.js
- frontend/src/views/store/StoreNotificationView.vue
- frontend/src/components/NotificationBell.vue

## 주요 변경 사항
- 가맹점 알림 API 함수 생성 (JWT 인증 기반, storeIdx 파라미터 제거)
- Pinia 스토어에 가맹점 전용 상태/함수 추가 (storeFetchNotifications, storeSubscribe 등)
- StoreNotificationView 실제 데이터 연결 및 필터 탭(재고/발주/배송) 구성
- NotificationBell 역할별(HQ/Store) SSE 구독 및 알림 분기 처리
- 알림 목록 스크롤 레이아웃 적용 (max-h-700px + 무한스크롤)

## Test Plan
- [ ] 점주 계정 로그인 → 알림 벨 아이콘 안읽음 수 표시 확인
- [ ] 알림 페이지 → 탭 필터(전체/재고/발주/배송) 동작 확인
- [ ] 스크롤 하단 도달 시 추가 알림 로드 확인
- [ ] 알림 클릭 시 읽음 처리 및 전체 읽음 동작 확인
- [ ] 본사 계정 → 기존 알림 기능 영향 없음 확인

## Issue
- Closes #107
- Closes #167