### PR TITLE
[Feat] #90 - 본사 정산 목록 조회

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/head/HeadController.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadController.java
@@ -1,12 +1,16 @@
 package com.example.nexus.domain.head;
 
+import com.example.nexus.domain.head.model.HeadIncomeDto;
 import com.example.nexus.domain.head.model.HeadInventoryDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RequestMapping("/head")
@@ -14,11 +18,25 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HeadController {
     private final HeadService headService;
+    private final HeadIncomeService headIncomeService;
 
     // 본사 재고 조회
     @GetMapping("/inventory/list")
     public ResponseEntity<List<HeadInventoryDto.ListRes>> list(){
         List<HeadInventoryDto.ListRes> result = headService.list();
+        return ResponseEntity.ok(result);
+    }
+
+    // 본사 정산 내역 조회
+    @GetMapping("/income")
+    public ResponseEntity<List<HeadIncomeDto.ListRes>> getIncomeList(
+            @RequestParam(required = false) String storeName,
+            @RequestParam(required = false) Boolean status,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        List<HeadIncomeDto.ListRes> result = headIncomeService.getIncomeList(storeName, status, startDate, endDate);
         return ResponseEntity.ok(result);
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java
@@ -2,7 +2,9 @@ package com.example.nexus.domain.head;
 
 import com.example.nexus.domain.head.model.HeadIncome;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface HeadIncomeRepository extends JpaRepository<HeadIncome, Long> {
@@ -11,4 +13,12 @@ public interface HeadIncomeRepository extends JpaRepository<HeadIncome, Long> {
     List<HeadIncome> findBySettlementIdx(Long idx);
 
     HeadIncome findByOrdersIdx(Long orderIdx);
+
+    @Query("SELECT hi FROM HeadIncome hi " +
+            "JOIN hi.orders o " +
+            "WHERE (:storeName IS NULL OR hi.store.storeName LIKE %:storeName%) " +
+            "AND (:status IS NULL OR hi.status = :status) " +
+            "AND (:startDate IS NULL OR FUNCTION('DATE', o.createdAt) >= :startDate) " +
+            "AND (:endDate IS NULL OR FUNCTION('DATE', o.createdAt) <= :endDate)")
+    List<HeadIncome> findByFilters(String storeName, Boolean status, LocalDate startDate, LocalDate endDate);
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java
@@ -6,8 +6,10 @@ import com.example.nexus.domain.orders.model.Orders;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -48,5 +50,35 @@ public class HeadIncomeService {
     }
 
 
+    public List<HeadIncomeDto.ListRes> getIncomeList(
+            String storeName, Boolean status, LocalDate startDate, LocalDate endDate) {
 
+        List<HeadIncome> incomes = headIncomeRepository.findByFilters(storeName, status, startDate, endDate);
+
+        List<HeadIncomeDto.ListRes> result = new ArrayList<>();
+
+        for (HeadIncome income : incomes) {
+
+            LocalDate orderDate = LocalDate.now();
+            if (income.getOrders() != null && income.getOrders().getCreatedAt() != null) {
+                orderDate = income.getOrders().getCreatedAt().toLocalDate();
+            }
+
+            HeadIncomeDto.ListRes dto = HeadIncomeDto.ListRes.builder()
+                    .headIncomeIdx(income.getIdx())
+                    .storeIdx(income.getStore().getIdx())
+                    .storeName(income.getStore().getStoreName())
+                    .periodStart(orderDate.withDayOfMonth(1))
+                    .periodEnd(orderDate.withDayOfMonth(orderDate.lengthOfMonth()))
+                    .totalPrice(income.getPrice())
+                    .status(income.getStatus())
+                    .settlementIdx(income.getSettlementIdx())
+                    .orderCount(1)
+                    .build();
+
+            result.add(dto);
+        }
+
+        return result;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/model/HeadIncomeDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/model/HeadIncomeDto.java
@@ -3,6 +3,8 @@ package com.example.nexus.domain.head.model;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 public class HeadIncomeDto {
 
     @Builder
@@ -30,4 +32,17 @@ public class HeadIncomeDto {
         private Long ordersIdx;
     }
 
+    @Getter
+    @Builder
+    public static class ListRes {
+        private Long headIncomeIdx;
+        private Long storeIdx;
+        private String storeName;
+        private LocalDate periodStart;
+        private LocalDate periodEnd;
+        private int orderCount;
+        private Long totalPrice;
+        private Boolean status;
+        private Long settlementIdx;
+    }
 }


### PR DESCRIPTION
## 📋 Summary
-  본사 정산 목록 조회 기능 구현

## 📂 변경 파일
- `backend/src/main/java/com/example/nexus/domain/head/HeadController.java`
- `backend/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java`
- `backend/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java`
- `backend/src/main/java/com/example/nexus/domain/head/model/HeadIncomeDto.java`

## ✨ 주요 변경 사항
- [ ] controller "head/income" 으로 본사 정산 목록 조회 구현
- [ ] -service 필터 조건으로 목록 반환, DB 조회해서 list로 저장 (날짜는 orders의 createdAt 가져와서 계산하게 함), 저장된 list Dto로 변환, 리스트 반환
- [ ] List 응답 Dto 구현
- [ ] Repository Query 조건에 따라 정산 목록 검색


Closes #90 