### PR TITLE
[Fix] #626 - 백엔드 배송/발주/대시보드 로직 수정 및 코드 정리 

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -38,24 +38,24 @@ public class DashboardController {
     }
 
     /**
-     * 배송 현황 KPI 조회
+     * 재고 위험 KPI 조회
      *
-     * @return ResponseEntity 진행중 배송 건수, 지연 건수, 지연 배송 목록
+     * @return ResponseEntity LOW/CRITICAL 상태 품목 수
      */
-    @GetMapping("/delivery/kpi")
-    public ResponseEntity<BaseResponse> getDeliveryKpi() {
-        DashboardDto.DeliveryKpiRes result = dashboardService.getDeliveryKpi();
+    @GetMapping("/inventory/kpi")
+    public ResponseEntity<BaseResponse> getInventoryKpi() {
+        DashboardDto.InventoryKpiRes result = dashboardService.getInventoryKpi();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
     /**
-     * 이상 발주 통계 조회
+     * 배송 현황 KPI 조회
      *
-     * @return ResponseEntity 최근 6개월 월별 이상 발주 상태별 건수
+     * @return ResponseEntity 진행중 배송 건수, 지연 배송 목록
      */
-    @GetMapping("/orders/danger/stats")
-    public ResponseEntity<BaseResponse> getDangerStats() {
-        DashboardDto.DangerStatsRes result = dashboardService.getDangerStats();
+    @GetMapping("/delivery/kpi")
+    public ResponseEntity<BaseResponse> getDeliveryKpi() {
+        DashboardDto.DeliveryKpiRes result = dashboardService.getDeliveryKpi();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
@@ -67,28 +67,6 @@ public class DashboardController {
     @GetMapping("/orders/weekly/stats")
     public ResponseEntity<BaseResponse> getWeeklyOrderStats() {
         DashboardDto.WeeklyOrderStatsRes result = dashboardService.getWeeklyOrderStats();
-        return ResponseEntity.ok(BaseResponse.success(result));
-    }
-
-    /**
-     * 배송 비율 조회
-     *
-     * @return ResponseEntity 배송 상태별 건수
-     */
-    @GetMapping("/delivery/ratio")
-    public ResponseEntity<BaseResponse> getDeliveryRatio() {
-        DashboardDto.DeliveryRatioRes result = dashboardService.getDeliveryRatio();
-        return ResponseEntity.ok(BaseResponse.success(result));
-    }
-
-    /**
-     * 재고 위험 KPI 조회
-     *
-     * @return ResponseEntity LOW/CRITICAL 상태 품목 수
-     */
-    @GetMapping("/inventory/kpi")
-    public ResponseEntity<BaseResponse> getInventoryKpi() {
-        DashboardDto.InventoryKpiRes result = dashboardService.getInventoryKpi();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
@@ -108,6 +86,17 @@ public class DashboardController {
     }
 
     /**
+     * 이상 발주 통계 조회
+     *
+     * @return ResponseEntity 최근 6개월 월별 이상 발주 상태별 건수
+     */
+    @GetMapping("/orders/danger/stats")
+    public ResponseEntity<BaseResponse> getOrdersDangerStats() {
+        DashboardDto.DangerStatsRes result = dashboardService.getOrdersDangerStats();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
      * 지연 배송 목록 조회
      *
      * @param page 페이지 번호 (0부터 시작, 기본값 0)
@@ -119,6 +108,17 @@ public class DashboardController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "4") int size) {
         DashboardDto.DelayDeliveryRes result = dashboardService.getDelayDeliveryList(page, size);
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
+     * 배송 비율 조회
+     *
+     * @return ResponseEntity 배송 상태별 건수
+     */
+    @GetMapping("/delivery/ratio")
+    public ResponseEntity<BaseResponse> getDeliveryRatio() {
+        DashboardDto.DeliveryRatioRes result = dashboardService.getDeliveryRatio();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import com.example.nexus.common.enums.InventoryStatus;
 import com.example.nexus.domain.dashboard.model.DashboardDto;
 import com.example.nexus.domain.delivery.DeliveryRepository;
+import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.head.HeadInventoryRepository;
 import com.example.nexus.domain.head.model.HeadInventory;
 import com.example.nexus.domain.orders.OrdersRepository;
@@ -32,7 +33,10 @@ public class DashboardService {
     private final DeliveryRepository deliveryRepository;
     private final HeadInventoryRepository headInventoryRepository;
 
+    // 본사 대시보드 입점 매장 카드 데이터 조회 메서드
     public DashboardDto.StoreKpiRes getStoreKpi() {
+
+        // 총 매장 수
         long totalCount = storeRepository.countByIsDeletedFalse();
 
         // 이번 달 1일 00:00 기준 신규 매장 수
@@ -51,7 +55,7 @@ public class DashboardService {
                 .build();
     }
 
-
+    // 본사 대시보드 발주 카드 데이터 조회 메서드
     public DashboardDto.OrdersKpiRes getOrdersKpi() {
         LocalDateTime todayStart = LocalDate.now().atStartOfDay();
 
@@ -75,9 +79,25 @@ public class DashboardService {
                 .build();
     }
 
+    // 본사 재고 위험 카드 데이터 조회 메서드
+    public DashboardDto.InventoryKpiRes getInventoryKpi() {
+
+        // 재고 부족 건수
+        long lowCount = headInventoryRepository.countByStatus(InventoryStatus.LOW);
+
+        // 재고 위험 건수
+        long criticalCount = headInventoryRepository.countByStatus(InventoryStatus.CRITICAL);
+
+        return DashboardDto.InventoryKpiRes.builder()
+                .lowCount(lowCount)
+                .criticalCount(criticalCount)
+                .totalDangerCount(lowCount + criticalCount)
+                .build();
+    }
+
+    // 본사 대시보드 배송 현황 카드 데이터 조회 메서드
     public DashboardDto.DeliveryKpiRes getDeliveryKpi() {
-        List<DeliveryStatus> ongoingStatuses = List.of(
-                DeliveryStatus.READY, DeliveryStatus.START, DeliveryStatus.DELIVERYING);
+        List<DeliveryStatus> ongoingStatuses = List.of(DeliveryStatus.START, DeliveryStatus.DELIVERYING);
 
         // 진행중 배송 건수
         long ongoingCount = deliveryRepository.countByDeliveryStatusIn(ongoingStatuses);
@@ -85,79 +105,13 @@ public class DashboardService {
         // 배송 지연 건수
         long delayCount = deliveryRepository.countByDeliveryStatus(DeliveryStatus.DELAY);
 
-        // 배송 지연 목록
-        List<DashboardDto.DeliveryItem> deliveryList = deliveryRepository
-                .findAllByDeliveryStatus(DeliveryStatus.DELAY).stream()
-                .map(DashboardDto.DeliveryItem::from)
-                .toList();
-
         return DashboardDto.DeliveryKpiRes.builder()
                 .ongoingCount(ongoingCount)
                 .delayCount(delayCount)
-                .deliveryList(deliveryList)
                 .build();
     }
 
-    public DashboardDto.DangerStatsRes getDangerStats() {
-        // 조회 시작 시점: 현재 월 포함 6개월 전 1일 00:00
-        // 예: 현재 2026-05 → 2025-12-01 00:00부터 조회
-        LocalDateTime since = LocalDate.now().minusMonths(5).withDayOfMonth(1).atStartOfDay();
-
-        // 6개월치 라벨(yyyy-MM)을 순서대로 생성하고, 각 월별 카운트 배열 초기화
-        // LinkedHashMap으로 삽입 순서 보장 → 프론트 차트 x축 순서 유지
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
-        Map<String, long[]> monthMap = new LinkedHashMap<>();
-        for (int i = 0; i < 6; i++) {
-            String label = YearMonth.now().minusMonths(5 - i).format(formatter);
-            monthMap.put(label, new long[3]); // [0: 승인대기(CONFIRMED), 1: 승인(APPROVE), 2: 반려(REJECT)]
-        }
-
-        // DB에서 월별 + 상태별 이상 발주 건수 조회 후 monthMap에 매핑
-        List<Object[]> rows = ordersRepository.findDangerStatsByMonth(since);
-        for (Object[] row : rows) {
-            String month = (String) row[0];
-            long count = (Long) row[2];
-
-            long[] counts = monthMap.get(month);
-            if (counts == null) {
-                continue;
-            }
-
-            OrdersStatus status = (OrdersStatus) row[1];
-            switch (status) {
-                case CONFIRMED :
-                    counts[0] = count;
-                    break; // 승인 대기
-                case APPROVE :
-                    counts[1] = count;
-                    break; // 승인
-                case REJECT :
-                    counts[2] = count;
-                    break; // 반려
-                default: break;
-            }
-        }
-
-        // monthMap을 프론트 차트에 맞는 배열 형태로 변환
-        List<String> labels = new ArrayList<>(monthMap.keySet());
-        List<Long> confirmed = new ArrayList<>();
-        List<Long> approved = new ArrayList<>();
-        List<Long> rejected = new ArrayList<>();
-
-        for (long[] counts : monthMap.values()) {
-            confirmed.add(counts[0]);
-            approved.add(counts[1]);
-            rejected.add(counts[2]);
-        }
-
-        return DashboardDto.DangerStatsRes.builder()
-                .labels(labels)
-                .confirmed(confirmed)
-                .approved(approved)
-                .rejected(rejected)
-                .build();
-    }
-
+    // 본사 대시보드 주간 발주 통계 데이터 조회 메서드
     public DashboardDto.WeeklyOrderStatsRes getWeeklyOrderStats() {
         // 이번 주 월요일 00:00 기준으로 이번 주 / 지난 주 범위 계산
         // 예: 오늘 2026-05-04(일) → 이번 주 월요일 04-28, 지난 주 월요일 04-21
@@ -198,6 +152,97 @@ public class DashboardService {
                 .build();
     }
 
+    // 본사 대시보드 재고 위험 리스트 조회 메서드
+    public DashboardDto.DangerInventoryRes getDangerInventoryList(int page, int size) {
+        // 위험 재고: status가 LOW 또는 CRITICAL인 본사 재고 목록
+        List<InventoryStatus> dangerStatuses = List.of(InventoryStatus.LOW, InventoryStatus.CRITICAL);
+
+        Slice<HeadInventory> slice = headInventoryRepository.findByStatusIn(dangerStatuses, PageRequest.of(page, size));
+
+        List<DashboardDto.DangerInventoryItem> items = slice.getContent().stream().map(DashboardDto.DangerInventoryItem::from).toList();
+
+        return DashboardDto.DangerInventoryRes.builder()
+                .items(items)
+                .hasNext(slice.hasNext())
+                .build();
+    }
+
+    // 본사 대시보드 이상 발주 통계 데이터 조회
+    public DashboardDto.DangerStatsRes getOrdersDangerStats() {
+        // 조회 시작 시점: 현재 월 포함 6개월 전 1일 00:00
+        // 예: 현재 2026-05 → 2025-12-01 00:00부터 조회
+        LocalDateTime since = LocalDate.now().minusMonths(5).withDayOfMonth(1).atStartOfDay();
+
+        // 6개월치 라벨(yyyy-MM)을 순서대로 생성하고, 각 월별 카운트 배열 초기화
+        // LinkedHashMap으로 삽입 순서 보장 → 프론트 차트 x축 순서 유지
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        Map<String, long[]> monthMap = new LinkedHashMap<>();
+        for (int i = 0; i < 6; i++) {
+            String label = YearMonth.now().minusMonths(5 - i).format(formatter);
+            monthMap.put(label, new long[3]); // [0: 승인대기(CONFIRMED), 1: 승인(APPROVE), 2: 반려(REJECT)]
+        }
+
+        // DB에서 월별 + 상태별 이상 발주 건수 조회 후 monthMap에 매핑
+        List<Object[]> rows = ordersRepository.findDangerStatsByMonth(since);
+
+        for (Object[] row : rows) {
+            String month = (String) row[0];
+            long count = (Long) row[2];
+
+            long[] counts = monthMap.get(month);
+            if (counts == null) {
+                continue;
+            }
+
+            OrdersStatus status = (OrdersStatus) row[1];
+            switch (status) {
+                case CONFIRMED :
+                    counts[0] = count;
+                    break;
+                case APPROVE :
+                    counts[1] = count;
+                    break;
+                case REJECT :
+                    counts[2] = count;
+                    break;
+                default: break;
+            }
+        }
+
+        // monthMap을 프론트 차트에 맞는 배열 형태로 변환
+        List<String> labels = new ArrayList<>(monthMap.keySet());
+        List<Long> confirmed = new ArrayList<>();
+        List<Long> approved = new ArrayList<>();
+        List<Long> rejected = new ArrayList<>();
+
+        for (long[] counts : monthMap.values()) {
+            confirmed.add(counts[0]);
+            approved.add(counts[1]);
+            rejected.add(counts[2]);
+        }
+
+        return DashboardDto.DangerStatsRes.builder()
+                .labels(labels)
+                .confirmed(confirmed)
+                .approved(approved)
+                .rejected(rejected)
+                .build();
+    }
+
+    // 본사 대시보드 지연 배송 목록 데이터 조회 메서드
+    public DashboardDto.DelayDeliveryRes getDelayDeliveryList(int page, int size) {
+        // 지연 배송 목록: status가 DELAY인 배송
+        Slice<Delivery> slice = deliveryRepository.findByDeliveryStatus(DeliveryStatus.DELAY, PageRequest.of(page, size));
+
+        List<DashboardDto.DeliveryItem> items = slice.getContent().stream().map(DashboardDto.DeliveryItem::from).toList();
+
+        return DashboardDto.DelayDeliveryRes.builder()
+                .items(items)
+                .hasNext(slice.hasNext())
+                .build();
+    }
+
+    // 본사 대시보드 배송 비율 데이터 조회 메서드
     public DashboardDto.DeliveryRatioRes getDeliveryRatio() {
         // 최근 한달 기준 배송 상태별 건수 조회
         LocalDateTime monthAgo = LocalDate.now().minusMonths(1).atStartOfDay();
@@ -213,49 +258,6 @@ public class DashboardService {
                 .delivering(delivering)
                 .delivered(delivered)
                 .delay(delay)
-                .build();
-    }
-
-    public DashboardDto.InventoryKpiRes getInventoryKpi() {
-        long lowCount = headInventoryRepository.countByStatus(InventoryStatus.LOW);
-        long criticalCount = headInventoryRepository.countByStatus(InventoryStatus.CRITICAL);
-
-        return DashboardDto.InventoryKpiRes.builder()
-                .lowCount(lowCount)
-                .criticalCount(criticalCount)
-                .totalDangerCount(lowCount + criticalCount)
-                .build();
-    }
-
-    public DashboardDto.DangerInventoryRes getDangerInventoryList(int page, int size) {
-        // 위험 재고: status가 LOW 또는 CRITICAL인 본사 재고 목록
-        List<InventoryStatus> dangerStatuses = List.of(InventoryStatus.LOW, InventoryStatus.CRITICAL);
-
-        Slice<HeadInventory> slice =
-                headInventoryRepository.findByStatusIn(dangerStatuses, PageRequest.of(page, size));
-
-        List<DashboardDto.DangerInventoryItem> items = slice.getContent().stream()
-                .map(DashboardDto.DangerInventoryItem::from)
-                .toList();
-
-        return DashboardDto.DangerInventoryRes.builder()
-                .items(items)
-                .hasNext(slice.hasNext())
-                .build();
-    }
-
-    public DashboardDto.DelayDeliveryRes getDelayDeliveryList(int page, int size) {
-        // 지연 배송 목록: status가 DELAY인 배송
-        Slice<com.example.nexus.domain.delivery.model.Delivery> slice =
-                deliveryRepository.findByDeliveryStatus(DeliveryStatus.DELAY, PageRequest.of(page, size));
-
-        List<DashboardDto.DeliveryItem> items = slice.getContent().stream()
-                .map(DashboardDto.DeliveryItem::from)
-                .toList();
-
-        return DashboardDto.DelayDeliveryRes.builder()
-                .items(items)
-                .hasNext(slice.hasNext())
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -30,8 +30,8 @@ import java.util.List;
 public class DashboardService {
     private final StoreRepository storeRepository;
     private final OrdersRepository ordersRepository;
-    private final DeliveryRepository deliveryRepository;
     private final HeadInventoryRepository headInventoryRepository;
+    private final DeliveryRepository deliveryRepository;
 
     // 본사 대시보드 입점 매장 카드 데이터 조회 메서드
     public DashboardDto.StoreKpiRes getStoreKpi() {

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -31,7 +31,6 @@ public class DashboardDto {
     public static class DeliveryKpiRes {
         private long ongoingCount;
         private long delayCount;
-        private List<DeliveryItem> deliveryList;
     }
 
     @Getter

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
@@ -53,17 +53,6 @@ public class DeliveryController {
         return ResponseEntity.ok(response);
     }
 
-    // 본사 배송 승인 (READY → START + 점주 배송 시작 알림)
-    @PatchMapping("/head/{deliveryIdx}/approve")
-    public ResponseEntity<String> approveDelivery(@PathVariable Long deliveryIdx) {
-        boolean isSuccess = deliveryService.approveDelivery(deliveryIdx);
-        if (isSuccess) {
-            return ResponseEntity.ok("배송이 승인되었습니다.");
-        } else {
-            return ResponseEntity.badRequest().body("승인할 수 없는 배송 상태입니다.");
-        }
-    }
-
     // 본사 배송 지연 사유 입력
     @PatchMapping("/head/{deliveryIdx}/delayreason")
     public ResponseEntity<String> updateDelayReason(

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -19,10 +19,10 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     // 발주 승인용 - 주문 기준 배송 조회
     Delivery findByOrders(Orders orders);
 
-    // 스케줄러용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
+    // 알림 스케줄러용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
     List<Delivery> findByDeliveryStatusAndDepartureDateBefore(DeliveryStatus status, LocalDateTime before);
 
-    // 스케줄러용 - 예상도착일 초과 + 미완료 배송 조회
+    // 알림 스케줄러용 - 예상도착일 초과 + 미완료 배송 조회
     @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s " +
             "WHERE d.estimatedArrivalAt < :now " +
             "AND d.deliveryStatus NOT IN (:excludeStatuses)")

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -14,34 +14,15 @@ import java.util.List;
 
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
-    // 대시보드용 - 본사 대시보드 진행중 배송 건수 KPI (여러 상태 합산)
-    long countByDeliveryStatusIn(List<DeliveryStatus> statuses);
-
-    // 대시보드용 - 본사 대시보드 특정 상태 배송 건수
-    long countByDeliveryStatus(DeliveryStatus status);
-
-    // 대시보드용 - 본사 대시보드 배송 비율 계산 (최근 한달 상태별 건수)
-    long countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus status, LocalDateTime since);
-
-    // 대시보드용 - 본사 대시보드 지연 배송 전체 목록 조회
-    List<Delivery> findAllByDeliveryStatus(DeliveryStatus status);
-
-    // 대시보드용 - 본사 대시보드 지연 배송 목록 무한스크롤 페이징
-    Slice<Delivery> findByDeliveryStatus(DeliveryStatus status, Pageable pageable);
-
-    // 점주 대시보드용 - 나의 배송 현황 목록 (배송완료 제외, 최신순)
-    List<Delivery> findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc(Long storeIdx, DeliveryStatus excludeStatus);
-
-    List<Delivery> findByDeliveryStatus(DeliveryStatus status);
-
     Delivery findByIdx(Long deliveryIdx);
 
+    // 발주 승인용 - 주문 기준 배송 조회
     Delivery findByOrders(Orders orders);
 
-    // 배송 상태 자동 전환용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
+    // 스케줄러용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
     List<Delivery> findByDeliveryStatusAndDepartureDateBefore(DeliveryStatus status, LocalDateTime before);
 
-    // 배송 지연 자동 감지용 - 예상도착일 초과 + 미완료 배송 조회
+    // 스케줄러용 - 예상도착일 초과 + 미완료 배송 조회
     @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s " +
             "WHERE d.estimatedArrivalAt < :now " +
             "AND d.deliveryStatus NOT IN (:excludeStatuses)")
@@ -49,7 +30,7 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             @Param("now") LocalDateTime now,
             @Param("excludeStatuses") List<DeliveryStatus> excludeStatuses);
 
-    // 본사 배송 조회용
+    // 본사 배송 관리 - 필터 조회
     @Query("SELECT d FROM Delivery d " +
             "JOIN FETCH d.orders o " +
             "JOIN FETCH o.store s " +
@@ -65,11 +46,11 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             @Param("month") Integer month,
             @Param("day") Integer day);
 
-    // 본인 가맹점 배송 현황 조회
+    // 가맹점 배송 현황 - 전체 조회
     @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s WHERE s.idx = :storeIdx")
     List<Delivery> findAllByOrdersStoreIdx(@Param("storeIdx") Long storeIdx);
 
-    // 가맹점 배송 현황 필터 및 발주번호 검색 조회
+    // 가맹점 배송 현황 - 필터 및 발주번호 검색 조회
     @Query("SELECT d FROM Delivery d " +
             "JOIN FETCH d.orders o " +
             "JOIN FETCH o.store s " +
@@ -86,5 +67,20 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             @Param("year") Integer year,
             @Param("month") Integer month,
             @Param("day") Integer day);
+
+    // 본사 대시보드 - 진행중 배송 건수 KPI (여러 상태 합산)
+    long countByDeliveryStatusIn(List<DeliveryStatus> statuses);
+
+    // 본사 대시보드 - 특정 상태 배송 건수 KPI
+    long countByDeliveryStatus(DeliveryStatus status);
+
+    // 본사 대시보드 - 배송 비율 계산 (최근 한달 상태별 건수)
+    long countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus status, LocalDateTime since);
+
+    // 본사 대시보드 - 지연 배송 목록 무한스크롤 페이징
+    Slice<Delivery> findByDeliveryStatus(DeliveryStatus status, Pageable pageable);
+
+    // 점주 대시보드 - 나의 배송 현황 목록 (배송완료 제외, 최신순)
+    List<Delivery> findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc(Long storeIdx, DeliveryStatus excludeStatus);
 }
 

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -2,6 +2,7 @@ package com.example.nexus.domain.delivery;
 
 import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.domain.delivery.model.Delivery;
+import com.example.nexus.domain.orders.model.Orders;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -34,6 +35,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     List<Delivery> findByDeliveryStatus(DeliveryStatus status);
 
     Delivery findByIdx(Long deliveryIdx);
+
+    Delivery findByOrders(Orders orders);
 
     // 배송 상태 자동 전환용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
     List<Delivery> findByDeliveryStatusAndDepartureDateBefore(DeliveryStatus status, LocalDateTime before);

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -53,27 +53,6 @@ public class DeliveryService {
                 orders.getStore());
     }
 
-    // 배송 승인: READY → START + 점주 배송 시작 알림 (NOTIFY_014)
-    @Transactional
-    public boolean approveDelivery(Long deliveryIdx) {
-        Delivery delivery = deliveryRepository.findByIdx(deliveryIdx);
-        if (delivery == null || delivery.getDeliveryStatus() != DeliveryStatus.READY) {
-            return false;
-        }
-
-        delivery.setDeliveryStatus(DeliveryStatus.START);
-
-        String storeName = delivery.getOrders().getStore().getStoreName();
-        storeNotificationService.create(
-                NotificationType.DELIVERY_START,
-                "배송 시작 안내",
-                "주문하신 상품의 배송이 시작되었습니다. 예상 도착일: "
-                        + delivery.getEstimatedArrivalAt().toLocalDate(),
-                delivery.getOrders().getStore());
-
-        return true;
-    }
-
     public List<DeliveryDto> getDeliveriesByHead(
             String storeName, DeliveryStatus status, Integer year, Integer month, Integer day) {
         return deliveryRepository.findAllByFilters(storeName, status, year, month, day)

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -24,7 +24,7 @@ public class DeliveryService {
     private final HeadNotificationService headNotificationService;
     private final StoreNotificationService storeNotificationService;
 
-    // 발주 승인 시 배송 생성 (READY 상태)
+    // 점주 발주 확정 시 배송 생성 (READY 상태)
     @Transactional
     public void createDelivery(Orders orders) {
         Delivery delivery = Delivery.builder()
@@ -34,6 +34,23 @@ public class DeliveryService {
                 .orders(orders)
                 .build();
         deliveryRepository.save(delivery);
+    }
+
+    // 본사 발주 승인 시 배송 시작 (READY → START) + 점주 알림
+    @Transactional
+    public void startDeliveryByOrders(Orders orders) {
+        Delivery delivery = deliveryRepository.findByOrders(orders);
+        if (delivery == null || delivery.getDeliveryStatus() != DeliveryStatus.READY) {
+            return;
+        }
+        delivery.setDeliveryStatus(DeliveryStatus.START);
+
+        storeNotificationService.create(
+                NotificationType.DELIVERY_START,
+                "배송 시작 안내",
+                "주문하신 상품의 배송이 시작되었습니다. 예상 도착일: "
+                        + delivery.getEstimatedArrivalAt().toLocalDate(),
+                orders.getStore());
     }
 
     // 배송 승인: READY → START + 점주 배송 시작 알림 (NOTIFY_014)

--- a/backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java
@@ -31,12 +31,12 @@ public class NotificationScheduler {
     /**
      * 유통기한 임박 알림
      * 매일 오전 7시에 실행
-     * 제조일 + dangerDays 기준으로 유통기한 7일 이내 제품 감지
+     * 제조일 + dangerDays 기준으로 유통기한 3일 이내 제품 감지
      */
     @Scheduled(cron = "0 0 7 * * *")
     public void checkExpiryNotification() {
         // 유통기한 만료까지 며칠 이내일 때 알림을 보낼지 설정
-        int alertDays = 7;
+        int alertDays = 3;
         LocalDateTime now = LocalDateTime.now();
 
         // 재고 수량이 1 이상인 제품만 조회 (재고 없으면 의미 없으므로)
@@ -52,7 +52,7 @@ public class NotificationScheduler {
             // 만료일까지 남은 일수 계산
             long daysUntilExpiry = java.time.Duration.between(now, expiryDate).toDays();
 
-            // 만료일이 7일 이내이고, 아직 만료되지 않은 경우에만 알림
+            // 만료일이 3일 이내이고, 아직 만료되지 않은 경우에만 알림
             if (daysUntilExpiry <= alertDays && daysUntilExpiry >= 0) {
                 String productName = inventory.getProduct().getProductName();
                 String title = "유통기한 임박 - " + productName;
@@ -95,48 +95,48 @@ public class NotificationScheduler {
      * 배송 상태 자동 전환
      * 10분마다 실행
      * START + 1시간 경과 → DELIVERYING
-     * START + 1일 경과 → DELIVERED + 점주 배송 완료 알림 (NOTIFY_015)
+     * DELIVERYING + 1일 경과 → DELIVERED + 점주 배송 완료 알림
      */
     @Scheduled(cron = "0 */10 * * * *")
     @Transactional
     public void updateDeliveryStatus() {
         LocalDateTime now = LocalDateTime.now();
 
-        // START + 1일 경과 → DELIVERED (먼저 체크하여 1시간/1일 모두 경과한 건은 바로 완료 처리)
+        // START + 1시간 경과 → DELIVERYING
+        List<Delivery> toDelivering = deliveryRepository.findByDeliveryStatusAndDepartureDateBefore(
+                DeliveryStatus.START, now.minusHours(1));
+
+        for (Delivery delivery : toDelivering) {
+            delivery.setDeliveryStatus(DeliveryStatus.DELIVERYING);
+        }
+
+        // DELIVERYING + 1일 경과 → DELIVERED + 점주 배송 완료 알림
         List<Delivery> toDeliver = deliveryRepository.findByDeliveryStatusAndDepartureDateBefore(
-                DeliveryStatus.START, now.minusDays(1));
+                DeliveryStatus.DELIVERYING, now.minusDays(1));
+
         for (Delivery delivery : toDeliver) {
             delivery.setDeliveryStatus(DeliveryStatus.DELIVERED);
             delivery.setDeliveredDate(now);
 
-            // 점주 배송 완료 알림 (NOTIFY_015)
             storeNotificationService.create(
                     NotificationType.DELIVERED,
                     "배송 완료 안내",
                     "주문하신 상품의 배송이 완료되었습니다.",
                     delivery.getOrders().getStore());
         }
-
-        // START + 1시간 경과 → DELIVERYING
-        List<Delivery> toDelivering = deliveryRepository.findByDeliveryStatusAndDepartureDateBefore(
-                DeliveryStatus.START, now.minusHours(1));
-        for (Delivery delivery : toDelivering) {
-            delivery.setDeliveryStatus(DeliveryStatus.DELIVERYING);
-        }
     }
 
     /**
      * 배송 지연 자동 감지
      * 매일 오전 8시에 실행
-     * 예상도착일 초과 + 미완료 배송 → 점주/운영자 알림 (NOTIFY_016)
+     * 예상도착일 초과 + 미완료 배송 → 점주/운영자 알림
      */
     @Scheduled(cron = "0 0 8 * * *")
     @Transactional
     public void checkDeliveryDelay() {
         LocalDateTime now = LocalDateTime.now();
 
-        List<Delivery> overdueDeliveries = deliveryRepository.findOverdueDeliveries(
-                now, List.of(DeliveryStatus.DELIVERED, DeliveryStatus.DELAY));
+        List<Delivery> overdueDeliveries = deliveryRepository.findOverdueDeliveries(now, List.of(DeliveryStatus.DELIVERED, DeliveryStatus.DELAY));
 
         for (Delivery delivery : overdueDeliveries) {
             String storeName = delivery.getOrders().getStore().getStoreName();
@@ -153,6 +153,9 @@ public class NotificationScheduler {
                     "배송 지연 안내",
                     "예상 도착일(" + delivery.getEstimatedArrivalAt().toLocalDate() + ")이 초과되었습니다. 본사에서 확인 중입니다.",
                     delivery.getOrders().getStore());
+
+            // 지연 처리 완료 → 다음 스케줄러 실행 시 중복 알림 방지
+            delivery.setDeliveryStatus(DeliveryStatus.DELAY);
         }
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -30,7 +30,7 @@ public class OrdersController {
     private final OrdersService orderService;
 
     /**
-     * 자동 발주 목록 조회
+     * 자동 발주 목록 조회 겸 검색
      *
      * @param keyword 검색 키워드 (선택)
      * @param page 페이지 번호 (기본값: 0)
@@ -43,12 +43,14 @@ public class OrdersController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        Page<OrdersDto.OrderListRes> result = orderService.findAllAuto(keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+        Page<OrdersDto.OrderListRes> result = orderService.findAllAuto(
+                keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
 
     /**
-     * 확정 발주 목록 조회
+     * 확정 발주 목록 조회 겸 검색
      *
      * @param keyword 검색 키워드 (선택)
      * @param page 페이지 번호 (기본값: 0)
@@ -67,7 +69,18 @@ public class OrdersController {
     }
 
     /**
-     * 발주 이력 목록 조회
+     * 확정 발주 일괄 승인
+     *
+     * @return ResponseEntity 일괄 승인 결과 메시지
+     */
+    @PutMapping("/confirmed/approve")
+    public ResponseEntity approveAll() {
+        orderService.approveAllConfirmed();
+        return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
+    /**
+     * 발주 이력 목록 조회 겸 검색
      *
      * @param ordersType 발주 유형 필터 (선택)
      * @param startDate 조회 시작일 (선택)
@@ -93,7 +106,7 @@ public class OrdersController {
     }
 
     /**
-     * 위험 발주 목록 조회
+     * 이상 발주 목록 조회 겸 검색
      *
      * @param startDate 조회 시작일 (선택)
      * @param endDate 조회 종료일 (선택)
@@ -129,7 +142,7 @@ public class OrdersController {
     }
 
     /**
-     * 위험 발주 기준 설정 조회
+     * 이상 발주 기준 설정 조회
      *
      * @return ResponseEntity 위험 발주 기준 설정 정보
      */
@@ -140,7 +153,7 @@ public class OrdersController {
     }
 
     /**
-     * 위험 발주 기준 설정 수정
+     * 이상 발주 기준 설정 수정
      *
      * @param req 위험 발주 기준 설정 요청 데이터
      * @return ResponseEntity 수정 결과 메시지
@@ -172,17 +185,6 @@ public class OrdersController {
     @PutMapping("/{ordersIdx}/reject")
     public ResponseEntity reject(@PathVariable Long ordersIdx) {
         orderService.reject(ordersIdx);
-        return ResponseEntity.ok(BaseResponse.success("update success"));
-    }
-
-    /**
-     * 확정 발주 일괄 승인
-     *
-     * @return ResponseEntity 일괄 승인 결과 메시지
-     */
-    @PutMapping("/confirmed/approve")
-    public ResponseEntity approveAll() {
-        orderService.approveAllConfirmed();
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -15,23 +15,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecificationExecutor<Orders> {
-    // 발주용 - 점주 제안 발주서 조회 (매장별 특정 상태)
-    List<Orders> findAllByStore_IdxAndOrdersStatus(Long storeIdx, OrdersStatus orderStatus);
-
-    // 발주용 - 점주 발주 이력 페이징 조회
-    Page<Orders> findAllByStore_IdxAndOrdersStatusIn(Long storeIdx, List<OrdersStatus> ordersStatuses, Pageable pageable);
-
-    // 발주용 - 본사 확정 발주 일괄 승인 대상 조회
-    List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
-
-    // 발주용 - 이상 발주 목록 조회 (위험 플래그 기준)
-    List<Orders> findAllByIsDangerTrue();
-
-    // 발주용 - 이상 발주 판별을 위한 매장별 평균 발주 수량 계산
-    @Query("SELECT COALESCE(SUM(i.count), 0) / GREATEST(COUNT(DISTINCT o.idx), 1) " +
-            "FROM Orders o JOIN o.ordersItemList i " +
-            "WHERE o.store.idx = :storeIdx AND o.createdAt >= :since AND (:excludeIdx IS NULL OR o.idx <> :excludeIdx)")
-    Integer findAvgQtyByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("since") LocalDateTime since, @Param("excludeIdx") Long excludeIdx);
 
     // 정산용 - 매장별 전체 주문 목록 조회
     List<Orders> findAllByStoreIdx(Long storeIdx);
@@ -45,13 +28,6 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     // 본사 대시보드 - 이상 발주 건수 KPI
     long countByIsDangerTrue();
 
-    // 본사 대시보드 - 이상 발주 월별 추이 차트 (상태별 그룹핑)
-    @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus, COUNT(o) " +
-            "FROM Orders o WHERE o.isDanger = true AND o.createdAt >= :since " +
-            "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus " +
-            "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m')")
-    List<Object[]> findDangerStatsByMonth(@Param("since") LocalDateTime since);
-
     // 본사 대시보드 - 주간 발주 추이 차트 (일별 건수)
     @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d'), COUNT(o) " +
             "FROM Orders o WHERE o.createdAt >= :since " +
@@ -59,13 +35,35 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d')")
     List<Object[]> findWeeklyOrderStats(@Param("since") LocalDateTime since);
 
+    // 본사 대시보드 - 이상 발주 월별 추이 차트 (상태별 그룹핑)
+    @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus, COUNT(o) " +
+            "FROM Orders o WHERE o.isDanger = true AND o.createdAt >= :since " +
+            "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus " +
+            "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m')")
+    List<Object[]> findDangerStatsByMonth(@Param("since") LocalDateTime since);
+
+    // 본사 발주 관리 - 본사 확정 발주 일괄 승인을 위한 대상 조회
+    List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
+
+    // 본사 발주 관리 - 이상 발주 목록 조회 (위험 플래그 기준)
+    List<Orders> findAllByIsDangerTrue();
+
+    // 본사 발주 관리 - 이상 발주 판별을 위한 매장별 평균 발주 수량 계산
+    @Query("SELECT COALESCE(SUM(i.count), 0) / GREATEST(COUNT(DISTINCT o.idx), 1) " +
+            "FROM Orders o JOIN o.ordersItemList i " +
+            "WHERE o.store.idx = :storeIdx AND o.createdAt >= :since AND (:excludeIdx IS NULL OR o.idx <> :excludeIdx)")
+    Integer findAvgQtyByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("since") LocalDateTime since, @Param("excludeIdx") Long excludeIdx);
+
     // 점주 대시보드 - 미확정 제안 발주서 개수 KPI
     long countByStore_IdxAndOrdersStatusAndOrdersType(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
-
-    // 점주 대시보드 - 미확정 제안 발주서 목록
-    List<Orders> findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
 
     // 점주 대시보드 - 기간별 승인 발주 금액 합계 (매출 KPI)
     @Query("SELECT COALESCE(SUM(o.price), 0) FROM Orders o WHERE o.store.idx = :storeIdx AND o.ordersStatus = 'APPROVE' AND o.createdAt >= :from AND o.createdAt < :to")
     long sumApprovedPriceByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
+    // 점주 제안 발주서 & 점주 대시보드  - 미확정 제안 발주서 목록
+    List<Orders> findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
+
+    // 점주 발주 관리 - 점주 이력 페이징 조회
+    Page<Orders> findAllByStore_IdxAndOrdersStatusIn(Long storeIdx, List<OrdersStatus> ordersStatuses, Pageable pageable);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -33,38 +33,39 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "WHERE o.store.idx = :storeIdx AND o.createdAt >= :since AND (:excludeIdx IS NULL OR o.idx <> :excludeIdx)")
     Integer findAvgQtyByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("since") LocalDateTime since, @Param("excludeIdx") Long excludeIdx);
 
-    // 본사 대시보드용 - 발주 유형별 최근 건수 (자동/수동 KPI)
+    // 정산용 - 매장별 전체 주문 목록 조회
+    List<Orders> findAllByStoreIdx(Long storeIdx);
+
+    // 본사 대시보드 - 발주 유형별 최근 건수 (자동/수동 KPI)
     long countByOrdersTypeAndCreatedAtAfter(OrdersType ordersType, LocalDateTime since);
 
-    // 본사 대시보드용 - 상태별 발주 건수 (확정 대기 KPI)
+    // 본사 대시보드 - 상태별 발주 건수 (확정 대기 KPI)
     long countByOrdersStatus(OrdersStatus ordersStatus);
 
-    // 본사 대시보드용 - 이상 발주 건수 KPI
+    // 본사 대시보드 - 이상 발주 건수 KPI
     long countByIsDangerTrue();
 
-    // 본사 대시보드용 - 이상 발주 월별 추이 차트 (상태별 그룹핑)
+    // 본사 대시보드 - 이상 발주 월별 추이 차트 (상태별 그룹핑)
     @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus, COUNT(o) " +
             "FROM Orders o WHERE o.isDanger = true AND o.createdAt >= :since " +
             "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus " +
             "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m')")
     List<Object[]> findDangerStatsByMonth(@Param("since") LocalDateTime since);
 
-    // 본사 대시보드용 - 주간 발주 추이 차트 (일별 건수)
+    // 본사 대시보드 - 주간 발주 추이 차트 (일별 건수)
     @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d'), COUNT(o) " +
             "FROM Orders o WHERE o.createdAt >= :since " +
             "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d') " +
             "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d')")
     List<Object[]> findWeeklyOrderStats(@Param("since") LocalDateTime since);
 
-    // 점주 대시보드용 - 미확정 제안 발주서 개수 KPI
+    // 점주 대시보드 - 미확정 제안 발주서 개수 KPI
     long countByStore_IdxAndOrdersStatusAndOrdersType(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
 
-    // 점주 대시보드용 - 미확정 제안 발주서 목록
+    // 점주 대시보드 - 미확정 제안 발주서 목록
     List<Orders> findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
 
-    // 점주 대시보드용 - 기간별 승인 발주 금액 합계 (매출 KPI)
+    // 점주 대시보드 - 기간별 승인 발주 금액 합계 (매출 KPI)
     @Query("SELECT COALESCE(SUM(o.price), 0) FROM Orders o WHERE o.store.idx = :storeIdx AND o.ordersStatus = 'APPROVE' AND o.createdAt >= :from AND o.createdAt < :to")
     long sumApprovedPriceByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
-
-    List<Orders> findAllByStoreIdx(Long storeIdx);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -177,7 +177,7 @@ public class OrdersService {
 
         applyOutboundForOrder(orders, "발주 승인(이상) ordersIdx=");
         orders.approve();
-        deliveryService.createDelivery(orders);
+        deliveryService.startDeliveryByOrders(orders);
     }
 
     // 본사 - 이상 발주 개별 반려
@@ -201,7 +201,7 @@ public class OrdersService {
         for (Orders orders : confirmedOrders) {
             applyOutboundForOrder(orders, "발주 일괄승인 ordersIdx=");
             orders.approve();
-            deliveryService.createDelivery(orders);
+            deliveryService.startDeliveryByOrders(orders);
         }
     }
 
@@ -305,6 +305,9 @@ public class OrdersService {
                     .orders(orders)
                     .build());
         }
+
+        // 7. 배송 생성 (READY 상태)
+        deliveryService.createDelivery(orders);
     }
 
     // 점주 - 제안 발주서 목록 조회 (WAITING 상태, 현재 재고 포함)
@@ -359,6 +362,7 @@ public class OrdersService {
         }
 
         orders.confirm();
+        deliveryService.createDelivery(orders);
     }
 
     // 점주 - 제안 발주서에 품목 추가 (가격 자동 반영)

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -254,14 +254,14 @@ public class OrdersService {
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
         // 3. Product 조회 및 총 가격 계산
-        long totalprice = 0;
+        long totalPrice = 0;
         List<OrdersItem> itemList = new ArrayList<>();
 
         for (OrdersItemDto.OrdersItemReq itemReq : req.getOrdersItemList()) {
             Product product = productRepository.findById(itemReq.getProductIdx())
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
-            totalprice += (long) product.getUnitPrice() * itemReq.getCount();
+            totalPrice += (long) product.getUnitPrice() * itemReq.getCount();
 
             itemList.add(OrdersItem.builder()
                     .count(itemReq.getCount())
@@ -290,7 +290,7 @@ public class OrdersService {
 
         // 5. Orders 저장
         Orders orders = ordersRepository.save(Orders.builder()
-                .price(totalprice)
+                .price(totalPrice)
                 .ordersType(OrdersType.MANUAL)
                 .ordersStatus(OrdersStatus.CONFIRMED)
                 .isDanger(isDanger)

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -316,10 +317,17 @@ public class OrdersService {
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
         List<StoreInventory> inventoryList = storeInventoryRepository.findByStoreIdx(store.getIdx());
-        Map<Long, Integer> stockMap = inventoryList.stream()
-                .collect(Collectors.toMap(inv -> inv.getProduct().getIdx(), StoreInventory::getCount, Integer::sum));
+        Map<Long, Integer> stockMap = new HashMap<>();
+        for (StoreInventory inv : inventoryList) {
+            Long productIdx = inv.getProduct().getIdx();
+            if (stockMap.containsKey(productIdx)) {
+                stockMap.put(productIdx, stockMap.get(productIdx) + inv.getCount());
+            } else {
+                stockMap.put(productIdx, inv.getCount());
+            }
+        }
 
-        return ordersRepository.findAllByStore_IdxAndOrdersStatus(store.getIdx(), OrdersStatus.WAITING).stream()
+        return ordersRepository.findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(store.getIdx(), OrdersStatus.WAITING, OrdersType.AUTO).stream()
                 .map(order -> OrdersDto.OrdersRes.fromWithStock(order, stockMap))
                 .toList();
     }

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
@@ -15,7 +15,6 @@ public class OrdersDto {
     @Getter
     @NoArgsConstructor
     public static class OrdersReq {
-        private Long storeIdx;
         private List<OrdersItemDto.OrdersItemReq> ordersItemList;
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java
@@ -23,15 +23,6 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
 
     Optional<Store> findByBusiness(String business);
 
-    // 대시보드용 - 본사 대시보드 전체 매장 수 KPI 카드
-    long countByIsDeletedFalse();
-
-    // 대시보드용 - 본사 대시보드 신규 매장 수 (기준일 이후 생성)
-    long countByIsDeletedFalseAndCreatedAtAfter(LocalDateTime since);
-
-    // 대시보드용 - 본사 대시보드 이전 기간 매장 수 (증감률 계산)
-    long countByIsDeletedFalseAndCreatedAtBefore(LocalDateTime until);
-
     // 전체 조회 시 이름 또는 주소 검색
     @Query("SELECT s FROM Store s WHERE " +
             "(s.storeName LIKE %:keyword% OR s.address LIKE %:keyword%) " +
@@ -52,4 +43,13 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
     Page<Store> findByIsDeletedFalseOrderByCreatedAtDesc(Pageable pageable); // 입점(false)
     // 검색 없이 '폐점'만 조회할 때: 최신 폐업일순 또는 등록순 정렬[cite: 7]
     Page<Store> findByIsDeletedTrueOrderByClosedAtDesc(Pageable pageable);
+
+    // 본사 대시보드용 - 전체 매장 수 KPI 카드
+    long countByIsDeletedFalse();
+
+    // 본사 대시보드용 - 신규 매장 수 (기준일 이후 생성)
+    long countByIsDeletedFalseAndCreatedAtAfter(LocalDateTime since);
+
+    // 본사 대시보드용 - 이전 기간 매장 수 (증감률 계산)
+    long countByIsDeletedFalseAndCreatedAtBefore(LocalDateTime until);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 배송/발주/대시보드 도메인의 로직 오류 수정 및 불필요한 코드 정리

## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java`
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java`
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java`
- `backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java`
- `backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java`
- `backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java`
- `backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java`
- `backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java`
- `backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java`

## 주요 변경 사항
- 배송 생성 시점을 발주 승인 → 점주 확정으로 변경 (READY 상태 생성, 승인 시 START 전환)
- 배송 스케줄러 상태 전환 흐름 수정 (START → DELIVERYING → DELIVERED)
- 지연 배송 감지 시 DELAY 상태 전환 추가하여 중복 알림 방지
- 유통기한 알림 기준 7일 → 3일로 변경
- 대시보드 지연 배송 전체 로드 제거 (DeliveryKpiRes에서 deliveryList 제거)
- 제안 발주서 조회 조건 수정 (WAITING → WAITING + AUTO)
- 미사용 코드 제거 (배송 승인 API, OrdersReq.storeIdx 등)
- Repository 메서드 정리 및 주석 추가
- OrdersService totalprice → totalPrice 네이밍 수정

## Test Plan
- 점주 발주 확정 시 배송 데이터가 READY 상태로 생성되는지 확인
- 본사 발주 승인 시 배송 상태가 START로 전환되는지 확인
- 스케줄러: START → DELIVERYING(1시간) → DELIVERED(1일) 흐름 확인
- 지연 배송 알림이 1회만 발송되는지 확인
- 점주 대시보드 제안 발주서 목록이 AUTO + WAITING만 표시되는지 확인

## Issue
- Closes #626