### PR TITLE
[Feat] #630, #631, #632, #633 - Blue/Green 무중단 배포 전환

### DIFF
--- a/jenkins/backend/Jenkinsfile
+++ b/jenkins/backend/Jenkinsfile
@@ -69,12 +69,24 @@ spec:
         stage('Deploy to Kubernetes') {
             steps {
                 container('kubectl') {
-                    sh """
-                        kubectl apply -f k8s/backend/deployment.yaml
-                        kubectl apply -f k8s/backend/service.yaml
-                        kubectl set image deployment/nexus-backend nexus-backend=${IMAGE_REPO}:${BUILD_NUMBER}
-                        kubectl rollout status deployment/nexus-backend
-                    """
+                    script {
+                        sh 'kubectl apply -f k8s/backend/deployment-blue.yaml'
+                        sh 'kubectl apply -f k8s/backend/deployment-green.yaml'
+                        sh 'kubectl apply -f k8s/backend/service.yaml'
+
+                        def currentSlot = sh(
+                            script: "kubectl get svc nexus-backend-service -o jsonpath='{.spec.selector.slot}'",
+                            returnStdout: true
+                        ).trim()
+
+                        def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
+
+                        sh "kubectl set image deployment/nexus-backend-${newSlot} nexus-backend=${IMAGE_REPO}:${BUILD_NUMBER}"
+                        sh "kubectl rollout status deployment/nexus-backend-${newSlot} --timeout=120s"
+                        sh "kubectl patch svc nexus-backend-service -p '{\"spec\":{\"selector\":{\"slot\":\"${newSlot}\"}}}'"
+
+                        echo "Switched traffic to ${newSlot} slot"
+                    }
                 }
             }
         }

--- a/jenkins/backend/Jenkinsfile
+++ b/jenkins/backend/Jenkinsfile
@@ -1,4 +1,5 @@
 pipeline {
+    // Jenkins 에이전트를 K8s Pod로 실행 (빌드용 컨테이너 3개를 하나의 Pod에 구성)
     agent {
         kubernetes {
             yaml """
@@ -7,54 +8,61 @@ kind: Pod
 spec:
   serviceAccountName: jenkins
   containers:
-  - name: gradle
+  - name: gradle                                    # Java 빌드용 (bootJar)
     image: eclipse-temurin:17-jdk-alpine
     command: ['sleep', 'infinity']
-  - name: kaniko
+  - name: kaniko                                    # Docker 이미지 빌드 & Push용 (Docker 데몬 불필요)
     image: gcr.io/kaniko-project/executor:debug
     command: ['sleep', 'infinity']
-  - name: kubectl
+  - name: kubectl                                   # K8s 클러스터 배포용
     image: bitnami/kubectl:latest
     command: ['sleep', 'infinity']
     securityContext:
-      runAsUser: 0
+      runAsUser: 0                                  # kubectl 실행을 위해 root 권한 필요
 """
         }
     }
 
     environment {
-        IMAGE_REPO = 'deatytim/nexusback'
+        IMAGE_REPO = 'deatytim/nexusback'           // Docker Hub 이미지 저장소
     }
 
     stages {
+        // 소스코드 체크아웃
         stage('Checkout') {
             steps {
                 checkout scm
             }
         }
 
+        // Spring Boot JAR 빌드
         stage('Build JAR') {
             steps {
                 container('gradle') {
                     dir('backend') {
+                        // gradlew 실행 권한 부여 후 테스트 제외하고 JAR 생성
                         sh 'chmod +x gradlew && ./gradlew bootJar -x test'
                     }
                 }
             }
         }
 
+        // Docker 이미지 빌드 및 Docker Hub Push
         stage('Build & Push Docker Image') {
             steps {
                 container('kaniko') {
+                    // Jenkins에 저장된 Docker Hub 자격증명 주입
                     withCredentials([usernamePassword(
                         credentialsId: 'dockerhub-credentials',
                         usernameVariable: 'DOCKER_USER',
                         passwordVariable: 'DOCKER_PASS'
                     )]) {
                         sh """
+                            # Kaniko용 Docker Hub 인증 설정
                             AUTH=\$(printf "%s:%s" "\$DOCKER_USER" "\$DOCKER_PASS" | base64 | tr -d '\\n')
                             mkdir -p /kaniko/.docker
                             printf '{"auths":{"https://index.docker.io/v1/":{"auth":"%s"}}}' "\$AUTH" > /kaniko/.docker/config.json
+                            # 이미지 빌드 후 빌드번호 태그 + latest 태그로 Push
                             /kaniko/executor \\
                                 --context=\$WORKSPACE/backend \\
                                 --dockerfile=\$WORKSPACE/docker/backend/Dockerfile \\
@@ -66,23 +74,32 @@ spec:
             }
         }
 
+        // Blue/Green 무중단 배포
+        // 1) 매니페스트 적용 → 2) 현재 슬롯 확인 → 3) 비활성 슬롯에 배포
+        // → 4) Ready 대기 → 5) Service selector 전환으로 트래픽 스위칭
         stage('Deploy to Kubernetes') {
             steps {
                 container('kubectl') {
                     script {
+                        // 1) blue/green 매니페스트 및 service 적용
                         sh 'kubectl apply -f k8s/backend/deployment-blue.yaml'
                         sh 'kubectl apply -f k8s/backend/deployment-green.yaml'
                         sh 'kubectl apply -f k8s/backend/service.yaml'
 
+                        // 2) 현재 트래픽을 받고 있는 슬롯 확인
                         def currentSlot = sh(
                             script: "kubectl get svc nexus-backend-service -o jsonpath='{.spec.selector.slot}'",
                             returnStdout: true
                         ).trim()
 
+                        // 3) 비활성 슬롯에 새 이미지 배포
                         def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
-
                         sh "kubectl set image deployment/nexus-backend-${newSlot} nexus-backend=${IMAGE_REPO}:${BUILD_NUMBER}"
+
+                        // 4) 새 pod가 Ready 상태가 될 때까지 대기
                         sh "kubectl rollout status deployment/nexus-backend-${newSlot} --timeout=120s"
+
+                        // 5) Service selector를 새 슬롯으로 전환 → 트래픽 즉시 이동
                         sh "kubectl patch svc nexus-backend-service -p '{\"spec\":{\"selector\":{\"slot\":\"${newSlot}\"}}}'"
 
                         echo "Switched traffic to ${newSlot} slot"

--- a/jenkins/frontend/Jenkinsfile
+++ b/jenkins/frontend/Jenkinsfile
@@ -69,13 +69,25 @@ spec:
         stage('Deploy to Kubernetes') {
             steps {
                 container('kubectl') {
-                    sh """
-                        kubectl apply -f k8s/frontend/deployment.yaml
-                        kubectl apply -f k8s/frontend/service.yaml
-                        kubectl apply -f k8s/ingress.yaml
-                        kubectl set image deployment/nexus-frontend nexus-frontend=${IMAGE_REPO}:${BUILD_NUMBER}
-                        kubectl rollout status deployment/nexus-frontend
-                    """
+                    script {
+                        sh 'kubectl apply -f k8s/frontend/deployment-blue.yaml'
+                        sh 'kubectl apply -f k8s/frontend/deployment-green.yaml'
+                        sh 'kubectl apply -f k8s/frontend/service.yaml'
+                        sh 'kubectl apply -f k8s/ingress.yaml'
+
+                        def currentSlot = sh(
+                            script: "kubectl get svc nexus-frontend-service -o jsonpath='{.spec.selector.slot}'",
+                            returnStdout: true
+                        ).trim()
+
+                        def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
+
+                        sh "kubectl set image deployment/nexus-frontend-${newSlot} nexus-frontend=${IMAGE_REPO}:${BUILD_NUMBER}"
+                        sh "kubectl rollout status deployment/nexus-frontend-${newSlot} --timeout=120s"
+                        sh "kubectl patch svc nexus-frontend-service -p '{\"spec\":{\"selector\":{\"slot\":\"${newSlot}\"}}}'"
+
+                        echo "Switched traffic to ${newSlot} slot"
+                    }
                 }
             }
         }

--- a/jenkins/frontend/Jenkinsfile
+++ b/jenkins/frontend/Jenkinsfile
@@ -1,4 +1,5 @@
 pipeline {
+    // Jenkins 에이전트를 K8s Pod로 실행 (빌드용 컨테이너 3개를 하나의 Pod에 구성)
     agent {
         kubernetes {
             yaml """
@@ -7,54 +8,61 @@ kind: Pod
 spec:
   serviceAccountName: jenkins
   containers:
-  - name: node
+  - name: node                                      # Frontend 빌드용 (npm)
     image: node:20-alpine
     command: ['sleep', 'infinity']
-  - name: kaniko
+  - name: kaniko                                    # Docker 이미지 빌드 & Push용 (Docker 데몬 불필요)
     image: gcr.io/kaniko-project/executor:debug
     command: ['sleep', 'infinity']
-  - name: kubectl
+  - name: kubectl                                   # K8s 클러스터 배포용
     image: bitnami/kubectl:latest
     command: ['sleep', 'infinity']
     securityContext:
-      runAsUser: 0
+      runAsUser: 0                                  # kubectl 실행을 위해 root 권한 필요
 """
         }
     }
 
     environment {
-        IMAGE_REPO = 'deatytim/nexusfront'
+        IMAGE_REPO = 'deatytim/nexusfront'          // Docker Hub 이미지 저장소
     }
 
     stages {
+        // 소스코드 체크아웃
         stage('Checkout') {
             steps {
                 checkout scm
             }
         }
 
+        // Frontend 빌드 (Vue.js)
         stage('Build') {
             steps {
                 container('node') {
                     dir('frontend') {
+                        // 의존성 클린 설치 후 프로덕션 빌드 (dist 폴더 생성)
                         sh 'npm ci && npm run build'
                     }
                 }
             }
         }
 
+        // Docker 이미지 빌드 및 Docker Hub Push
         stage('Build & Push Docker Image') {
             steps {
                 container('kaniko') {
+                    // Jenkins에 저장된 Docker Hub 자격증명 주입
                     withCredentials([usernamePassword(
                         credentialsId: 'dockerhub-credentials',
                         usernameVariable: 'DOCKER_USER',
                         passwordVariable: 'DOCKER_PASS'
                     )]) {
                         sh """
+                            # Kaniko용 Docker Hub 인증 설정
                             AUTH=\$(printf "%s:%s" "\$DOCKER_USER" "\$DOCKER_PASS" | base64 | tr -d '\\n')
                             mkdir -p /kaniko/.docker
                             printf '{"auths":{"https://index.docker.io/v1/":{"auth":"%s"}}}' "\$AUTH" > /kaniko/.docker/config.json
+                            # 이미지 빌드 후 빌드번호 태그 + latest 태그로 Push
                             /kaniko/executor \\
                                 --context=\$WORKSPACE/frontend \\
                                 --dockerfile=\$WORKSPACE/docker/frontend/Dockerfile \\
@@ -66,24 +74,33 @@ spec:
             }
         }
 
+        // Blue/Green 무중단 배포
+        // 1) 매니페스트 적용 → 2) 현재 슬롯 확인 → 3) 비활성 슬롯에 배포
+        // → 4) Ready 대기 → 5) Service selector 전환으로 트래픽 스위칭
         stage('Deploy to Kubernetes') {
             steps {
                 container('kubectl') {
                     script {
+                        // 1) blue/green 매니페스트, service, ingress 적용
                         sh 'kubectl apply -f k8s/frontend/deployment-blue.yaml'
                         sh 'kubectl apply -f k8s/frontend/deployment-green.yaml'
                         sh 'kubectl apply -f k8s/frontend/service.yaml'
                         sh 'kubectl apply -f k8s/ingress.yaml'
 
+                        // 2) 현재 트래픽을 받고 있는 슬롯 확인
                         def currentSlot = sh(
                             script: "kubectl get svc nexus-frontend-service -o jsonpath='{.spec.selector.slot}'",
                             returnStdout: true
                         ).trim()
 
+                        // 3) 비활성 슬롯에 새 이미지 배포
                         def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
-
                         sh "kubectl set image deployment/nexus-frontend-${newSlot} nexus-frontend=${IMAGE_REPO}:${BUILD_NUMBER}"
+
+                        // 4) 새 pod가 Ready 상태가 될 때까지 대기
                         sh "kubectl rollout status deployment/nexus-frontend-${newSlot} --timeout=120s"
+
+                        // 5) Service selector를 새 슬롯으로 전환 → 트래픽 즉시 이동
                         sh "kubectl patch svc nexus-frontend-service -p '{\"spec\":{\"selector\":{\"slot\":\"${newSlot}\"}}}'"
 
                         echo "Switched traffic to ${newSlot} slot"

--- a/k8s/backend/deployment-blue.yaml
+++ b/k8s/backend/deployment-blue.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nexus-backend-blue
+  labels:
+    app: nexus-backend
+    slot: blue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nexus-backend
+      slot: blue
+  template:
+    metadata:
+      labels:
+        app: nexus-backend
+        slot: blue
+    spec:
+      containers:
+        - name: nexus-backend
+          image: deatytim/nexusback:latest
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: nexus-backend-config
+            - secretRef:
+                name: nexus-backend-secret
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30

--- a/k8s/backend/deployment-blue.yaml
+++ b/k8s/backend/deployment-blue.yaml
@@ -1,10 +1,12 @@
+# Blue/Green 배포 - Blue 슬롯
+# Service의 selector.slot 값을 blue/green으로 전환하여 트래픽을 제어합니다.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nexus-backend-blue
   labels:
     app: nexus-backend
-    slot: blue
+    slot: blue            # blue/green 슬롯 구분용 라벨
 spec:
   replicas: 1
   selector:

--- a/k8s/backend/deployment-green.yaml
+++ b/k8s/backend/deployment-green.yaml
@@ -1,18 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nexus-backend
+  name: nexus-backend-green
   labels:
     app: nexus-backend
+    slot: green
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: nexus-backend
+      slot: green
   template:
     metadata:
       labels:
         app: nexus-backend
+        slot: green
     spec:
       containers:
         - name: nexus-backend

--- a/k8s/backend/deployment-green.yaml
+++ b/k8s/backend/deployment-green.yaml
@@ -1,10 +1,12 @@
+# Blue/Green 배포 - Green 슬롯
+# Service의 selector.slot 값을 blue/green으로 전환하여 트래픽을 제어합니다.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nexus-backend-green
   labels:
     app: nexus-backend
-    slot: green
+    slot: green            # blue/green 슬롯 구분용 라벨
 spec:
   replicas: 1
   selector:

--- a/k8s/backend/service.yaml
+++ b/k8s/backend/service.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   selector:
     app: nexus-backend
+    slot: blue
   ports:
     - protocol: TCP
       port: 8080

--- a/k8s/backend/service.yaml
+++ b/k8s/backend/service.yaml
@@ -1,3 +1,5 @@
+# Blue/Green 배포용 Service
+# slot 값을 Jenkins 파이프라인에서 blue <-> green으로 patch하여 트래픽을 전환합니다.
 apiVersion: v1
 kind: Service
 metadata:
@@ -5,7 +7,7 @@ metadata:
 spec:
   selector:
     app: nexus-backend
-    slot: blue
+    slot: blue              # Jenkins에서 kubectl patch로 blue <-> green 전환
   ports:
     - protocol: TCP
       port: 8080

--- a/k8s/frontend/deployment-blue.yaml
+++ b/k8s/frontend/deployment-blue.yaml
@@ -1,18 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nexus-frontend
+  name: nexus-frontend-blue
   labels:
     app: nexus-frontend
+    slot: blue
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: nexus-frontend
+      slot: blue
   template:
     metadata:
       labels:
         app: nexus-frontend
+        slot: blue
     spec:
       containers:
         - name: nexus-frontend

--- a/k8s/frontend/deployment-blue.yaml
+++ b/k8s/frontend/deployment-blue.yaml
@@ -1,10 +1,12 @@
+# Blue/Green 배포 - Blue 슬롯
+# Service의 selector.slot 값을 blue/green으로 전환하여 트래픽을 제어합니다.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nexus-frontend-blue
   labels:
     app: nexus-frontend
-    slot: blue
+    slot: blue            # blue/green 슬롯 구분용 라벨
 spec:
   replicas: 1
   selector:

--- a/k8s/frontend/deployment-green.yaml
+++ b/k8s/frontend/deployment-green.yaml
@@ -1,10 +1,12 @@
+# Blue/Green 배포 - Green 슬롯
+# Service의 selector.slot 값을 blue/green으로 전환하여 트래픽을 제어합니다.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nexus-frontend-green
   labels:
     app: nexus-frontend
-    slot: green
+    slot: green            # blue/green 슬롯 구분용 라벨
 spec:
   replicas: 1
   selector:

--- a/k8s/frontend/deployment-green.yaml
+++ b/k8s/frontend/deployment-green.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nexus-frontend-green
+  labels:
+    app: nexus-frontend
+    slot: green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nexus-frontend
+      slot: green
+  template:
+    metadata:
+      labels:
+        app: nexus-frontend
+        slot: green
+    spec:
+      containers:
+        - name: nexus-frontend
+          image: deatytim/nexusfront:latest
+          ports:
+            - containerPort: 80

--- a/k8s/frontend/service.yaml
+++ b/k8s/frontend/service.yaml
@@ -1,3 +1,5 @@
+# Blue/Green 배포용 Service
+# slot 값을 Jenkins 파이프라인에서 blue <-> green으로 patch하여 트래픽을 전환합니다.
 apiVersion: v1
 kind: Service
 metadata:
@@ -5,7 +7,7 @@ metadata:
 spec:
   selector:
     app: nexus-frontend
-    slot: blue
+    slot: blue              # Jenkins에서 kubectl patch로 blue <-> green 전환
   ports:
     - protocol: TCP
       port: 80

--- a/k8s/frontend/service.yaml
+++ b/k8s/frontend/service.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   selector:
     app: nexus-frontend
+    slot: blue
   ports:
     - protocol: TCP
       port: 80


### PR DESCRIPTION
## Summary
- 기존 Rolling Update 방식에서 Blue/Green 배포로 전환하여 무중단 배포 구현

## 변경 파일
- k8s/backend/deployment-blue.yaml (신규)
- k8s/backend/deployment-green.yaml (신규)
- k8s/backend/deployment.yaml (삭제)
- k8s/backend/service.yaml
- k8s/frontend/deployment-blue.yaml (신규)
- k8s/frontend/deployment-green.yaml (신규)
- k8s/frontend/deployment.yaml (삭제)
- k8s/frontend/service.yaml
- jenkins/backend/Jenkinsfile
- jenkins/frontend/Jenkinsfile

## 주요 변경 사항
- Backend/Frontend Deployment를 blue/green 두 벌로 분리하고 slot 라벨 추가
- Service selector에 slot 필드 추가하여 트래픽 전환 지원
- Jenkinsfile Deploy 단계를 현재 슬롯 조회 → 비활성 슬롯 배포 → rollout 대기 → selector patch 흐름으로 변경

## DB & Infrastructure
- DB 변경 없음
- K8s Deployment 2벌 운영으로 pod 수 증가 (backend 1→2, frontend 1→2)

## Test Plan
- [ ] Jenkins 파이프라인 실행하여 blue/green 전환 정상 동작 확인
- [ ] 배포 중 서비스 다운타임 없는지 확인
- [ ] 배포 실패 시 기존 슬롯 유지되는지 확인

## Issue
- Closes #630
- Closes #631
- Closes #632
- Closes #633