### PR TITLE
[Fix] 가맹점 대시보드 일별 매출 차트 조회 500 에러 수정

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
@@ -249,8 +249,13 @@ public class StoreDashboardService {
     private Map<LocalDate, Long> toDailySalesMap(List<Object[]> rows) {
         Map<LocalDate, Long> map = new java.util.HashMap<>();
         for (Object[] row : rows) {
-            LocalDate date = ((java.sql.Date) row[0]).toLocalDate();
-            Long amount = (Long) row[1];
+            LocalDate date;
+            if (row[0] instanceof java.sql.Date sqlDate) {
+                date = sqlDate.toLocalDate();
+            } else {
+                date = (LocalDate) row[0];
+            }
+            Long amount = ((Number) row[1]).longValue();
             map.put(date, amount);
         }
         return map;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 가맹점 대시보드 일별 매출 차트 API 호출 시 500 에러 발생하는 타입 캐스팅 버그 수정                                                                                                                                              
                                                          
## 변경 파일
- backend/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java

## 주요 변경 사항
- JPQL CAST 결과의 java.sql.Date/java.time.LocalDate 호환 처리
- SUM 결과 타입을 Number로 안전하게 변환하여 ClassCastException 방지

## Test Plan
- [ ] 가맹점 로그인 후 대시보드 진입 시 일별 매출 차트 정상 렌더링 확인
- [ ] 매출 데이터가 없는 기간에도 0으로 정상 표시되는지 확인