### PR TITLE
[Feat] Blue/Green 무중단 배포 전환 및 기능 통합

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -38,24 +38,24 @@ public class DashboardController {
     }
 
     /**
-     * 배송 현황 KPI 조회
+     * 재고 위험 KPI 조회
      *
-     * @return ResponseEntity 진행중 배송 건수, 지연 건수, 지연 배송 목록
+     * @return ResponseEntity LOW/CRITICAL 상태 품목 수
      */
-    @GetMapping("/delivery/kpi")
-    public ResponseEntity<BaseResponse> getDeliveryKpi() {
-        DashboardDto.DeliveryKpiRes result = dashboardService.getDeliveryKpi();
+    @GetMapping("/inventory/kpi")
+    public ResponseEntity<BaseResponse> getInventoryKpi() {
+        DashboardDto.InventoryKpiRes result = dashboardService.getInventoryKpi();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
     /**
-     * 이상 발주 통계 조회
+     * 배송 현황 KPI 조회
      *
-     * @return ResponseEntity 최근 6개월 월별 이상 발주 상태별 건수
+     * @return ResponseEntity 진행중 배송 건수, 지연 배송 목록
      */
-    @GetMapping("/orders/danger/stats")
-    public ResponseEntity<BaseResponse> getDangerStats() {
-        DashboardDto.DangerStatsRes result = dashboardService.getDangerStats();
+    @GetMapping("/delivery/kpi")
+    public ResponseEntity<BaseResponse> getDeliveryKpi() {
+        DashboardDto.DeliveryKpiRes result = dashboardService.getDeliveryKpi();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
@@ -67,28 +67,6 @@ public class DashboardController {
     @GetMapping("/orders/weekly/stats")
     public ResponseEntity<BaseResponse> getWeeklyOrderStats() {
         DashboardDto.WeeklyOrderStatsRes result = dashboardService.getWeeklyOrderStats();
-        return ResponseEntity.ok(BaseResponse.success(result));
-    }
-
-    /**
-     * 배송 비율 조회
-     *
-     * @return ResponseEntity 배송 상태별 건수
-     */
-    @GetMapping("/delivery/ratio")
-    public ResponseEntity<BaseResponse> getDeliveryRatio() {
-        DashboardDto.DeliveryRatioRes result = dashboardService.getDeliveryRatio();
-        return ResponseEntity.ok(BaseResponse.success(result));
-    }
-
-    /**
-     * 재고 위험 KPI 조회
-     *
-     * @return ResponseEntity LOW/CRITICAL 상태 품목 수
-     */
-    @GetMapping("/inventory/kpi")
-    public ResponseEntity<BaseResponse> getInventoryKpi() {
-        DashboardDto.InventoryKpiRes result = dashboardService.getInventoryKpi();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
@@ -108,6 +86,17 @@ public class DashboardController {
     }
 
     /**
+     * 이상 발주 통계 조회
+     *
+     * @return ResponseEntity 최근 6개월 월별 이상 발주 상태별 건수
+     */
+    @GetMapping("/orders/danger/stats")
+    public ResponseEntity<BaseResponse> getOrdersDangerStats() {
+        DashboardDto.DangerStatsRes result = dashboardService.getOrdersDangerStats();
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
      * 지연 배송 목록 조회
      *
      * @param page 페이지 번호 (0부터 시작, 기본값 0)
@@ -119,6 +108,17 @@ public class DashboardController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "4") int size) {
         DashboardDto.DelayDeliveryRes result = dashboardService.getDelayDeliveryList(page, size);
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
+     * 배송 비율 조회
+     *
+     * @return ResponseEntity 배송 상태별 건수
+     */
+    @GetMapping("/delivery/ratio")
+    public ResponseEntity<BaseResponse> getDeliveryRatio() {
+        DashboardDto.DeliveryRatioRes result = dashboardService.getDeliveryRatio();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import com.example.nexus.common.enums.InventoryStatus;
 import com.example.nexus.domain.dashboard.model.DashboardDto;
 import com.example.nexus.domain.delivery.DeliveryRepository;
+import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.head.HeadInventoryRepository;
 import com.example.nexus.domain.head.model.HeadInventory;
 import com.example.nexus.domain.orders.OrdersRepository;
@@ -32,7 +33,10 @@ public class DashboardService {
     private final DeliveryRepository deliveryRepository;
     private final HeadInventoryRepository headInventoryRepository;
 
+    // 본사 대시보드 입점 매장 카드 데이터 조회 메서드
     public DashboardDto.StoreKpiRes getStoreKpi() {
+
+        // 총 매장 수
         long totalCount = storeRepository.countByIsDeletedFalse();
 
         // 이번 달 1일 00:00 기준 신규 매장 수
@@ -51,7 +55,7 @@ public class DashboardService {
                 .build();
     }
 
-
+    // 본사 대시보드 발주 카드 데이터 조회 메서드
     public DashboardDto.OrdersKpiRes getOrdersKpi() {
         LocalDateTime todayStart = LocalDate.now().atStartOfDay();
 
@@ -75,9 +79,25 @@ public class DashboardService {
                 .build();
     }
 
+    // 본사 재고 위험 카드 데이터 조회 메서드
+    public DashboardDto.InventoryKpiRes getInventoryKpi() {
+
+        // 재고 부족 건수
+        long lowCount = headInventoryRepository.countByStatus(InventoryStatus.LOW);
+
+        // 재고 위험 건수
+        long criticalCount = headInventoryRepository.countByStatus(InventoryStatus.CRITICAL);
+
+        return DashboardDto.InventoryKpiRes.builder()
+                .lowCount(lowCount)
+                .criticalCount(criticalCount)
+                .totalDangerCount(lowCount + criticalCount)
+                .build();
+    }
+
+    // 본사 대시보드 배송 현황 카드 데이터 조회 메서드
     public DashboardDto.DeliveryKpiRes getDeliveryKpi() {
-        List<DeliveryStatus> ongoingStatuses = List.of(
-                DeliveryStatus.READY, DeliveryStatus.START, DeliveryStatus.DELIVERYING);
+        List<DeliveryStatus> ongoingStatuses = List.of(DeliveryStatus.START, DeliveryStatus.DELIVERYING);
 
         // 진행중 배송 건수
         long ongoingCount = deliveryRepository.countByDeliveryStatusIn(ongoingStatuses);
@@ -85,79 +105,13 @@ public class DashboardService {
         // 배송 지연 건수
         long delayCount = deliveryRepository.countByDeliveryStatus(DeliveryStatus.DELAY);
 
-        // 배송 지연 목록
-        List<DashboardDto.DeliveryItem> deliveryList = deliveryRepository
-                .findAllByDeliveryStatus(DeliveryStatus.DELAY).stream()
-                .map(DashboardDto.DeliveryItem::from)
-                .toList();
-
         return DashboardDto.DeliveryKpiRes.builder()
                 .ongoingCount(ongoingCount)
                 .delayCount(delayCount)
-                .deliveryList(deliveryList)
                 .build();
     }
 
-    public DashboardDto.DangerStatsRes getDangerStats() {
-        // 조회 시작 시점: 현재 월 포함 6개월 전 1일 00:00
-        // 예: 현재 2026-05 → 2025-12-01 00:00부터 조회
-        LocalDateTime since = LocalDate.now().minusMonths(5).withDayOfMonth(1).atStartOfDay();
-
-        // 6개월치 라벨(yyyy-MM)을 순서대로 생성하고, 각 월별 카운트 배열 초기화
-        // LinkedHashMap으로 삽입 순서 보장 → 프론트 차트 x축 순서 유지
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
-        Map<String, long[]> monthMap = new LinkedHashMap<>();
-        for (int i = 0; i < 6; i++) {
-            String label = YearMonth.now().minusMonths(5 - i).format(formatter);
-            monthMap.put(label, new long[3]); // [0: 승인대기(CONFIRMED), 1: 승인(APPROVE), 2: 반려(REJECT)]
-        }
-
-        // DB에서 월별 + 상태별 이상 발주 건수 조회 후 monthMap에 매핑
-        List<Object[]> rows = ordersRepository.findDangerStatsByMonth(since);
-        for (Object[] row : rows) {
-            String month = (String) row[0];
-            long count = (Long) row[2];
-
-            long[] counts = monthMap.get(month);
-            if (counts == null) {
-                continue;
-            }
-
-            OrdersStatus status = (OrdersStatus) row[1];
-            switch (status) {
-                case CONFIRMED :
-                    counts[0] = count;
-                    break; // 승인 대기
-                case APPROVE :
-                    counts[1] = count;
-                    break; // 승인
-                case REJECT :
-                    counts[2] = count;
-                    break; // 반려
-                default: break;
-            }
-        }
-
-        // monthMap을 프론트 차트에 맞는 배열 형태로 변환
-        List<String> labels = new ArrayList<>(monthMap.keySet());
-        List<Long> confirmed = new ArrayList<>();
-        List<Long> approved = new ArrayList<>();
-        List<Long> rejected = new ArrayList<>();
-
-        for (long[] counts : monthMap.values()) {
-            confirmed.add(counts[0]);
-            approved.add(counts[1]);
-            rejected.add(counts[2]);
-        }
-
-        return DashboardDto.DangerStatsRes.builder()
-                .labels(labels)
-                .confirmed(confirmed)
-                .approved(approved)
-                .rejected(rejected)
-                .build();
-    }
-
+    // 본사 대시보드 주간 발주 통계 데이터 조회 메서드
     public DashboardDto.WeeklyOrderStatsRes getWeeklyOrderStats() {
         // 이번 주 월요일 00:00 기준으로 이번 주 / 지난 주 범위 계산
         // 예: 오늘 2026-05-04(일) → 이번 주 월요일 04-28, 지난 주 월요일 04-21
@@ -198,6 +152,97 @@ public class DashboardService {
                 .build();
     }
 
+    // 본사 대시보드 재고 위험 리스트 조회 메서드
+    public DashboardDto.DangerInventoryRes getDangerInventoryList(int page, int size) {
+        // 위험 재고: status가 LOW 또는 CRITICAL인 본사 재고 목록
+        List<InventoryStatus> dangerStatuses = List.of(InventoryStatus.LOW, InventoryStatus.CRITICAL);
+
+        Slice<HeadInventory> slice = headInventoryRepository.findByStatusIn(dangerStatuses, PageRequest.of(page, size));
+
+        List<DashboardDto.DangerInventoryItem> items = slice.getContent().stream().map(DashboardDto.DangerInventoryItem::from).toList();
+
+        return DashboardDto.DangerInventoryRes.builder()
+                .items(items)
+                .hasNext(slice.hasNext())
+                .build();
+    }
+
+    // 본사 대시보드 이상 발주 통계 데이터 조회
+    public DashboardDto.DangerStatsRes getOrdersDangerStats() {
+        // 조회 시작 시점: 현재 월 포함 6개월 전 1일 00:00
+        // 예: 현재 2026-05 → 2025-12-01 00:00부터 조회
+        LocalDateTime since = LocalDate.now().minusMonths(5).withDayOfMonth(1).atStartOfDay();
+
+        // 6개월치 라벨(yyyy-MM)을 순서대로 생성하고, 각 월별 카운트 배열 초기화
+        // LinkedHashMap으로 삽입 순서 보장 → 프론트 차트 x축 순서 유지
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        Map<String, long[]> monthMap = new LinkedHashMap<>();
+        for (int i = 0; i < 6; i++) {
+            String label = YearMonth.now().minusMonths(5 - i).format(formatter);
+            monthMap.put(label, new long[3]); // [0: 승인대기(CONFIRMED), 1: 승인(APPROVE), 2: 반려(REJECT)]
+        }
+
+        // DB에서 월별 + 상태별 이상 발주 건수 조회 후 monthMap에 매핑
+        List<Object[]> rows = ordersRepository.findDangerStatsByMonth(since);
+
+        for (Object[] row : rows) {
+            String month = (String) row[0];
+            long count = (Long) row[2];
+
+            long[] counts = monthMap.get(month);
+            if (counts == null) {
+                continue;
+            }
+
+            OrdersStatus status = (OrdersStatus) row[1];
+            switch (status) {
+                case CONFIRMED :
+                    counts[0] = count;
+                    break;
+                case APPROVE :
+                    counts[1] = count;
+                    break;
+                case REJECT :
+                    counts[2] = count;
+                    break;
+                default: break;
+            }
+        }
+
+        // monthMap을 프론트 차트에 맞는 배열 형태로 변환
+        List<String> labels = new ArrayList<>(monthMap.keySet());
+        List<Long> confirmed = new ArrayList<>();
+        List<Long> approved = new ArrayList<>();
+        List<Long> rejected = new ArrayList<>();
+
+        for (long[] counts : monthMap.values()) {
+            confirmed.add(counts[0]);
+            approved.add(counts[1]);
+            rejected.add(counts[2]);
+        }
+
+        return DashboardDto.DangerStatsRes.builder()
+                .labels(labels)
+                .confirmed(confirmed)
+                .approved(approved)
+                .rejected(rejected)
+                .build();
+    }
+
+    // 본사 대시보드 지연 배송 목록 데이터 조회 메서드
+    public DashboardDto.DelayDeliveryRes getDelayDeliveryList(int page, int size) {
+        // 지연 배송 목록: status가 DELAY인 배송
+        Slice<Delivery> slice = deliveryRepository.findByDeliveryStatus(DeliveryStatus.DELAY, PageRequest.of(page, size));
+
+        List<DashboardDto.DeliveryItem> items = slice.getContent().stream().map(DashboardDto.DeliveryItem::from).toList();
+
+        return DashboardDto.DelayDeliveryRes.builder()
+                .items(items)
+                .hasNext(slice.hasNext())
+                .build();
+    }
+
+    // 본사 대시보드 배송 비율 데이터 조회 메서드
     public DashboardDto.DeliveryRatioRes getDeliveryRatio() {
         // 최근 한달 기준 배송 상태별 건수 조회
         LocalDateTime monthAgo = LocalDate.now().minusMonths(1).atStartOfDay();
@@ -213,49 +258,6 @@ public class DashboardService {
                 .delivering(delivering)
                 .delivered(delivered)
                 .delay(delay)
-                .build();
-    }
-
-    public DashboardDto.InventoryKpiRes getInventoryKpi() {
-        long lowCount = headInventoryRepository.countByStatus(InventoryStatus.LOW);
-        long criticalCount = headInventoryRepository.countByStatus(InventoryStatus.CRITICAL);
-
-        return DashboardDto.InventoryKpiRes.builder()
-                .lowCount(lowCount)
-                .criticalCount(criticalCount)
-                .totalDangerCount(lowCount + criticalCount)
-                .build();
-    }
-
-    public DashboardDto.DangerInventoryRes getDangerInventoryList(int page, int size) {
-        // 위험 재고: status가 LOW 또는 CRITICAL인 본사 재고 목록
-        List<InventoryStatus> dangerStatuses = List.of(InventoryStatus.LOW, InventoryStatus.CRITICAL);
-
-        Slice<HeadInventory> slice =
-                headInventoryRepository.findByStatusIn(dangerStatuses, PageRequest.of(page, size));
-
-        List<DashboardDto.DangerInventoryItem> items = slice.getContent().stream()
-                .map(DashboardDto.DangerInventoryItem::from)
-                .toList();
-
-        return DashboardDto.DangerInventoryRes.builder()
-                .items(items)
-                .hasNext(slice.hasNext())
-                .build();
-    }
-
-    public DashboardDto.DelayDeliveryRes getDelayDeliveryList(int page, int size) {
-        // 지연 배송 목록: status가 DELAY인 배송
-        Slice<com.example.nexus.domain.delivery.model.Delivery> slice =
-                deliveryRepository.findByDeliveryStatus(DeliveryStatus.DELAY, PageRequest.of(page, size));
-
-        List<DashboardDto.DeliveryItem> items = slice.getContent().stream()
-                .map(DashboardDto.DeliveryItem::from)
-                .toList();
-
-        return DashboardDto.DelayDeliveryRes.builder()
-                .items(items)
-                .hasNext(slice.hasNext())
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -30,8 +30,8 @@ import java.util.List;
 public class DashboardService {
     private final StoreRepository storeRepository;
     private final OrdersRepository ordersRepository;
-    private final DeliveryRepository deliveryRepository;
     private final HeadInventoryRepository headInventoryRepository;
+    private final DeliveryRepository deliveryRepository;
 
     // 본사 대시보드 입점 매장 카드 데이터 조회 메서드
     public DashboardDto.StoreKpiRes getStoreKpi() {

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -31,7 +31,6 @@ public class DashboardDto {
     public static class DeliveryKpiRes {
         private long ongoingCount;
         private long delayCount;
-        private List<DeliveryItem> deliveryList;
     }
 
     @Getter

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
@@ -53,17 +53,6 @@ public class DeliveryController {
         return ResponseEntity.ok(response);
     }
 
-    // 본사 배송 승인 (READY → START + 점주 배송 시작 알림)
-    @PatchMapping("/head/{deliveryIdx}/approve")
-    public ResponseEntity<String> approveDelivery(@PathVariable Long deliveryIdx) {
-        boolean isSuccess = deliveryService.approveDelivery(deliveryIdx);
-        if (isSuccess) {
-            return ResponseEntity.ok("배송이 승인되었습니다.");
-        } else {
-            return ResponseEntity.badRequest().body("승인할 수 없는 배송 상태입니다.");
-        }
-    }
-
     // 본사 배송 지연 사유 입력
     @PatchMapping("/head/{deliveryIdx}/delayreason")
     public ResponseEntity<String> updateDelayReason(

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -19,10 +19,10 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     // 발주 승인용 - 주문 기준 배송 조회
     Delivery findByOrders(Orders orders);
 
-    // 스케줄러용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
+    // 알림 스케줄러용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
     List<Delivery> findByDeliveryStatusAndDepartureDateBefore(DeliveryStatus status, LocalDateTime before);
 
-    // 스케줄러용 - 예상도착일 초과 + 미완료 배송 조회
+    // 알림 스케줄러용 - 예상도착일 초과 + 미완료 배송 조회
     @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s " +
             "WHERE d.estimatedArrivalAt < :now " +
             "AND d.deliveryStatus NOT IN (:excludeStatuses)")

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -14,34 +14,15 @@ import java.util.List;
 
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
-    // 대시보드용 - 본사 대시보드 진행중 배송 건수 KPI (여러 상태 합산)
-    long countByDeliveryStatusIn(List<DeliveryStatus> statuses);
-
-    // 대시보드용 - 본사 대시보드 특정 상태 배송 건수
-    long countByDeliveryStatus(DeliveryStatus status);
-
-    // 대시보드용 - 본사 대시보드 배송 비율 계산 (최근 한달 상태별 건수)
-    long countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus status, LocalDateTime since);
-
-    // 대시보드용 - 본사 대시보드 지연 배송 전체 목록 조회
-    List<Delivery> findAllByDeliveryStatus(DeliveryStatus status);
-
-    // 대시보드용 - 본사 대시보드 지연 배송 목록 무한스크롤 페이징
-    Slice<Delivery> findByDeliveryStatus(DeliveryStatus status, Pageable pageable);
-
-    // 점주 대시보드용 - 나의 배송 현황 목록 (배송완료 제외, 최신순)
-    List<Delivery> findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc(Long storeIdx, DeliveryStatus excludeStatus);
-
-    List<Delivery> findByDeliveryStatus(DeliveryStatus status);
-
     Delivery findByIdx(Long deliveryIdx);
 
+    // 발주 승인용 - 주문 기준 배송 조회
     Delivery findByOrders(Orders orders);
 
-    // 배송 상태 자동 전환용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
+    // 스케줄러용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
     List<Delivery> findByDeliveryStatusAndDepartureDateBefore(DeliveryStatus status, LocalDateTime before);
 
-    // 배송 지연 자동 감지용 - 예상도착일 초과 + 미완료 배송 조회
+    // 스케줄러용 - 예상도착일 초과 + 미완료 배송 조회
     @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s " +
             "WHERE d.estimatedArrivalAt < :now " +
             "AND d.deliveryStatus NOT IN (:excludeStatuses)")
@@ -49,7 +30,7 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             @Param("now") LocalDateTime now,
             @Param("excludeStatuses") List<DeliveryStatus> excludeStatuses);
 
-    // 본사 배송 조회용
+    // 본사 배송 관리 - 필터 조회
     @Query("SELECT d FROM Delivery d " +
             "JOIN FETCH d.orders o " +
             "JOIN FETCH o.store s " +
@@ -65,11 +46,11 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             @Param("month") Integer month,
             @Param("day") Integer day);
 
-    // 본인 가맹점 배송 현황 조회
+    // 가맹점 배송 현황 - 전체 조회
     @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s WHERE s.idx = :storeIdx")
     List<Delivery> findAllByOrdersStoreIdx(@Param("storeIdx") Long storeIdx);
 
-    // 가맹점 배송 현황 필터 및 발주번호 검색 조회
+    // 가맹점 배송 현황 - 필터 및 발주번호 검색 조회
     @Query("SELECT d FROM Delivery d " +
             "JOIN FETCH d.orders o " +
             "JOIN FETCH o.store s " +
@@ -86,5 +67,20 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             @Param("year") Integer year,
             @Param("month") Integer month,
             @Param("day") Integer day);
+
+    // 본사 대시보드 - 진행중 배송 건수 KPI (여러 상태 합산)
+    long countByDeliveryStatusIn(List<DeliveryStatus> statuses);
+
+    // 본사 대시보드 - 특정 상태 배송 건수 KPI
+    long countByDeliveryStatus(DeliveryStatus status);
+
+    // 본사 대시보드 - 배송 비율 계산 (최근 한달 상태별 건수)
+    long countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus status, LocalDateTime since);
+
+    // 본사 대시보드 - 지연 배송 목록 무한스크롤 페이징
+    Slice<Delivery> findByDeliveryStatus(DeliveryStatus status, Pageable pageable);
+
+    // 점주 대시보드 - 나의 배송 현황 목록 (배송완료 제외, 최신순)
+    List<Delivery> findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc(Long storeIdx, DeliveryStatus excludeStatus);
 }
 

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -2,6 +2,7 @@ package com.example.nexus.domain.delivery;
 
 import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.domain.delivery.model.Delivery;
+import com.example.nexus.domain.orders.model.Orders;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -34,6 +35,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     List<Delivery> findByDeliveryStatus(DeliveryStatus status);
 
     Delivery findByIdx(Long deliveryIdx);
+
+    Delivery findByOrders(Orders orders);
 
     // 배송 상태 자동 전환용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
     List<Delivery> findByDeliveryStatusAndDepartureDateBefore(DeliveryStatus status, LocalDateTime before);

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -53,27 +53,6 @@ public class DeliveryService {
                 orders.getStore());
     }
 
-    // 배송 승인: READY → START + 점주 배송 시작 알림 (NOTIFY_014)
-    @Transactional
-    public boolean approveDelivery(Long deliveryIdx) {
-        Delivery delivery = deliveryRepository.findByIdx(deliveryIdx);
-        if (delivery == null || delivery.getDeliveryStatus() != DeliveryStatus.READY) {
-            return false;
-        }
-
-        delivery.setDeliveryStatus(DeliveryStatus.START);
-
-        String storeName = delivery.getOrders().getStore().getStoreName();
-        storeNotificationService.create(
-                NotificationType.DELIVERY_START,
-                "배송 시작 안내",
-                "주문하신 상품의 배송이 시작되었습니다. 예상 도착일: "
-                        + delivery.getEstimatedArrivalAt().toLocalDate(),
-                delivery.getOrders().getStore());
-
-        return true;
-    }
-
     public List<DeliveryDto> getDeliveriesByHead(
             String storeName, DeliveryStatus status, Integer year, Integer month, Integer day) {
         return deliveryRepository.findAllByFilters(storeName, status, year, month, day)

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -24,7 +24,7 @@ public class DeliveryService {
     private final HeadNotificationService headNotificationService;
     private final StoreNotificationService storeNotificationService;
 
-    // 발주 승인 시 배송 생성 (READY 상태)
+    // 점주 발주 확정 시 배송 생성 (READY 상태)
     @Transactional
     public void createDelivery(Orders orders) {
         Delivery delivery = Delivery.builder()
@@ -34,6 +34,23 @@ public class DeliveryService {
                 .orders(orders)
                 .build();
         deliveryRepository.save(delivery);
+    }
+
+    // 본사 발주 승인 시 배송 시작 (READY → START) + 점주 알림
+    @Transactional
+    public void startDeliveryByOrders(Orders orders) {
+        Delivery delivery = deliveryRepository.findByOrders(orders);
+        if (delivery == null || delivery.getDeliveryStatus() != DeliveryStatus.READY) {
+            return;
+        }
+        delivery.setDeliveryStatus(DeliveryStatus.START);
+
+        storeNotificationService.create(
+                NotificationType.DELIVERY_START,
+                "배송 시작 안내",
+                "주문하신 상품의 배송이 시작되었습니다. 예상 도착일: "
+                        + delivery.getEstimatedArrivalAt().toLocalDate(),
+                orders.getStore());
     }
 
     // 배송 승인: READY → START + 점주 배송 시작 알림 (NOTIFY_014)

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadController.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadController.java
@@ -1,12 +1,16 @@
 package com.example.nexus.domain.head;
 
+import com.example.nexus.domain.head.model.HeadIncomeDto;
 import com.example.nexus.domain.head.model.HeadInventoryDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RequestMapping("/head")
@@ -14,11 +18,25 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HeadController {
     private final HeadService headService;
+    private final HeadIncomeService headIncomeService;
 
     // 본사 재고 조회
     @GetMapping("/inventory/list")
     public ResponseEntity<List<HeadInventoryDto.ListRes>> list(){
         List<HeadInventoryDto.ListRes> result = headService.list();
+        return ResponseEntity.ok(result);
+    }
+
+    // 본사 정산 내역 조회
+    @GetMapping("/income")
+    public ResponseEntity<List<HeadIncomeDto.ListRes>> getIncomeList(
+            @RequestParam(required = false) String storeName,
+            @RequestParam(required = false) Boolean status,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        List<HeadIncomeDto.ListRes> result = headIncomeService.getIncomeList(storeName, status, startDate, endDate);
         return ResponseEntity.ok(result);
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java
@@ -2,7 +2,9 @@ package com.example.nexus.domain.head;
 
 import com.example.nexus.domain.head.model.HeadIncome;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface HeadIncomeRepository extends JpaRepository<HeadIncome, Long> {
@@ -11,4 +13,12 @@ public interface HeadIncomeRepository extends JpaRepository<HeadIncome, Long> {
     List<HeadIncome> findBySettlementIdx(Long idx);
 
     HeadIncome findByOrdersIdx(Long orderIdx);
+
+    @Query("SELECT hi FROM HeadIncome hi " +
+            "JOIN hi.orders o " +
+            "WHERE (:storeName IS NULL OR hi.store.storeName LIKE %:storeName%) " +
+            "AND (:status IS NULL OR hi.status = :status) " +
+            "AND (:startDate IS NULL OR FUNCTION('DATE', o.createdAt) >= :startDate) " +
+            "AND (:endDate IS NULL OR FUNCTION('DATE', o.createdAt) <= :endDate)")
+    List<HeadIncome> findByFilters(String storeName, Boolean status, LocalDate startDate, LocalDate endDate);
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java
@@ -36,15 +36,18 @@ public class HeadIncomeService {
     // ordersIdx 로 HeadIncome을 찾기
     public HeadIncomeDto.FindHeadIncomeRes findByOrdersIdx(Long ordersIdx) {
         HeadIncome headIncome = headIncomeRepository.findByOrdersIdx(ordersIdx);
-        HeadIncomeDto.FindHeadIncomeRes resDto = HeadIncomeDto.FindHeadIncomeRes.builder()
-                .idx(headIncome.getIdx())
-                .price(headIncome.getPrice())
-                .paid(headIncome.getStatus())
-                .settlementIdx(headIncome.getSettlementIdx())
-                .storeIdx(headIncome.getStore().getIdx())
-                .ordersIdx(headIncome.getOrders().getIdx())
-                .build();
-        return  resDto;
+        if (headIncome != null) {
+            HeadIncomeDto.FindHeadIncomeRes resDto = HeadIncomeDto.FindHeadIncomeRes.builder()
+                    .idx(headIncome.getIdx())
+                    .price(headIncome.getPrice())
+                    .paid(headIncome.getStatus())
+                    .settlementIdx(headIncome.getSettlementIdx())
+                    .storeIdx(headIncome.getStore().getIdx())
+                    .ordersIdx(headIncome.getOrders().getIdx())
+                    .build();
+            return resDto;
+        }
+        return null;
     }
 
 

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java
@@ -6,8 +6,10 @@ import com.example.nexus.domain.orders.model.Orders;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -48,5 +50,35 @@ public class HeadIncomeService {
     }
 
 
+    public List<HeadIncomeDto.ListRes> getIncomeList(
+            String storeName, Boolean status, LocalDate startDate, LocalDate endDate) {
 
+        List<HeadIncome> incomes = headIncomeRepository.findByFilters(storeName, status, startDate, endDate);
+
+        List<HeadIncomeDto.ListRes> result = new ArrayList<>();
+
+        for (HeadIncome income : incomes) {
+
+            LocalDate orderDate = LocalDate.now();
+            if (income.getOrders() != null && income.getOrders().getCreatedAt() != null) {
+                orderDate = income.getOrders().getCreatedAt().toLocalDate();
+            }
+
+            HeadIncomeDto.ListRes dto = HeadIncomeDto.ListRes.builder()
+                    .headIncomeIdx(income.getIdx())
+                    .storeIdx(income.getStore().getIdx())
+                    .storeName(income.getStore().getStoreName())
+                    .periodStart(orderDate.withDayOfMonth(1))
+                    .periodEnd(orderDate.withDayOfMonth(orderDate.lengthOfMonth()))
+                    .totalPrice(income.getPrice())
+                    .status(income.getStatus())
+                    .settlementIdx(income.getSettlementIdx())
+                    .orderCount(1)
+                    .build();
+
+            result.add(dto);
+        }
+
+        return result;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/model/HeadIncomeDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/model/HeadIncomeDto.java
@@ -3,6 +3,8 @@ package com.example.nexus.domain.head.model;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 public class HeadIncomeDto {
 
     @Builder
@@ -30,4 +32,17 @@ public class HeadIncomeDto {
         private Long ordersIdx;
     }
 
+    @Getter
+    @Builder
+    public static class ListRes {
+        private Long headIncomeIdx;
+        private Long storeIdx;
+        private String storeName;
+        private LocalDate periodStart;
+        private LocalDate periodEnd;
+        private int orderCount;
+        private Long totalPrice;
+        private Boolean status;
+        private Long settlementIdx;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -13,6 +13,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -31,6 +35,7 @@ public class MenuService {
     private final ProductRepository productRepository;
 
     private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
 
     @Value("${spring.cloud.aws.s3.menu-bucket}")
     private String menuBucket;
@@ -123,40 +128,80 @@ public class MenuService {
 
     @Transactional
     public void menuUpdate(Long menuIdx, MenuDto.MenuRegReq dto) {
-        Menu menu = menuRepository.findByIdxAndIsDeletedFalse(menuIdx)
-                .orElseThrow(() -> new BaseException(NOT_FOUND_MENU));
+        String newFilePath = dto.getImgPath();
+        String oldFilePath = "";
 
-        // 메뉴명 중복 확인
-        if (menuRepository.existsByMenuNameAndIdxNot(dto.getMenuName(), menuIdx)) {
-            throw new BaseException(DUPLICATE_MENU_NAME);
+        try{
+            Menu menu = menuRepository.findByIdxAndIsDeletedFalse(menuIdx)
+                    .orElseThrow(() -> new BaseException(NOT_FOUND_MENU));
+
+            // 카테고리 존재 여부 확인
+            MenuCategory category = menuCategoryRepository.findById(dto.getMenuCategoryIdx())
+                    .orElseThrow(() -> new BaseException(NOT_FOUND_CATEGORY));
+
+            oldFilePath = menu.getImgPath();
+
+            // 메뉴명 중복 확인
+            if (menuRepository.existsByMenuNameAndIdxNot(dto.getMenuName(), menuIdx)) {
+                throw new BaseException(DUPLICATE_MENU_NAME);
+            }
+
+
+            // 제품 조회
+            List<Long> productIds = Optional.ofNullable(dto.getMenuItemList()).orElseGet(Collections::emptyList).stream()
+                    .map(MenuDto.MenuItemReq::getProductIdx).toList();
+            List<Product> products = productRepository.findAllById(productIds);
+
+            // 4. [S3 관리 로직] 커밋 직전에 등록
+            // 새 파일이 들어왔고, 기존 파일과 다를 경우에만 동기화 등록
+            if (newFilePath != null && !newFilePath.equals(oldFilePath)) {
+                String finalOldFile = oldFilePath;
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        // DB 커밀이 성공하면 S3에서 옛날 파일을 지움
+                        deleteS3Object(finalOldFile);
+                    }
+                });
+            }
+
+            // 메뉴 업데이트
+            menu.update(dto.getMenuName(), dto.getPrice(), dto.getImgPath(), category);
+
+            // 해당 메뉴에 재료 리스트(MenuItem) 비우기
+            menu.getMenuItemList().clear();
+
+            Map<Long, Product> productMap = products.stream()
+                    .collect(Collectors.toMap(Product::getIdx, p -> p));
+
+            for (MenuDto.MenuItemReq itemReq : Optional.ofNullable(dto.getMenuItemList()).orElseGet(Collections::emptyList)) {
+                Product product = productMap.get(itemReq.getProductIdx());
+                if (product == null) throw new BaseException(NOT_FOUND_PRODUCT);
+
+                // 기존에 잘 만들어둔 toEntity를 그대로 활용합니다!
+                MenuItem newItem = itemReq.toEntity(menu, product);
+                menu.getMenuItemList().add(newItem);
+            }
+
+        }catch (Exception e) {
+            if (newFilePath != null && !newFilePath.equals(oldFilePath)) {
+                deleteS3Object(newFilePath); // 새 파일 롤백 삭제
+            }
+
+            if (e instanceof BaseException) throw (BaseException) e;
+            throw new RuntimeException(e);
         }
+    }
 
-
-        // 카테고리 존재 여부 확인
-        MenuCategory category = menuCategoryRepository.findById(dto.getMenuCategoryIdx())
-                .orElseThrow(() -> new BaseException(NOT_FOUND_CATEGORY));
-
-        // 제품 조회
-        List<Long> productIds = Optional.ofNullable(dto.getMenuItemList()).orElseGet(Collections::emptyList).stream()
-                .map(MenuDto.MenuItemReq::getProductIdx).toList();
-        List<Product> products = productRepository.findAllById(productIds);
-
-        // 메뉴 업데이트
-        menu.update(dto.getMenuName(), dto.getPrice(), dto.getImgPath(), category);
-
-        // 해당 메뉴에 재료 리스트(MenuItem) 비우기
-        menu.getMenuItemList().clear();
-
-        Map<Long, Product> productMap = products.stream()
-                .collect(Collectors.toMap(Product::getIdx, p -> p));
-
-        for (MenuDto.MenuItemReq itemReq : Optional.ofNullable(dto.getMenuItemList()).orElseGet(Collections::emptyList)) {
-            Product product = productMap.get(itemReq.getProductIdx());
-            if (product == null) throw new BaseException(NOT_FOUND_PRODUCT);
-
-            // 기존에 잘 만들어둔 toEntity를 그대로 활용합니다!
-            MenuItem newItem = itemReq.toEntity(menu, product);
-            menu.getMenuItemList().add(newItem);
+    private void deleteS3Object(String key) {
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(menuBucket)
+                    .key(key)
+                    .build());
+        } catch (Exception e) {
+            // S3 삭제 실패 시 예외를 던져서 호출부에서 인지하게 처리
+            throw new BaseException(S3_DELETE_FAILED); // BaseResponseStatus에 추가 필요
         }
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -130,7 +130,11 @@ public class MenuService {
             // 4. 예외 발생 시 S3 롤백 삭제
             // 등록 중 에러가 나면 DB는 롤백되지만, 이미 업로드된 파일은 좀비가 되므로 삭제 처리
             if (newFilePath != null && !newFilePath.isEmpty()) {
-                deleteS3Object(newFilePath);
+                try {
+                    deleteS3Object(newFilePath);
+                } catch (Exception ignored) {
+                    // 롤백 중 S3 삭제 실패는 무시하여 원래 예외를 보존합니다.
+                }
             }
 
             // 5. 예외 다시 던지기
@@ -168,12 +172,11 @@ public class MenuService {
 
             // 4. [S3 관리 로직] 커밋 직전에 등록
             // 새 파일이 들어왔고, 기존 파일과 다를 경우에만 동기화 등록
-            if (newFilePath != null && !newFilePath.equals(oldFilePath)) {
+            if (newFilePath != null && !newFilePath.equals(oldFilePath) && oldFilePath != null && !oldFilePath.isBlank()) {
                 String finalOldFile = oldFilePath;
                 TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                     @Override
                     public void afterCommit() {
-                        // DB 커밀이 성공하면 S3에서 옛날 파일을 지움
                         deleteS3Object(finalOldFile);
                     }
                 });
@@ -198,8 +201,12 @@ public class MenuService {
             }
 
         }catch (Exception e) {
-            if (newFilePath != null && !newFilePath.equals(oldFilePath)) {
-                deleteS3Object(newFilePath); // 새 파일 롤백 삭제
+            if (newFilePath != null && !newFilePath.isEmpty()) {
+                try {
+                    deleteS3Object(newFilePath);
+                } catch (Exception ignored) {
+                    // 롤백 중 S3 삭제 실패는 무시하여 원래 예외를 보존합니다.
+                }
             }
 
             if (e instanceof BaseException) throw (BaseException) e;
@@ -208,14 +215,16 @@ public class MenuService {
     }
 
     private void deleteS3Object(String key) {
+        if (key == null || key.isBlank()) {
+            return;
+        }
         try {
             s3Client.deleteObject(DeleteObjectRequest.builder()
                     .bucket(menuBucket)
                     .key(key)
                     .build());
         } catch (Exception e) {
-            // S3 삭제 실패 시 예외를 던져서 호출부에서 인지하게 처리
-            throw new BaseException(S3_DELETE_FAILED); // BaseResponseStatus에 추가 필요
+            // S3 삭제 실패 시 로그를 남기거나 무시하여 원래 예외가 전파되도록 합니다.
         }
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -101,29 +101,43 @@ public class MenuService {
 
     @Transactional
     public void menuRegister(MenuDto.MenuRegReq dto) {
+        String newFilePath = dto.getImgPath();
 
-        if (menuRepository.existsByMenuName(dto.getMenuName())) {
-            throw new BaseException(DUPLICATE_MENU_NAME);
+        try {
+            if (menuRepository.existsByMenuName(dto.getMenuName())) {
+                throw new BaseException(DUPLICATE_MENU_NAME);
+            }
+
+            // 카테고리 존재 여부 확인
+            MenuCategory category = menuCategoryRepository.findById(dto.getMenuCategoryIdx())
+                    .orElseThrow(() -> new BaseException(NOT_FOUND_CATEGORY));
+
+
+            List<Long> productIds = Collections.emptyList();
+            List<Product> products = Collections.emptyList();
+
+            if (dto.getMenuItemList() != null && !dto.getMenuItemList().isEmpty()) {
+                productIds = dto.getMenuItemList().stream()
+                        .map(MenuDto.MenuItemReq::getProductIdx).toList();
+                products = productRepository.findAllById(productIds);
+            }
+
+
+            Menu menu = dto.toEntity(category, products);
+            menuRepository.save(menu);
+
+        } catch (Exception e) {
+            // 4. 예외 발생 시 S3 롤백 삭제
+            // 등록 중 에러가 나면 DB는 롤백되지만, 이미 업로드된 파일은 좀비가 되므로 삭제 처리
+            if (newFilePath != null && !newFilePath.isEmpty()) {
+                deleteS3Object(newFilePath);
+            }
+
+            // 5. 예외 다시 던지기
+            if (e instanceof BaseException) throw (BaseException) e;
+            throw new RuntimeException(e);
         }
 
-        // 카테고리 존재 여부 확인
-        MenuCategory category = menuCategoryRepository.findById(dto.getMenuCategoryIdx())
-                .orElseThrow(() -> new BaseException(NOT_FOUND_CATEGORY));
-
-
-        List<Long> productIds = Collections.emptyList();
-        List<Product> products = Collections.emptyList();
-
-        if (dto.getMenuItemList() != null && !dto.getMenuItemList().isEmpty()) {
-            productIds = dto.getMenuItemList().stream()
-                    .map(MenuDto.MenuItemReq::getProductIdx).toList();
-            products = productRepository.findAllById(productIds);
-        }
-
-
-        Menu menu = dto.toEntity(category, products);
-
-        menuRepository.save(menu);
     }
 
     @Transactional

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -201,7 +201,7 @@ public class MenuService {
             }
 
         }catch (Exception e) {
-            if (newFilePath != null && !newFilePath.isEmpty()) {
+            if (newFilePath != null && !newFilePath.isEmpty() && !newFilePath.equals(oldFilePath)) {
                 try {
                     deleteS3Object(newFilePath);
                 } catch (Exception ignored) {

--- a/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
@@ -104,10 +104,12 @@ public class MenuDto {
     @Getter
     @Builder
     public static class MenuCategoryRes{
+        private Long categoryIdx;
         private String menuCategoryName;
 
         public static MenuDto.MenuCategoryRes from(MenuCategory entity){
             return MenuCategoryRes.builder()
+                    .categoryIdx(entity.getIdx())
                     .menuCategoryName(entity.getMenuCategoryName())
                     .build();
         }

--- a/backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/NotificationScheduler.java
@@ -31,12 +31,12 @@ public class NotificationScheduler {
     /**
      * 유통기한 임박 알림
      * 매일 오전 7시에 실행
-     * 제조일 + dangerDays 기준으로 유통기한 7일 이내 제품 감지
+     * 제조일 + dangerDays 기준으로 유통기한 3일 이내 제품 감지
      */
     @Scheduled(cron = "0 0 7 * * *")
     public void checkExpiryNotification() {
         // 유통기한 만료까지 며칠 이내일 때 알림을 보낼지 설정
-        int alertDays = 7;
+        int alertDays = 3;
         LocalDateTime now = LocalDateTime.now();
 
         // 재고 수량이 1 이상인 제품만 조회 (재고 없으면 의미 없으므로)
@@ -52,7 +52,7 @@ public class NotificationScheduler {
             // 만료일까지 남은 일수 계산
             long daysUntilExpiry = java.time.Duration.between(now, expiryDate).toDays();
 
-            // 만료일이 7일 이내이고, 아직 만료되지 않은 경우에만 알림
+            // 만료일이 3일 이내이고, 아직 만료되지 않은 경우에만 알림
             if (daysUntilExpiry <= alertDays && daysUntilExpiry >= 0) {
                 String productName = inventory.getProduct().getProductName();
                 String title = "유통기한 임박 - " + productName;
@@ -95,48 +95,48 @@ public class NotificationScheduler {
      * 배송 상태 자동 전환
      * 10분마다 실행
      * START + 1시간 경과 → DELIVERYING
-     * START + 1일 경과 → DELIVERED + 점주 배송 완료 알림 (NOTIFY_015)
+     * DELIVERYING + 1일 경과 → DELIVERED + 점주 배송 완료 알림
      */
     @Scheduled(cron = "0 */10 * * * *")
     @Transactional
     public void updateDeliveryStatus() {
         LocalDateTime now = LocalDateTime.now();
 
-        // START + 1일 경과 → DELIVERED (먼저 체크하여 1시간/1일 모두 경과한 건은 바로 완료 처리)
+        // START + 1시간 경과 → DELIVERYING
+        List<Delivery> toDelivering = deliveryRepository.findByDeliveryStatusAndDepartureDateBefore(
+                DeliveryStatus.START, now.minusHours(1));
+
+        for (Delivery delivery : toDelivering) {
+            delivery.setDeliveryStatus(DeliveryStatus.DELIVERYING);
+        }
+
+        // DELIVERYING + 1일 경과 → DELIVERED + 점주 배송 완료 알림
         List<Delivery> toDeliver = deliveryRepository.findByDeliveryStatusAndDepartureDateBefore(
-                DeliveryStatus.START, now.minusDays(1));
+                DeliveryStatus.DELIVERYING, now.minusDays(1));
+
         for (Delivery delivery : toDeliver) {
             delivery.setDeliveryStatus(DeliveryStatus.DELIVERED);
             delivery.setDeliveredDate(now);
 
-            // 점주 배송 완료 알림 (NOTIFY_015)
             storeNotificationService.create(
                     NotificationType.DELIVERED,
                     "배송 완료 안내",
                     "주문하신 상품의 배송이 완료되었습니다.",
                     delivery.getOrders().getStore());
         }
-
-        // START + 1시간 경과 → DELIVERYING
-        List<Delivery> toDelivering = deliveryRepository.findByDeliveryStatusAndDepartureDateBefore(
-                DeliveryStatus.START, now.minusHours(1));
-        for (Delivery delivery : toDelivering) {
-            delivery.setDeliveryStatus(DeliveryStatus.DELIVERYING);
-        }
     }
 
     /**
      * 배송 지연 자동 감지
      * 매일 오전 8시에 실행
-     * 예상도착일 초과 + 미완료 배송 → 점주/운영자 알림 (NOTIFY_016)
+     * 예상도착일 초과 + 미완료 배송 → 점주/운영자 알림
      */
     @Scheduled(cron = "0 0 8 * * *")
     @Transactional
     public void checkDeliveryDelay() {
         LocalDateTime now = LocalDateTime.now();
 
-        List<Delivery> overdueDeliveries = deliveryRepository.findOverdueDeliveries(
-                now, List.of(DeliveryStatus.DELIVERED, DeliveryStatus.DELAY));
+        List<Delivery> overdueDeliveries = deliveryRepository.findOverdueDeliveries(now, List.of(DeliveryStatus.DELIVERED, DeliveryStatus.DELAY));
 
         for (Delivery delivery : overdueDeliveries) {
             String storeName = delivery.getOrders().getStore().getStoreName();
@@ -153,6 +153,9 @@ public class NotificationScheduler {
                     "배송 지연 안내",
                     "예상 도착일(" + delivery.getEstimatedArrivalAt().toLocalDate() + ")이 초과되었습니다. 본사에서 확인 중입니다.",
                     delivery.getOrders().getStore());
+
+            // 지연 처리 완료 → 다음 스케줄러 실행 시 중복 알림 방지
+            delivery.setDeliveryStatus(DeliveryStatus.DELAY);
         }
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -30,7 +30,7 @@ public class OrdersController {
     private final OrdersService orderService;
 
     /**
-     * 자동 발주 목록 조회
+     * 자동 발주 목록 조회 겸 검색
      *
      * @param keyword 검색 키워드 (선택)
      * @param page 페이지 번호 (기본값: 0)
@@ -43,12 +43,14 @@ public class OrdersController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        Page<OrdersDto.OrderListRes> result = orderService.findAllAuto(keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+        Page<OrdersDto.OrderListRes> result = orderService.findAllAuto(
+                keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
 
     /**
-     * 확정 발주 목록 조회
+     * 확정 발주 목록 조회 겸 검색
      *
      * @param keyword 검색 키워드 (선택)
      * @param page 페이지 번호 (기본값: 0)
@@ -67,7 +69,18 @@ public class OrdersController {
     }
 
     /**
-     * 발주 이력 목록 조회
+     * 확정 발주 일괄 승인
+     *
+     * @return ResponseEntity 일괄 승인 결과 메시지
+     */
+    @PutMapping("/confirmed/approve")
+    public ResponseEntity approveAll() {
+        orderService.approveAllConfirmed();
+        return ResponseEntity.ok(BaseResponse.success("update success"));
+    }
+
+    /**
+     * 발주 이력 목록 조회 겸 검색
      *
      * @param ordersType 발주 유형 필터 (선택)
      * @param startDate 조회 시작일 (선택)
@@ -93,7 +106,7 @@ public class OrdersController {
     }
 
     /**
-     * 위험 발주 목록 조회
+     * 이상 발주 목록 조회 겸 검색
      *
      * @param startDate 조회 시작일 (선택)
      * @param endDate 조회 종료일 (선택)
@@ -129,7 +142,7 @@ public class OrdersController {
     }
 
     /**
-     * 위험 발주 기준 설정 조회
+     * 이상 발주 기준 설정 조회
      *
      * @return ResponseEntity 위험 발주 기준 설정 정보
      */
@@ -140,7 +153,7 @@ public class OrdersController {
     }
 
     /**
-     * 위험 발주 기준 설정 수정
+     * 이상 발주 기준 설정 수정
      *
      * @param req 위험 발주 기준 설정 요청 데이터
      * @return ResponseEntity 수정 결과 메시지
@@ -172,17 +185,6 @@ public class OrdersController {
     @PutMapping("/{ordersIdx}/reject")
     public ResponseEntity reject(@PathVariable Long ordersIdx) {
         orderService.reject(ordersIdx);
-        return ResponseEntity.ok(BaseResponse.success("update success"));
-    }
-
-    /**
-     * 확정 발주 일괄 승인
-     *
-     * @return ResponseEntity 일괄 승인 결과 메시지
-     */
-    @PutMapping("/confirmed/approve")
-    public ResponseEntity approveAll() {
-        orderService.approveAllConfirmed();
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -15,23 +15,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecificationExecutor<Orders> {
-    // 발주용 - 점주 제안 발주서 조회 (매장별 특정 상태)
-    List<Orders> findAllByStore_IdxAndOrdersStatus(Long storeIdx, OrdersStatus orderStatus);
-
-    // 발주용 - 점주 발주 이력 페이징 조회
-    Page<Orders> findAllByStore_IdxAndOrdersStatusIn(Long storeIdx, List<OrdersStatus> ordersStatuses, Pageable pageable);
-
-    // 발주용 - 본사 확정 발주 일괄 승인 대상 조회
-    List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
-
-    // 발주용 - 이상 발주 목록 조회 (위험 플래그 기준)
-    List<Orders> findAllByIsDangerTrue();
-
-    // 발주용 - 이상 발주 판별을 위한 매장별 평균 발주 수량 계산
-    @Query("SELECT COALESCE(SUM(i.count), 0) / GREATEST(COUNT(DISTINCT o.idx), 1) " +
-            "FROM Orders o JOIN o.ordersItemList i " +
-            "WHERE o.store.idx = :storeIdx AND o.createdAt >= :since AND (:excludeIdx IS NULL OR o.idx <> :excludeIdx)")
-    Integer findAvgQtyByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("since") LocalDateTime since, @Param("excludeIdx") Long excludeIdx);
 
     // 정산용 - 매장별 전체 주문 목록 조회
     List<Orders> findAllByStoreIdx(Long storeIdx);
@@ -45,13 +28,6 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     // 본사 대시보드 - 이상 발주 건수 KPI
     long countByIsDangerTrue();
 
-    // 본사 대시보드 - 이상 발주 월별 추이 차트 (상태별 그룹핑)
-    @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus, COUNT(o) " +
-            "FROM Orders o WHERE o.isDanger = true AND o.createdAt >= :since " +
-            "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus " +
-            "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m')")
-    List<Object[]> findDangerStatsByMonth(@Param("since") LocalDateTime since);
-
     // 본사 대시보드 - 주간 발주 추이 차트 (일별 건수)
     @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d'), COUNT(o) " +
             "FROM Orders o WHERE o.createdAt >= :since " +
@@ -59,13 +35,35 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d')")
     List<Object[]> findWeeklyOrderStats(@Param("since") LocalDateTime since);
 
+    // 본사 대시보드 - 이상 발주 월별 추이 차트 (상태별 그룹핑)
+    @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus, COUNT(o) " +
+            "FROM Orders o WHERE o.isDanger = true AND o.createdAt >= :since " +
+            "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus " +
+            "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m')")
+    List<Object[]> findDangerStatsByMonth(@Param("since") LocalDateTime since);
+
+    // 본사 발주 관리 - 본사 확정 발주 일괄 승인을 위한 대상 조회
+    List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
+
+    // 본사 발주 관리 - 이상 발주 목록 조회 (위험 플래그 기준)
+    List<Orders> findAllByIsDangerTrue();
+
+    // 본사 발주 관리 - 이상 발주 판별을 위한 매장별 평균 발주 수량 계산
+    @Query("SELECT COALESCE(SUM(i.count), 0) / GREATEST(COUNT(DISTINCT o.idx), 1) " +
+            "FROM Orders o JOIN o.ordersItemList i " +
+            "WHERE o.store.idx = :storeIdx AND o.createdAt >= :since AND (:excludeIdx IS NULL OR o.idx <> :excludeIdx)")
+    Integer findAvgQtyByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("since") LocalDateTime since, @Param("excludeIdx") Long excludeIdx);
+
     // 점주 대시보드 - 미확정 제안 발주서 개수 KPI
     long countByStore_IdxAndOrdersStatusAndOrdersType(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
-
-    // 점주 대시보드 - 미확정 제안 발주서 목록
-    List<Orders> findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
 
     // 점주 대시보드 - 기간별 승인 발주 금액 합계 (매출 KPI)
     @Query("SELECT COALESCE(SUM(o.price), 0) FROM Orders o WHERE o.store.idx = :storeIdx AND o.ordersStatus = 'APPROVE' AND o.createdAt >= :from AND o.createdAt < :to")
     long sumApprovedPriceByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
+    // 점주 제안 발주서 & 점주 대시보드  - 미확정 제안 발주서 목록
+    List<Orders> findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
+
+    // 점주 발주 관리 - 점주 이력 페이징 조회
+    Page<Orders> findAllByStore_IdxAndOrdersStatusIn(Long storeIdx, List<OrdersStatus> ordersStatuses, Pageable pageable);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -33,38 +33,39 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "WHERE o.store.idx = :storeIdx AND o.createdAt >= :since AND (:excludeIdx IS NULL OR o.idx <> :excludeIdx)")
     Integer findAvgQtyByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("since") LocalDateTime since, @Param("excludeIdx") Long excludeIdx);
 
-    // 본사 대시보드용 - 발주 유형별 최근 건수 (자동/수동 KPI)
+    // 정산용 - 매장별 전체 주문 목록 조회
+    List<Orders> findAllByStoreIdx(Long storeIdx);
+
+    // 본사 대시보드 - 발주 유형별 최근 건수 (자동/수동 KPI)
     long countByOrdersTypeAndCreatedAtAfter(OrdersType ordersType, LocalDateTime since);
 
-    // 본사 대시보드용 - 상태별 발주 건수 (확정 대기 KPI)
+    // 본사 대시보드 - 상태별 발주 건수 (확정 대기 KPI)
     long countByOrdersStatus(OrdersStatus ordersStatus);
 
-    // 본사 대시보드용 - 이상 발주 건수 KPI
+    // 본사 대시보드 - 이상 발주 건수 KPI
     long countByIsDangerTrue();
 
-    // 본사 대시보드용 - 이상 발주 월별 추이 차트 (상태별 그룹핑)
+    // 본사 대시보드 - 이상 발주 월별 추이 차트 (상태별 그룹핑)
     @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus, COUNT(o) " +
             "FROM Orders o WHERE o.isDanger = true AND o.createdAt >= :since " +
             "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m'), o.ordersStatus " +
             "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m')")
     List<Object[]> findDangerStatsByMonth(@Param("since") LocalDateTime since);
 
-    // 본사 대시보드용 - 주간 발주 추이 차트 (일별 건수)
+    // 본사 대시보드 - 주간 발주 추이 차트 (일별 건수)
     @Query("SELECT FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d'), COUNT(o) " +
             "FROM Orders o WHERE o.createdAt >= :since " +
             "GROUP BY FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d') " +
             "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%m-%d')")
     List<Object[]> findWeeklyOrderStats(@Param("since") LocalDateTime since);
 
-    // 점주 대시보드용 - 미확정 제안 발주서 개수 KPI
+    // 점주 대시보드 - 미확정 제안 발주서 개수 KPI
     long countByStore_IdxAndOrdersStatusAndOrdersType(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
 
-    // 점주 대시보드용 - 미확정 제안 발주서 목록
+    // 점주 대시보드 - 미확정 제안 발주서 목록
     List<Orders> findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
 
-    // 점주 대시보드용 - 기간별 승인 발주 금액 합계 (매출 KPI)
+    // 점주 대시보드 - 기간별 승인 발주 금액 합계 (매출 KPI)
     @Query("SELECT COALESCE(SUM(o.price), 0) FROM Orders o WHERE o.store.idx = :storeIdx AND o.ordersStatus = 'APPROVE' AND o.createdAt >= :from AND o.createdAt < :to")
     long sumApprovedPriceByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
-
-    List<Orders> findAllByStoreIdx(Long storeIdx);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -177,7 +177,7 @@ public class OrdersService {
 
         applyOutboundForOrder(orders, "발주 승인(이상) ordersIdx=");
         orders.approve();
-        deliveryService.createDelivery(orders);
+        deliveryService.startDeliveryByOrders(orders);
     }
 
     // 본사 - 이상 발주 개별 반려
@@ -201,7 +201,7 @@ public class OrdersService {
         for (Orders orders : confirmedOrders) {
             applyOutboundForOrder(orders, "발주 일괄승인 ordersIdx=");
             orders.approve();
-            deliveryService.createDelivery(orders);
+            deliveryService.startDeliveryByOrders(orders);
         }
     }
 
@@ -305,6 +305,9 @@ public class OrdersService {
                     .orders(orders)
                     .build());
         }
+
+        // 7. 배송 생성 (READY 상태)
+        deliveryService.createDelivery(orders);
     }
 
     // 점주 - 제안 발주서 목록 조회 (WAITING 상태, 현재 재고 포함)
@@ -359,6 +362,7 @@ public class OrdersService {
         }
 
         orders.confirm();
+        deliveryService.createDelivery(orders);
     }
 
     // 점주 - 제안 발주서에 품목 추가 (가격 자동 반영)

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -254,14 +254,14 @@ public class OrdersService {
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
         // 3. Product 조회 및 총 가격 계산
-        long totalprice = 0;
+        long totalPrice = 0;
         List<OrdersItem> itemList = new ArrayList<>();
 
         for (OrdersItemDto.OrdersItemReq itemReq : req.getOrdersItemList()) {
             Product product = productRepository.findById(itemReq.getProductIdx())
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
-            totalprice += (long) product.getUnitPrice() * itemReq.getCount();
+            totalPrice += (long) product.getUnitPrice() * itemReq.getCount();
 
             itemList.add(OrdersItem.builder()
                     .count(itemReq.getCount())
@@ -290,7 +290,7 @@ public class OrdersService {
 
         // 5. Orders 저장
         Orders orders = ordersRepository.save(Orders.builder()
-                .price(totalprice)
+                .price(totalPrice)
                 .ordersType(OrdersType.MANUAL)
                 .ordersStatus(OrdersStatus.CONFIRMED)
                 .isDanger(isDanger)

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -316,10 +317,17 @@ public class OrdersService {
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
         List<StoreInventory> inventoryList = storeInventoryRepository.findByStoreIdx(store.getIdx());
-        Map<Long, Integer> stockMap = inventoryList.stream()
-                .collect(Collectors.toMap(inv -> inv.getProduct().getIdx(), StoreInventory::getCount, Integer::sum));
+        Map<Long, Integer> stockMap = new HashMap<>();
+        for (StoreInventory inv : inventoryList) {
+            Long productIdx = inv.getProduct().getIdx();
+            if (stockMap.containsKey(productIdx)) {
+                stockMap.put(productIdx, stockMap.get(productIdx) + inv.getCount());
+            } else {
+                stockMap.put(productIdx, inv.getCount());
+            }
+        }
 
-        return ordersRepository.findAllByStore_IdxAndOrdersStatus(store.getIdx(), OrdersStatus.WAITING).stream()
+        return ordersRepository.findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(store.getIdx(), OrdersStatus.WAITING, OrdersType.AUTO).stream()
                 .map(order -> OrdersDto.OrdersRes.fromWithStock(order, stockMap))
                 .toList();
     }

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
@@ -15,7 +15,6 @@ public class OrdersDto {
     @Getter
     @NoArgsConstructor
     public static class OrdersReq {
-        private Long storeIdx;
         private List<OrdersItemDto.OrdersItemReq> ordersItemList;
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/settlement/SettlementController.java
+++ b/backend/src/main/java/com/example/nexus/domain/settlement/SettlementController.java
@@ -11,6 +11,7 @@ import com.example.nexus.domain.user.model.AuthUserDetails;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,6 +36,7 @@ public class SettlementController {
     @PostMapping("/pay")
     public ResponseEntity pay (@AuthenticationPrincipal AuthUserDetails authUserDetails) {
 
+        // 로그인 한 사용자의  storeIdx 가져오기
         Long storeIdx = storeService.findStoreIdx(authUserDetails.getIdx());
 
         LocalDateTime now = LocalDateTime.now();
@@ -42,30 +44,38 @@ public class SettlementController {
 
         List<Orders> ordersList = ordersService.findByStoreIdx(storeIdx);
 
-        List<Orders> thisMonthOrderList = new ArrayList<>();
+        List<Orders> lastMonthOrderList = new ArrayList<>();
 
+        YearMonth lastMonth = currentYearMonth.minusMonths(1);
+        System.out.println("지난 달 " + lastMonth);
         for (Orders orders : ordersList) {
 
             YearMonth orderYearMonth = YearMonth.from(orders.getCreatedAt());
 
-            if (currentYearMonth.equals(orderYearMonth)) {
+            if (lastMonth.equals(orderYearMonth)) {
                 // 이번 달에 결제/생성된 주문 처리 로직 작성
 
-                thisMonthOrderList.add(orders);
+                lastMonthOrderList.add(orders);
+                System.out.println(orders.getIdx());
             }
         }
+
+        // 여기까지는 지난 달 발주서 제대로 불러왔음
 
         int totalPrice = 0;
         List<Long> notPaidHeadIncomeIdxList = new ArrayList<>();
-        for (Orders orders : thisMonthOrderList) {
+        System.out.println(lastMonthOrderList.size());
+        for (Orders orders : lastMonthOrderList) {
             // 이번 달에 생성된 발주서 중 결제 안된 것들
+            System.out.println("이번달 생성된 발주서 중 결제 안된 것들 " + orders.getIdx());
             HeadIncomeDto.FindHeadIncomeRes resDto = headIncomeService.findByOrdersIdx(orders.getIdx());
-            if (!resDto.isPaid()) {
+            if (resDto != null && !resDto.isPaid()) {
+                System.out.println(resDto.getPrice());
                 totalPrice += resDto.getPrice();
                 notPaidHeadIncomeIdxList.add(resDto.getIdx());
+                System.out.println("미결제 : " + resDto.getIdx());
             }
         }
-
         SettlementDto.PayReq reqDto = SettlementDto.PayReq.builder()
                 .paymentPrice((long)totalPrice)
                 .headIncomeidxList(notPaidHeadIncomeIdxList)

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreRepository.java
@@ -23,15 +23,6 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
 
     Optional<Store> findByBusiness(String business);
 
-    // 대시보드용 - 본사 대시보드 전체 매장 수 KPI 카드
-    long countByIsDeletedFalse();
-
-    // 대시보드용 - 본사 대시보드 신규 매장 수 (기준일 이후 생성)
-    long countByIsDeletedFalseAndCreatedAtAfter(LocalDateTime since);
-
-    // 대시보드용 - 본사 대시보드 이전 기간 매장 수 (증감률 계산)
-    long countByIsDeletedFalseAndCreatedAtBefore(LocalDateTime until);
-
     // 전체 조회 시 이름 또는 주소 검색
     @Query("SELECT s FROM Store s WHERE " +
             "(s.storeName LIKE %:keyword% OR s.address LIKE %:keyword%) " +
@@ -52,4 +43,13 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
     Page<Store> findByIsDeletedFalseOrderByCreatedAtDesc(Pageable pageable); // 입점(false)
     // 검색 없이 '폐점'만 조회할 때: 최신 폐업일순 또는 등록순 정렬[cite: 7]
     Page<Store> findByIsDeletedTrueOrderByClosedAtDesc(Pageable pageable);
+
+    // 본사 대시보드용 - 전체 매장 수 KPI 카드
+    long countByIsDeletedFalse();
+
+    // 본사 대시보드용 - 신규 매장 수 (기준일 이후 생성)
+    long countByIsDeletedFalseAndCreatedAtAfter(LocalDateTime since);
+
+    // 본사 대시보드용 - 이전 기간 매장 수 (증감률 계산)
+    long countByIsDeletedFalseAndCreatedAtBefore(LocalDateTime until);
 }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreService.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreService.java
@@ -136,7 +136,11 @@ public class StoreService {
             // 5. 예외 발생 시 S3 롤백 삭제
             // 트랜잭션 도중 에러가 나면 DB는 롤백되지만, S3에 업로드된 파일은 남으므로 삭제 처리
             if (newFilePath != null && !newFilePath.isEmpty()) {
-                deleteS3Object(newFilePath);
+                try {
+                    deleteS3Object(newFilePath);
+                } catch (Exception ignored) {
+                    // 롤백 중 S3 삭제 실패는 무시하여 원래 예외를 보존합니다.
+                }
             }
 
             // 6. 예외 다시 던지기
@@ -197,7 +201,7 @@ public class StoreService {
             User owner = store.getUser();
             if (owner == null || owner.isDeleted()) throw new BaseException(NOT_FOUND_USER);
 
-            if (newFilePath != null && !newFilePath.equals(oldFilePath)) {
+            if (newFilePath != null && !newFilePath.equals(oldFilePath) && oldFilePath != null && !oldFilePath.isBlank()) {
                 String finalOldFile = oldFilePath;
                 TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                     @Override
@@ -211,8 +215,12 @@ public class StoreService {
             owner.updateOwner(dto.getOwnerName(), dto.getOwnerEmail());
 
         } catch (Exception e) {
-            if (newFilePath != null && !newFilePath.equals(oldFilePath)) {
-                deleteS3Object(newFilePath); // 새 파일 롤백 삭제
+            if (newFilePath != null && !newFilePath.isEmpty()) {
+                try {
+                    deleteS3Object(newFilePath);
+                } catch (Exception ignored) {
+                    // 롤백 중 S3 삭제 실패는 무시하여 원래 예외를 보존합니다.
+                }
             }
 
             if (e instanceof BaseException) throw (BaseException) e;
@@ -221,14 +229,16 @@ public class StoreService {
     }
 
     private void deleteS3Object(String key) {
+        if (key == null || key.isBlank()) {
+            return;
+        }
         try {
             s3Client.deleteObject(DeleteObjectRequest.builder()
                     .bucket(storeBucket)
                     .key(key)
                     .build());
         } catch (Exception e) {
-            // S3 삭제 실패 시 예외를 던져서 호출부에서 인지하게 처리
-            throw new BaseException(S3_DELETE_FAILED); // BaseResponseStatus에 추가 필요
+            // S3 삭제 실패 시 로그를 남기거나 무시하여 원래 예외가 전파되도록 합니다.
         }
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreService.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreService.java
@@ -215,7 +215,7 @@ public class StoreService {
             owner.updateOwner(dto.getOwnerName(), dto.getOwnerEmail());
 
         } catch (Exception e) {
-            if (newFilePath != null && !newFilePath.isEmpty()) {
+            if (newFilePath != null && !newFilePath.isEmpty() && !newFilePath.equals(oldFilePath)) {
                 try {
                     deleteS3Object(newFilePath);
                 } catch (Exception ignored) {

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreService.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreService.java
@@ -94,41 +94,55 @@ public class StoreService {
 
     @Transactional
     public void storeReg(StoreDto.StoreRegReq dto) {
-        // 이메일을 통한 가맹점 점주 체크
-        User owner = userRepository.findByEmail(dto.getOwnerEmail()).orElseThrow(
-                ()-> new BaseException(NOT_FOUND_USER));
+        String newFilePath = dto.getFilePath();
 
-        // 점주 중복 체크
-        storeRepository.findByUserIdx(owner.getIdx())
-                .ifPresent(s-> {
-                    throw new BaseException(ALREADY_HAS_STORE);
-                });
+        try{
+            // 이메일을 통한 가맹점 점주 체크
+            User owner = userRepository.findByEmail(dto.getOwnerEmail()).orElseThrow(
+                    ()-> new BaseException(NOT_FOUND_USER));
 
-        // 가맹점 이름 중복 체크
-        storeRepository.findByStoreName(dto.getStoreName())
-                .ifPresent(s -> {
-                    throw new BaseException(STORE_NAME_ALREADY_EXISTS);
-                });
+            // 점주 중복 체크
+            storeRepository.findByUserIdx(owner.getIdx())
+                    .ifPresent(s-> {
+                        throw new BaseException(ALREADY_HAS_STORE);
+                    });
 
-        // 가맹점 사업자 번호 중복 체크
-        storeRepository.findByBusiness(dto.getBusiness())
-                .ifPresent(s -> {
-                    throw new BaseException(BUSINESS_NUMBER_ALREADY_EXISTS);
-                });
+            // 가맹점 이름 중복 체크
+            storeRepository.findByStoreName(dto.getStoreName())
+                    .ifPresent(s -> {
+                        throw new BaseException(STORE_NAME_ALREADY_EXISTS);
+                    });
 
-        Store store = Store.builder()
-                .storeName(dto.getStoreName())
-                .postcode(dto.getPostcode())
-                .address(dto.getAddress())
-                .addressDetail(dto.getAddressDetail())
-                .filePath(dto.getFilePath())
-                .business(dto.getBusiness())
-                .createdAt(LocalDateTime.now())
-                .isDeleted(false)
-                .user(owner)
-                .build();
+            // 가맹점 사업자 번호 중복 체크
+            storeRepository.findByBusiness(dto.getBusiness())
+                    .ifPresent(s -> {
+                        throw new BaseException(BUSINESS_NUMBER_ALREADY_EXISTS);
+                    });
 
-        storeRepository.save(store);
+            Store store = Store.builder()
+                    .storeName(dto.getStoreName())
+                    .postcode(dto.getPostcode())
+                    .address(dto.getAddress())
+                    .addressDetail(dto.getAddressDetail())
+                    .filePath(dto.getFilePath())
+                    .business(dto.getBusiness())
+                    .createdAt(LocalDateTime.now())
+                    .isDeleted(false)
+                    .user(owner)
+                    .build();
+
+            storeRepository.save(store);
+        } catch (Exception e) {
+            // 5. 예외 발생 시 S3 롤백 삭제
+            // 트랜잭션 도중 에러가 나면 DB는 롤백되지만, S3에 업로드된 파일은 남으므로 삭제 처리
+            if (newFilePath != null && !newFilePath.isEmpty()) {
+                deleteS3Object(newFilePath);
+            }
+
+            // 6. 예외 다시 던지기
+            if (e instanceof BaseException) throw (BaseException) e;
+            throw new RuntimeException(e);
+        }
     }
 
     // Presigned URL을 발급 받는 로직

--- a/backend/src/main/java/com/example/nexus/utils/JwtUtil.java
+++ b/backend/src/main/java/com/example/nexus/utils/JwtUtil.java
@@ -19,7 +19,7 @@ public class JwtUtil {
                 .claim("idx", idx)
                 .claim("email", email)
                 .claim("role", role)
-                .issuedAt(new Date()).expiration(new Date(System.currentTimeMillis()+ 300000)).signWith(encodedKey).compact();
+                .issuedAt(new Date()).expiration(new Date(System.currentTimeMillis()+ 86400000)).signWith(encodedKey).compact();
 
         return jwt;
     }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -143,27 +143,27 @@ INSERT INTO menu_category (menu_category_name, is_deleted) VALUES
 -- ============================================================
 INSERT INTO menu (menu_name, price, img_path, is_deleted, menu_category_idx) VALUES
 -- 커피 (idx: 1)
-('아메리카노', 1500, '/uploads/menu/americano.jpg', false, 1),
-('카페라떼', 2500, '/uploads/menu/cafelatte.jpg', false, 1),
-('바닐라라떼', 3000, '/uploads/menu/vanillalatte.jpg', false, 1),
-('카라멜마끼아또', 3500, '/uploads/menu/caramelmacchiato.jpg', false, 1),
-('카푸치노', 2500, '/uploads/menu/cappuccino.jpg', false, 1),
+('아메리카노', 1500, 'theVenti_logo.png ', false, 1),
+('카페라떼', 2500, 'theVenti_logo.png ', false, 1),
+('바닐라라떼', 3000, 'theVenti_logo.png ', false, 1),
+('카라멜마끼아또', 3500, 'theVenti_logo.png ', false, 1),
+('카푸치노', 2500, 'theVenti_logo.png ', false, 1),
 
 -- 베버리지 (idx: 2)
-('녹차라떼', 3000, '/uploads/menu/greentealatte.jpg', false, 2),
-('초코라떼', 3000, '/uploads/menu/chocolatte.jpg', false, 2),
+('녹차라떼', 3000, 'theVenti_logo.png ', false, 2),
+('초코라떼', 3000, 'theVenti_logo.png ', false, 2),
 
 -- 아이스블렌디드 (idx: 3)
-('딸기스무디', 3500, '/uploads/menu/strawberrysmoothie.jpg', false, 3),
-('망고스무디', 3500, '/uploads/menu/mangosmoothie.jpg', false, 3),
+('딸기스무디', 3500, 'theVenti_logo.png ', false, 3),
+('망고스무디', 3500, 'theVenti_logo.png ', false, 3),
 
 -- 티 & 에이드 (idx: 4)
-('복숭아아이스티', 2500, '/uploads/menu/peachicedtea.jpg', false, 4),
-('레몬에이드', 2500, '/uploads/menu/lemonade.jpg', false, 4),
-('자몽에이드', 3000, '/uploads/menu/grapefruitade.jpg', false, 4),
-('얼그레이티', 2000, '/uploads/menu/earlgrey.jpg', false, 4),
-('캐모마일티', 2000, '/uploads/menu/chamomile.jpg', false, 4),
-('히비스커스티', 2000, '/uploads/menu/hibiscus.jpg', false, 4);
+('복숭아아이스티', 2500, 'theVenti_logo.png ', false, 4),
+('레몬에이드', 2500, 'theVenti_logo.png ', false, 4),
+('자몽에이드', 3000, 'theVenti_logo.png ', false, 4),
+('얼그레이티', 2000, 'theVenti_logo.png ', false, 4),
+('캐모마일티', 2000, 'theVenti_logo.png ', false, 4),
+('히비스커스티', 2000, 'theVenti_logo.png ', false, 4);
 
 
 -- ============================================================

--- a/frontend/src/api/menu/index.js
+++ b/frontend/src/api/menu/index.js
@@ -12,3 +12,5 @@ export const getMenuList = (searchReq, page, size) => {
 }
 
 export const getProductList = () => api.get('/product/list')
+
+export const getCategoryList = () => api.get('/menu/category/list')

--- a/frontend/src/api/menu/index.js
+++ b/frontend/src/api/menu/index.js
@@ -14,3 +14,5 @@ export const getMenuList = (searchReq, page, size) => {
 export const getProductList = () => api.get('/product/list')
 
 export const getCategoryList = () => api.get('/menu/category/list')
+
+export const getMenuItemList = (menuIdx) => api.get(`/menu/item/list/${menuIdx}`)

--- a/frontend/src/api/menu/index.js
+++ b/frontend/src/api/menu/index.js
@@ -1,6 +1,6 @@
 import api from '@/plugins/axiosinterceptor'
 
-const getMenuList = (searchReq, page, size) => {
+export const getMenuList = (searchReq, page, size) => {
   return api.get('/menu/list', {
     params: {
       keyword: searchReq.keyword,
@@ -10,3 +10,5 @@ const getMenuList = (searchReq, page, size) => {
     }
   });
 }
+
+export const getProductList = () => api.get('/product/list')

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -507,28 +507,30 @@ onMounted(() => {
           </div>
         </div>
         <div class="p-7">
-          <table class="w-full text-sm text-left">
-            <thead>
-            <tr class="border-b border-gray-100 bg-gray-50/60">
-              <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">재료번호</th>
-              <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품명</th>
-              <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-right">소요량</th>
-              <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</th>
-            </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-50">
-            <tr v-for="(item, idx) in selectedMenu?.menuItemList" :key="idx"
-                class="hover:bg-gray-50/80 transition-colors">
-              <td class="px-3 py-3 font-mono text-xs text-gray-400">R-{{ String(idx + 1).padStart(3, '0') }}</td>
-              <td class="px-3 py-3 font-semibold text-gray-800">{{ getProductName(item.productName) }}</td>
-              <td class="px-3 py-3 text-right text-gray-700 font-mono">{{ item.quantity }}</td>
-              <td class="px-3 py-3 text-gray-500">{{ item.menuUnit }}</td>
-            </tr>
-            <tr v-if="!selectedMenu?.menuItemList?.length">
-              <td colspan="4" class="px-3 py-8 text-center text-gray-400 text-sm">등록된 재료가 없습니다.</td>
-            </tr>
-            </tbody>
-          </table>
+          <div class="h-[200px] overflow-y-auto scrollbar-hide border-b border-gray-50">
+            <table class="w-full text-sm text-left">
+              <thead class="sticky top-0 z-10 bg-gray-50/90 backdrop-blur-sm"> <!-- 헤더 고정 -->
+              <tr class="border-b border-gray-100">
+                <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">재료번호</th>
+                <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">제품명</th>
+                <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-right">소요량</th>
+                <th class="px-3 py-2.5 text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</th>
+              </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-50">
+              <tr v-for="(item, idx) in selectedMenu?.menuItemList" :key="idx"
+                  class="hover:bg-gray-50/80 transition-colors">
+                <td class="px-3 py-3 font-mono text-xs text-gray-400">R-{{ String(idx + 1).padStart(3, '0') }}</td>
+                <td class="px-3 py-3 font-semibold text-gray-800">{{ getProductName(item.productName) }}</td>
+                <td class="px-3 py-3 text-right text-gray-700 font-mono">{{ item.quantity }}</td>
+                <td class="px-3 py-3 text-gray-500">{{ item.menuUnit }}</td>
+              </tr>
+              <tr v-if="!selectedMenu?.menuItemList?.length">
+                <td colspan="4" class="px-3 py-8 text-center text-gray-400 text-sm">등록된 재료가 없습니다.</td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
 
           <div class="mt-5 flex justify-end">
             <button @click="showIngredientModal = false"

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
-import {Plus, Trash2, Search, Image as ImageIcon, ChevronDown, Tag} from 'lucide-vue-next'
+import {ref, computed, onMounted, reactive} from 'vue'
+import {Plus, Search, Image as ImageIcon, ChevronDown, Tag} from 'lucide-vue-next'
+import { getProductList } from '@/api/menu/index.js'
 // ─────────────────────────────────────────────
 //  상태 관리 (카테고리 관리 관련 추가)
 // ─────────────────────────────────────────────
@@ -11,39 +12,38 @@ const newCategoryInput = ref('')
 // ─────────────────────────────────────────────
 //  상품 목록 (제품 관리에서 연동 가정)
 // ─────────────────────────────────────────────
-const products = ref([
-  { id: 'P-001', name: '더벤티 다크 로스팅 원두' },
-  { id: 'P-002', name: '1A등급 신선우유' },
-  { id: 'P-003', name: '바닐라 빈 시럽' },
-  { id: 'P-004', name: '초코 파우더' },
-  { id: 'P-005', name: '타피오카 펄' },
-  { id: 'P-006', name: '휘핑크림' },
-])
+const products = ref([])
+
+const productListRes = async () => {
+  const res  = await getProductList()
+  console.log(res.data)
+  products.value = res.data
+}
 
 // ─────────────────────────────────────────────
 //  메뉴 데이터
 // ─────────────────────────────────────────────
 const menus = ref([
   {
-    id: 'M-001', name: '아인슈페너(반절커피)', price: 3500, imageName: '', category: '커피',
+    id: '1', name: '아인슈페너(반절커피)', price: 3500, imageName: '', category: '커피',
     ingredients: [
-      { productId: 'P-001', amount: 2, unit: '샷' },
-      { productId: 'P-006', amount: 50, unit: 'ml' },
+      { productId: '1', amount: 2, unit: '샷' },
+      { productId: '6', amount: 50, unit: 'ml' },
     ]
   },
   {
-    id: 'M-002', name: '바닐라라떼', price: 3500, imageName: '', category: '커피',
+    id: '2', name: '바닐라라떼', price: 3500, imageName: '', category: '커피',
     ingredients: [
-      { productId: 'P-001', amount: 2, unit: '샷' },
-      { productId: 'P-002', amount: 250, unit: 'ml' },
-      { productId: 'P-003', amount: 3, unit: '펌프' },
+      { productId: '1', amount: 2, unit: '샷' },
+      { productId: '2', amount: 250, unit: 'ml' },
+      { productId: '3', amount: 3, unit: '펌프' },
     ]
   },
   {
-    id: 'M-003', name: '타로 버블티', price: 4300, imageName: '', category: '버블티',
+    id: '3', name: '타로 버블티', price: 4300, imageName: '', category: '버블티',
     ingredients: [
-      { productId: 'P-002', amount: 200, unit: 'ml' },
-      { productId: 'P-005', amount: 80, unit: 'g' },
+      { productId: '2', amount: 200, unit: 'ml' },
+      { productId: '5', amount: 80, unit: 'g' },
     ]
   },
 ])
@@ -193,8 +193,9 @@ function openIngredientModal(menu) {
   showIngredientModal.value = true
 }
 
-function getProductName(productId) {
-  return products.value.find(p => p.id === productId)?.name ?? productId
+function getProductName(productIdx) {
+  return products.value.find(p => p.idx === productIdx)?.name ?? productIdx
+
 }
 
 function editIngredient(idx) {
@@ -235,6 +236,7 @@ function formatPrice(price) {
   return '₩ ' + price.toLocaleString('ko-KR')
 }
 onMounted(() => {
+  productListRes()
   fetchCategories()
 })
 </script>
@@ -284,7 +286,7 @@ onMounted(() => {
         >
           <option value="">전체 제품 보기</option>
           <option v-for="product in products" :key="product.id" :value="product.id">
-            {{ product.name }}
+            {{ product.productName }}
           </option>
         </select>
         <div class="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400">
@@ -432,7 +434,7 @@ onMounted(() => {
                 <select v-model="item.productId"
                         class="w-full px-3 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] focus:ring-4 focus:ring-[#F97316]/5 transition-all">
                   <option value="">상품 선택</option>
-                  <option v-for="p in products" :key="p.id" :value="p.id">{{ p.name }}</option>
+                  <option v-for="p in products" :key="p.id" :value="p.id">{{ p.productName }}</option>
                 </select>
                 <input v-model.number="item.amount" type="number" placeholder="0" min="0" step="any"
                        class="w-full px-3 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] focus:ring-4 focus:ring-[#F97316]/5 transition-all" />
@@ -507,7 +509,7 @@ onMounted(() => {
             <tr v-for="(item, idx) in selectedMenu?.ingredients" :key="idx"
                 class="hover:bg-gray-50/80 transition-colors">
               <td class="px-3 py-3 font-mono text-xs text-gray-400">R-{{ String(idx + 1).padStart(3, '0') }}</td>
-              <td class="px-3 py-3 font-semibold text-gray-800">{{ getProductName(item.productId) }}</td>
+              <td class="px-3 py-3 font-semibold text-gray-800">{{ getProductName(item.idx) }}</td>
               <td class="px-3 py-3 text-right text-gray-700 font-mono">{{ item.amount }}</td>
               <td class="px-3 py-3 text-gray-500">{{ item.unit }}</td>
             </tr>

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -9,6 +9,7 @@ const showCategoryModal = ref(false)
 const newCategoryInput = ref('')
 const UNIT_OPTIONS = ['g', 'kg', 'ml', 'L', '개', '봉', '묶음', 'ea', '기타']
 
+
 //  상품 목록
 const products = ref([])
 const productListRes = async () => {
@@ -24,14 +25,24 @@ const pagination = reactive({
   currentPage: 0,
   currentSize: 10
 })
+
 const getMenuRes = async (page = 0)=>{
   const searchReq = {
     keyword : searchQuery.value,
-    categoryIdx: null
+    categoryIdx: selectedCategoryIdx.value
   }
 
   const res = await getMenuList(searchReq, page, pagination.currentSize)
   menus.value = res.data.result.menuList
+
+  pagination.totalPage = res.data.result.totalPage
+  pagination.totalCount = res.data.result.totalCount
+  pagination.currentPage = res.data.result.currentPage
+
+}
+const selectCategory = (idx) => {
+  selectedCategoryIdx.value = idx; // idx (Long) 저장
+  getMenuRes(0); // 페이지를 0으로 초기화하여 재조회
 }
 
 //  검색 및 필터링
@@ -43,23 +54,15 @@ const categories = ref([])
 const categoryRes = async () => {
   const res = await getCategoryList()
   categories.value = res.data.result
+  console.log(categories.value)
 }
 
+// --- 카테고리 필터링 (클라이언트 사이드) ---
 const filteredMenus = computed(() => {
-  let list = menus.value
-
-  // 제품 드롭다운 필터: 선택한 제품이 재료(ingredients)에 포함되어 있는지 확인
-  if (selectedCategoryIdx.value) {
-    list = list.filter(m => m.ingredients.some(ing => ing.productIdx === selectedCategoryIdx.value))
-  }
-
-  // 텍스트 검색 (메뉴명)
-  const q = searchQuery.value.trim().toLowerCase()
-  if (q) {
-    list = list.filter(m => m.name.toLowerCase().includes(q))
-  }
-  return list
+  return menus.value; // 서버에서 이미 필터링된 결과를 받아오므로 그대로 반환
 })
+
+
 
 //  메뉴 등록 / 수정 모달
 const showMenuModal = ref(false)
@@ -155,6 +158,7 @@ async function deleteCategoryAction(idx, name) {
   try {
     await deleteCategory(idx)
     await categoryRes()
+    if (selectedCategoryIdx.value === name) selectedCategoryIdx.value = '전체'
   } catch (error) {
     alert('삭제 실패: 해당 카테고리를 사용하는 데이터가 있을 수 있습니다.')
   }
@@ -198,6 +202,22 @@ function confirmDelete() {
 function formatPrice(price) {
   return '₩ ' + price.toLocaleString('ko-KR')
 }
+
+const visiblePages = computed(() => {
+  const range = 10; // 한 번에 보여줄 페이지 개수
+  const currentGroup = Math.floor(pagination.currentPage / range);
+
+  const start = currentGroup * range;
+  const end = Math.min(start + range, pagination.totalPage);
+
+  const pages = [];
+  for (let i = start; i < end; i++) {
+    pages.push(i);
+  }
+  return pages;
+});
+
+
 onMounted(() => {
   getMenuRes()
   productListRes()
@@ -242,20 +262,23 @@ onMounted(() => {
         />
       </div>
 
-      <!-- 수정된 부분: 재료(제품명) 선택 드롭다운 -->
-      <div class="relative w-64">
-        <select
-          v-model="selectedCategoryIdx"
-          class="w-full pl-4 pr-10 py-2 bg-white border border-gray-200 rounded-lg text-sm appearance-none outline-none focus:border-[#F97316] focus:ring-1 focus:ring-[#F97316] transition-colors shadow-sm cursor-pointer text-gray-600"
-        >
-          <option value="">전체 제품 보기</option>
-          <option v-for="product in products" :key="product.idx" :value="product.idx">
-            {{ categories.categoryName }}
-          </option>
-        </select>
-        <div class="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400">
-          <ChevronDown class="w-4 h-4" />
-        </div>
+      <div class="flex gap-1.5 flex-wrap">
+        <button @click="selectCategory(null)"
+                class="px-3 py-1.5 text-sm font-semibold border rounded-lg transition-colors shadow-sm cursor-pointer"
+                :class="selectedCategoryIdx === null
+        ? 'bg-[#F37321] text-white border-[#F37321]'
+        : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'">
+          전체
+        </button>
+
+        <button v-for="cat in categories"
+                :key="cat.idx"
+                @click="selectCategory(cat.categoryIdx)"
+                class="px-3 py-1.5 text-sm font-semibold border rounded-lg transition-colors shadow-sm cursor-pointer"
+                :class="selectedCategoryIdx === cat.categoryIdx
+        ? 'bg-[#F37321] text-white border-[#F37321]'
+        : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'">
+          {{ cat.menuCategoryName }} </button>
       </div>
     </div>
 

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {ref, computed, onMounted, reactive} from 'vue'
 import {Plus, Search, Image as ImageIcon, ChevronDown, Tag} from 'lucide-vue-next'
-import { getProductList, getCategoryList } from '@/api/menu/index.js'
+import {getProductList, getCategoryList, getMenuList, getMenuItemList} from '@/api/menu/index.js'
 // ─────────────────────────────────────────────
 //  상태 관리 (카테고리 관리 관련 추가)
 // ─────────────────────────────────────────────
@@ -19,36 +19,29 @@ const productListRes = async () => {
 // ─────────────────────────────────────────────
 //  메뉴 데이터
 // ─────────────────────────────────────────────
-const menus = ref([
-  {
-    id: '1', name: '아인슈페너(반절커피)', price: 3500, imageName: '', category: '커피',
-    ingredients: [
-      { productId: '1', amount: 2, unit: '샷' },
-      { productId: '6', amount: 50, unit: 'ml' },
-    ]
-  },
-  {
-    id: '2', name: '바닐라라떼', price: 3500, imageName: '', category: '커피',
-    ingredients: [
-      { productId: '1', amount: 2, unit: '샷' },
-      { productId: '2', amount: 250, unit: 'ml' },
-      { productId: '3', amount: 3, unit: '펌프' },
-    ]
-  },
-  {
-    id: '3', name: '타로 버블티', price: 4300, imageName: '', category: '버블티',
-    ingredients: [
-      { productId: '2', amount: 200, unit: 'ml' },
-      { productId: '5', amount: 80, unit: 'g' },
-    ]
-  },
-])
+
+const menus = ref([])
+const pagination = reactive({
+  totalPage: 0,
+  totalCount: 0,
+  currentPage: 0,
+  currentSize: 10
+})
+const getMenuRes = async (page = 0)=>{
+  const searchReq = {
+    keyword : searchQuery.value,
+    categoryIdx: null
+  }
+
+  const res = await getMenuList(searchReq, page, pagination.currentSize)
+  menus.value = res.data.result.menuList
+}
 
 // ─────────────────────────────────────────────
 //  검색 및 필터링
 // ─────────────────────────────────────────────
 const searchQuery = ref('')
-const selectedProductId = ref('') // 제품 드롭다운 필터용 상태
+const selectedCategoryId = ref('') // 제품 드롭다운 필터용 상태
 
 // 카테고리
 const categories = ref([])
@@ -61,8 +54,8 @@ const filteredMenus = computed(() => {
   let list = menus.value
 
   // 제품 드롭다운 필터: 선택한 제품이 재료(ingredients)에 포함되어 있는지 확인
-  if (selectedProductId.value) {
-    list = list.filter(m => m.ingredients.some(ing => ing.productId === selectedProductId.value))
+  if (selectedCategoryId.value) {
+    list = list.filter(m => m.ingredients.some(ing => ing.productId === selectedCategoryId.value))
   }
 
   // 텍스트 검색 (메뉴명)
@@ -190,8 +183,11 @@ async function deleteCategoryAction(idx, name) {
 const showIngredientModal = ref(false)
 const selectedMenu = ref(null)
 
-function openIngredientModal(menu) {
-  selectedMenu.value = menu
+// 상세 모달 창
+async function openIngredientModal(menuIdx) {
+  const res = await getMenuItemList(menuIdx)
+  console.log(res.data.result)
+  selectedMenu.value = res.data.result
   showIngredientModal.value = true
 }
 
@@ -238,6 +234,7 @@ function formatPrice(price) {
   return '₩ ' + price.toLocaleString('ko-KR')
 }
 onMounted(() => {
+  getMenuRes()
   productListRes()
   fetchCategories()
   categoryRes()
@@ -284,12 +281,12 @@ onMounted(() => {
       <!-- 수정된 부분: 재료(제품명) 선택 드롭다운 -->
       <div class="relative w-64">
         <select
-          v-model="selectedProductId"
+          v-model="selectedCategoryId"
           class="w-full pl-4 pr-10 py-2 bg-white border border-gray-200 rounded-lg text-sm appearance-none outline-none focus:border-[#F97316] focus:ring-1 focus:ring-[#F97316] transition-colors shadow-sm cursor-pointer text-gray-600"
         >
           <option value="">전체 제품 보기</option>
           <option v-for="product in products" :key="product.id" :value="product.id">
-            {{ product.productName }}
+            {{ categories.categoryName }}
           </option>
         </select>
         <div class="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400">
@@ -313,20 +310,20 @@ onMounted(() => {
           </tr>
           </thead>
           <tbody class="divide-y divide-gray-100">
-          <tr v-for="menu in filteredMenus" :key="menu.id"
-              @click="openIngredientModal(menu)"
+          <tr v-for="menu in filteredMenus" :key="menu.idx"
+              @click="openIngredientModal(menu.idx)"
               class="hover:bg-gray-50/50 transition-colors cursor-pointer group">
-            <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ menu.id }}</td>
+            <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ menu.idx }}</td>
             <td class="px-5 py-3.5">
               <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-bold bg-gray-100 text-gray-600 border border-gray-200">
-                {{ menu.category || '기타' }}
+                {{ menu.menuCategory || '기타' }}
               </span>
             </td>
-            <td class="px-5 py-3.5 font-bold text-gray-900 group-hover:text-[#F97316] transition-colors">{{ menu.name }}</td>
+            <td class="px-5 py-3.5 font-bold text-gray-900 group-hover:text-[#F97316] transition-colors">{{ menu.menuName }}</td>
             <td class="px-5 py-3.5 text-gray-700 font-semibold">{{ formatPrice(menu.price) }}</td>
             <td class="px-5 py-3.5 text-center">
                 <span class="text-xs font-bold px-2 py-0.5 rounded-full bg-orange-50 text-orange-600">
-                  {{ menu.ingredients.length }}종
+                  {{ menu.menuItemCount }} 개
                 </span>
             </td>
 
@@ -395,7 +392,7 @@ onMounted(() => {
                         ? 'bg-[#F97316] text-white border-[#F97316]'
                         : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300 hover:bg-gray-50'"
                       class="px-3 py-1.5 rounded-lg border text-xs font-semibold transition-all cursor-pointer">
-                {{ cat }}
+                {{ cat.menuCategoryName }}
               </button>
             </div>
           </div>
@@ -488,16 +485,27 @@ onMounted(() => {
 
         <div class="px-7 py-5 border-b border-gray-100 flex justify-between items-center bg-gray-50">
           <div>
-            <h3 class="font-bold text-gray-900 text-lg">{{ selectedMenu?.name }}</h3>
-            <p class="text-xs text-gray-400 mt-0.5">{{selectedMenu?.id}}</p>
+            <h3 class="font-bold text-gray-900 text-lg">{{ selectedMenu?.menuName }}</h3>
+            <p class="text-xs text-gray-400 mt-0.5">ID: {{ selectedMenu?.idx }}</p>
           </div>
-          <div class="flex items-center gap-4">
-            <!-- 추가 요청 사항: 재료 추가 버튼 -->
-
-            <button @click="showIngredientModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl cursor-pointer">✕</button>
-          </div>
+          <button @click="showIngredientModal = false" class="text-gray-400 hover:text-gray-600 font-bold text-xl cursor-pointer">✕</button>
         </div>
 
+        <div class="p-7">
+          <div class="flex justify-center mb-8">
+            <div class="w-48 h-48 rounded-2xl border border-gray-100 overflow-hidden bg-white shadow-md">
+              <img v-if="selectedMenu?.imgPath"
+                   :src="'https://nexus-menu-assets.s3.ap-northeast-2.amazonaws.com/' + selectedMenu.imgPath"
+                   :alt="'nexus ' + selectedMenu?.menuName"
+                   class="w-full h-full object-cover"
+                   @error="(e) => e.target.src = 'https://nexus-menu-assets.s3.ap-northeast-2.amazonaws.com/theVenti_logo.png'" />
+              <img v-else
+                   :src="'https://nexus-menu-assets.s3.ap-northeast-2.amazonaws.com/theVenti_logo.png'"
+                   :alt="NEXUS"
+                   class="w-full h-full object-cover" />
+            </div>
+          </div>
+        </div>
         <div class="p-7">
           <table class="w-full text-sm text-left">
             <thead>
@@ -509,14 +517,14 @@ onMounted(() => {
             </tr>
             </thead>
             <tbody class="divide-y divide-gray-50">
-            <tr v-for="(item, idx) in selectedMenu?.ingredients" :key="idx"
+            <tr v-for="(item, idx) in selectedMenu?.menuItemList" :key="idx"
                 class="hover:bg-gray-50/80 transition-colors">
               <td class="px-3 py-3 font-mono text-xs text-gray-400">R-{{ String(idx + 1).padStart(3, '0') }}</td>
-              <td class="px-3 py-3 font-semibold text-gray-800">{{ getProductName(item.idx) }}</td>
-              <td class="px-3 py-3 text-right text-gray-700 font-mono">{{ item.amount }}</td>
-              <td class="px-3 py-3 text-gray-500">{{ item.unit }}</td>
+              <td class="px-3 py-3 font-semibold text-gray-800">{{ getProductName(item.productName) }}</td>
+              <td class="px-3 py-3 text-right text-gray-700 font-mono">{{ item.quantity }}</td>
+              <td class="px-3 py-3 text-gray-500">{{ item.menuUnit }}</td>
             </tr>
-            <tr v-if="!selectedMenu?.ingredients?.length">
+            <tr v-if="!selectedMenu?.menuItemList?.length">
               <td colspan="4" class="px-3 py-8 text-center text-gray-400 text-sm">등록된 재료가 없습니다.</td>
             </tr>
             </tbody>

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -1,14 +1,13 @@
 <script setup>
 import {ref, computed, onMounted, reactive} from 'vue'
-import {Plus, Search, Image as ImageIcon, ChevronDown, Tag, FileText} from 'lucide-vue-next'
+import {Plus, Search, Image as ImageIcon, ChevronDown, Tag, Trash2} from 'lucide-vue-next'
 import {getProductList, getCategoryList, getMenuList, getMenuItemList} from '@/api/menu/index.js'
-// ─────────────────────────────────────────────
+
+
 //  상태 관리 (카테고리 관리 관련 추가)
-// ─────────────────────────────────────────────
-const categoriesList = ref([]) // 서버에서 받아온 카테고리 객체 배열
 const showCategoryModal = ref(false)
 const newCategoryInput = ref('')
-const UNIT_OPTIONS = ['g', 'kg', 'ml', 'L', '개', '봉', '박스', '묶음', 'ea', '기타']
+const UNIT_OPTIONS = ['g', 'kg', 'ml', 'L', '개', '봉', '묶음', 'ea', '기타']
 
 //  상품 목록
 const products = ref([])
@@ -17,10 +16,7 @@ const productListRes = async () => {
   products.value = res.data
 }
 
-// ─────────────────────────────────────────────
 //  메뉴 데이터
-// ─────────────────────────────────────────────
-
 const menus = ref([])
 const pagination = reactive({
   totalPage: 0,
@@ -38,9 +34,7 @@ const getMenuRes = async (page = 0)=>{
   menus.value = res.data.result.menuList
 }
 
-// ─────────────────────────────────────────────
 //  검색 및 필터링
-// ─────────────────────────────────────────────
 const searchQuery = ref('')
 const selectedCategoryIdx = ref('') // 제품 드롭다운 필터용 상태
 
@@ -67,9 +61,7 @@ const filteredMenus = computed(() => {
   return list
 })
 
-// ─────────────────────────────────────────────
 //  메뉴 등록 / 수정 모달
-// ─────────────────────────────────────────────
 const showMenuModal = ref(false)
 const editTarget = ref(null)
 const menuForm = ref({ name: '', price: 0, imageName: '', category: '전체', ingredients: [] })
@@ -143,17 +135,8 @@ function saveMenu() {
   }
   showMenuModal.value = false
 }
-// ─────────────────────────────────────────────
-//  카테고리 액션 (productview 로직 이식)
-// ─────────────────────────────────────────────
-const fetchCategories = async () => {
-  try {
-    const response = await readCategoryList()
-    categoriesList.value = response.data
-  } catch (error) {
 
-  }
-}
+
 
 async function addCategoryAction() {
   const name = newCategoryInput.value.trim()
@@ -161,7 +144,7 @@ async function addCategoryAction() {
   try {
     await createCategory(name)
     newCategoryInput.value = ''
-    await fetchCategories()
+    await categoryRes()
   } catch (error) {
     alert('카테고리 등록 실패')
   }
@@ -171,17 +154,13 @@ async function deleteCategoryAction(idx, name) {
   if (!confirm(`'${name}' 카테고리를 삭제하시겠습니까?`)) return
   try {
     await deleteCategory(idx)
-    await fetchCategories()
+    await categoryRes()
   } catch (error) {
     alert('삭제 실패: 해당 카테고리를 사용하는 데이터가 있을 수 있습니다.')
   }
 }
 
-
-
-// ─────────────────────────────────────────────
 //  재료 목록 모달
-// ─────────────────────────────────────────────
 const showIngredientModal = ref(false)
 const selectedMenu = ref(null)
 
@@ -198,21 +177,7 @@ function getProductName(productIdx) {
 
 }
 
-function editIngredient(idx) {
-  // 재료 상세 모달을 닫고 수정 모달로 이동
-  showIngredientModal.value = false
-  openEditMenuModal(selectedMenu.value)
-}
-
-function deleteIngredient(idx) {
-  if (selectedMenu.value) {
-    selectedMenu.value.ingredients.splice(idx, 1)
-  }
-}
-
-// ─────────────────────────────────────────────
 //  삭제 확인 모달
-// ─────────────────────────────────────────────
 const showDeleteConfirm = ref(false)
 const deleteTarget = ref(null)
 
@@ -229,16 +194,13 @@ function confirmDelete() {
   deleteTarget.value = null
 }
 
-// ─────────────────────────────────────────────
 //  유틸
-// ─────────────────────────────────────────────
 function formatPrice(price) {
   return '₩ ' + price.toLocaleString('ko-KR')
 }
 onMounted(() => {
   getMenuRes()
   productListRes()
-  fetchCategories()
   categoryRes()
 })
 </script>
@@ -570,6 +532,47 @@ onMounted(() => {
         </div>
       </div>
     </div>
+
+    <!-- 카테고리 관리 모달 -->
+    <div v-if="showCategoryModal" class="fixed inset-0 z-50 flex items-center justify-center">
+      <div class="absolute inset-0 bg-black/40" @click="showCategoryModal = false"></div>
+      <div class="relative bg-white rounded-lg w-full max-w-md border border-gray-200 shadow-xl">
+        <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+          <h3 class="font-bold text-gray-900">카테고리 관리</h3>
+          <button @click="showCategoryModal = false" class="text-gray-400 hover:text-gray-600 cursor-pointer">✕</button>
+        </div>
+        <div class="p-6 space-y-4">
+          <div class="flex gap-2">
+            <input v-model="newCategoryInput" type="text" placeholder="새 카테고리명 입력"
+                   @keyup.enter="addCategoryAction"
+                   class="flex-1 px-3 py-2 rounded border border-gray-200 text-sm focus:border-[#F37321] focus:ring-2 focus:ring-[#F37321]/10 outline-none" />
+            <button @click="addCategoryAction"
+                    class="px-4 py-2 bg-[#F37321] text-white text-sm font-semibold rounded hover:bg-[#e0661d] cursor-pointer">추가</button>
+          </div>
+          <div class="border border-gray-200 rounded-lg overflow-hidden">
+            <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-100">
+              <p class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">카테고리 목록 ({{ categories.length }}개)</p>
+            </div>
+            <div class="divide-y divide-gray-100 max-h-64 overflow-y-auto">
+              <div v-for="cat in categories" :key="cat.idx"
+                   class="flex items-center justify-between px-4 py-2.5 hover:bg-gray-50">
+                <span class="text-sm font-medium text-gray-700">{{ cat.menuCategoryName }}</span>
+                <button @click="deleteCategoryAction(cat.idx, cat.menuCategoryName)" class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer">
+                  <Trash2 class="w-3.5 h-3.5" />
+                </button>
+              </div>
+              <div v-if="categories.length === 0" class="px-4 py-6 text-center text-gray-400 text-sm">
+                등록된 카테고리가 없습니다.
+              </div>
+            </div>
+          </div>
+          <button @click="showCategoryModal = false"
+                  class="w-full py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer">닫기</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- 이전 다음 버튼 -->
     <div class="flex items-center justify-center gap-3 mt-8 pb-10">
       <!-- 이전 페이지 버튼 (작게) -->
       <button

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {ref, computed, onMounted, reactive} from 'vue'
-import {Plus, Search, Image as ImageIcon, ChevronDown, Tag} from 'lucide-vue-next'
+import {Plus, Search, Image as ImageIcon, ChevronDown, Tag, FileText} from 'lucide-vue-next'
 import {getProductList, getCategoryList, getMenuList, getMenuItemList} from '@/api/menu/index.js'
 // ─────────────────────────────────────────────
 //  상태 관리 (카테고리 관리 관련 추가)
@@ -8,6 +8,7 @@ import {getProductList, getCategoryList, getMenuList, getMenuItemList} from '@/a
 const categoriesList = ref([]) // 서버에서 받아온 카테고리 객체 배열
 const showCategoryModal = ref(false)
 const newCategoryInput = ref('')
+const UNIT_OPTIONS = ['g', 'kg', 'ml', 'L', '개', '봉', '박스', '묶음', 'ea', '기타']
 
 //  상품 목록
 const products = ref([])
@@ -41,7 +42,7 @@ const getMenuRes = async (page = 0)=>{
 //  검색 및 필터링
 // ─────────────────────────────────────────────
 const searchQuery = ref('')
-const selectedCategoryId = ref('') // 제품 드롭다운 필터용 상태
+const selectedCategoryIdx = ref('') // 제품 드롭다운 필터용 상태
 
 // 카테고리
 const categories = ref([])
@@ -54,8 +55,8 @@ const filteredMenus = computed(() => {
   let list = menus.value
 
   // 제품 드롭다운 필터: 선택한 제품이 재료(ingredients)에 포함되어 있는지 확인
-  if (selectedCategoryId.value) {
-    list = list.filter(m => m.ingredients.some(ing => ing.productId === selectedCategoryId.value))
+  if (selectedCategoryIdx.value) {
+    list = list.filter(m => m.ingredients.some(ing => ing.productIdx === selectedCategoryIdx.value))
   }
 
   // 텍스트 검색 (메뉴명)
@@ -81,14 +82,21 @@ function openNewMenuModal() {
   showMenuModal.value = true
 }
 
-function openEditMenuModal(menu) {
+async function openEditMenuModal(menu) {
+  const res = await getMenuItemList(menu.idx)
+  const detail = res.data.result
+
   editTarget.value = menu
   menuForm.value = {
-    name: menu.name,
+    name: menu.menuName,
     price: menu.price,
-    imageName: menu.imageName,
-    category: menu.category,
-    ingredients: menu.ingredients.map(i => ({ ...i })),
+    imageName: detail.imgPath?.trim() ?? '',
+    category: menu.menuCategory,
+    ingredients: detail.menuItemList ? detail.menuItemList.map(i => ({
+      productIdx: i.idx,
+      amount: i.quantity,
+      unit: i.menuUnit,
+    })) : [],
   }
   formattedPriceInput.value = menu.price.toLocaleString('ko-KR')
   showMenuModal.value = true
@@ -101,7 +109,7 @@ const onPriceInput = (e) => {
 };
 
 function addIngredientRow() {
-  menuForm.value.ingredients.push({ productId: '', amount: 0, unit: '' })
+  menuForm.value.ingredients.push({ productIdx: '', amount: 0, unit: '' })
 }
 
 function removeIngredientRow(idx) {
@@ -112,31 +120,25 @@ function handleImageChange(e) {
   const file = e.target.files[0]
   if (file) menuForm.value.imageName = file.name
 }
-
 function saveMenu() {
   if (editTarget.value) {
-    // 수정
     Object.assign(editTarget.value, {
-      name: menuForm.value.name,
+      menuName: menuForm.value.name,
       price: menuForm.value.price,
-      imageName: menuForm.value.imageName,
-      category: menuForm.value.category,
-      ingredients: menuForm.value.ingredients.map(i => ({ ...i })),
+      imgPath: menuForm.value.imageName,
+      menuCategory: menuForm.value.category,
+      menuItemList: menuForm.value.ingredients.map(i => ({ ...i })),
     })
   } else {
-    // 가장 큰 숫자 ID를 찾아 +1 하기 (ID 충돌 방지)
-    const maxIdNum = menus.value.reduce((max, menu) => {
-      const idNum = parseInt(menu.id.split('-')[1]);
-      return idNum > max ? idNum : max;
-    }, 0);
-    const newId = `M-${String(maxIdNum + 1).padStart(3, '0')}`;
+    const maxIdx = menus.value.reduce((max, menu) => menu.idx > max ? menu.idx : max, 0)
     menus.value.push({
-      id: newId,
-      name: menuForm.value.name,
+      idx: maxIdx + 1,
+      menuName: menuForm.value.name,
       price: menuForm.value.price,
-      imageName: menuForm.value.imageName,
-      category: menuForm.value.category,
-      ingredients: menuForm.value.ingredients.map(i => ({ ...i })),
+      imgPath: menuForm.value.imageName,
+      menuCategory: menuForm.value.category,
+      menuItemList: menuForm.value.ingredients.map(i => ({ ...i })),
+      menuItemCount: menuForm.value.ingredients.length,
     })
   }
   showMenuModal.value = false
@@ -221,7 +223,7 @@ function openDeleteConfirm(menu) {
 
 function confirmDelete() {
   if (deleteTarget.value) {
-    menus.value = menus.value.filter(m => m.id !== deleteTarget.value.id)
+    menus.value = menus.value.filter(m => m.idx !== deleteTarget.value.idx)
   }
   showDeleteConfirm.value = false
   deleteTarget.value = null
@@ -281,11 +283,11 @@ onMounted(() => {
       <!-- 수정된 부분: 재료(제품명) 선택 드롭다운 -->
       <div class="relative w-64">
         <select
-          v-model="selectedCategoryId"
+          v-model="selectedCategoryIdx"
           class="w-full pl-4 pr-10 py-2 bg-white border border-gray-200 rounded-lg text-sm appearance-none outline-none focus:border-[#F97316] focus:ring-1 focus:ring-[#F97316] transition-colors shadow-sm cursor-pointer text-gray-600"
         >
           <option value="">전체 제품 보기</option>
-          <option v-for="product in products" :key="product.id" :value="product.id">
+          <option v-for="product in products" :key="product.idx" :value="product.idx">
             {{ categories.categoryName }}
           </option>
         </select>
@@ -353,7 +355,7 @@ onMounted(() => {
     ══════════════════════════════════════════ -->
     <div v-if="showMenuModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div class="absolute inset-0 bg-black/40 " @click="showMenuModal = false"></div>
-      <div class="relative bg-white rounded-xl w-full max-w-xl border border-gray-200 shadow-xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
+      <div class="relative bg-white rounded-xl w-full max-w-2xl border border-gray-200 shadow-xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
 
         <!-- 모달 헤더 -->
         <div class="px-7 py-5 border-b border-gray-100 flex justify-between items-center bg-gray-50">
@@ -387,8 +389,8 @@ onMounted(() => {
             <div class="flex items-center gap-2 flex-wrap">
               <button v-for="cat in categories.filter(c => c !== '전체')" :key="cat"
                       type="button"
-                      @click="menuForm.category = cat"
-                      :class="menuForm.category === cat
+                      @click="menuForm.category = cat.menuCategoryName"
+                      :class="menuForm.category === cat.menuCategoryName
                         ? 'bg-[#F97316] text-white border-[#F97316]'
                         : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300 hover:bg-gray-50'"
                       class="px-3 py-1.5 rounded-lg border text-xs font-semibold transition-all cursor-pointer">
@@ -401,10 +403,11 @@ onMounted(() => {
           <div class="space-y-1.5">
             <label class="text-[11px] font-bold text-gray-400 uppercase tracking-widest">메뉴 이미지</label>
             <label class="cursor-pointer block">
-              <div class="w-full px-4 py-3 rounded-lg border-2 border-dashed border-gray-200 text-sm text-gray-400 bg-gray-50 hover:bg-gray-100 hover:border-[#F97316]/40 transition-all flex items-center justify-between">
+              <div class="w-full px-4 py-2 rounded-lg border border-gray-200 text-sm text-gray-400 bg-gray-50 hover:bg-gray-100 transition-colors flex items-center justify-between">
                 <span>{{ menuForm.imageName || '이미지를 업로드하세요' }}</span>
                 <ImageIcon class="w-4 h-4 flex-shrink-0" />
               </div>
+
               <input type="file" class="hidden" @change="handleImageChange" accept="image/*" />
             </label>
           </div>
@@ -420,38 +423,42 @@ onMounted(() => {
             </div>
 
             <!-- 재료 컬럼 레이블 -->
-            <div class="grid grid-cols-[2fr_1fr_1fr_32px] gap-2 mb-2 px-0.5">
+            <div class="grid grid-cols-[2.5fr_1fr_1.2fr_1.2fr_32px] gap-2 mb-2 px-0.5">
               <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">상품명</span>
               <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">소요량</span>
-              <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위</span>
+              <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">단위 선택</span>
+              <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">직접 입력</span>
               <span></span>
             </div>
 
             <!-- 재료 행 목록 -->
-            <div class="space-y-2">
+            <div class="space-y-3">
               <div v-for="(item, idx) in menuForm.ingredients" :key="idx"
-                   class="grid grid-cols-[2fr_1fr_1fr_32px] gap-2 items-center">
-                <select v-model="item.productId"
-                        class="w-full px-3 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] focus:ring-4 focus:ring-[#F97316]/5 transition-all">
-                  <option value="">상품 선택</option>
-                  <option v-for="p in products" :key="p.id" :value="p.id">{{ p.productName }}</option>
-                </select>
-                <input v-model.number="item.amount" type="number" placeholder="0" min="0" step="any"
-                       class="w-full px-3 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] focus:ring-4 focus:ring-[#F97316]/5 transition-all" />
+                   class="grid grid-cols-[2.5fr_1fr_1.2fr_1.2fr_32px] gap-2 items-center"> <select v-model="item.productIdx"
+                                                                                                   class="w-full px-2 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] transition-all appearance-none bg-white">
+                <option value="">상품 선택</option>
+                <option v-for="p in products" :key="p.idx" :value="p.idx">{{ p.productName }}</option>
+              </select>
+
+                <input v-model.number="item.amount" type="number" placeholder="0"
+                       class="w-full px-2 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] text-right" />
+
                 <select v-model="item.unit"
-                        class="w-full px-3 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] focus:ring-4 focus:ring-[#F97316]/5 transition-all">
-                  <option value="">단위 선택</option>
-                  <option>kg</option>
-                  <option>g</option>
-                  <option>L</option>
-                  <option>ml</option>
-                  <option>개</option>
-                  <option>봉</option>
-                  <option>박스</option>
-                  <option>묶음</option>
+                        @change="item.unit !== '기타' ? item.customUnit = '' : null"
+                        class="w-full px-2 py-2 rounded-lg border border-gray-200 text-sm outline-none focus:border-[#F97316] bg-white">
+                  <option value="">선택</option>
+                  <option v-for="unit in UNIT_OPTIONS" :key="unit" :value="unit">{{ unit }}</option>
                 </select>
+
+                <input v-model="item.customUnit"
+                       :disabled="item.unit !== '기타'"
+                       type="text"
+                       placeholder="직접 입력"
+                       :class="item.unit === '기타' ? 'bg-white border-gray-200' : 'bg-gray-50 border-gray-100 text-transparent select-none'"
+                       class="w-full px-2 py-2 rounded-lg border text-sm outline-none focus:border-[#F97316] transition-all" />
+
                 <button type="button" @click="removeIngredientRow(idx)"
-                        class="w-8 h-8 flex items-center justify-center rounded-lg bg-red-50 text-red-400 hover:bg-red-100 hover:text-red-600 transition-colors text-sm font-bold cursor-pointer">
+                        class="w-8 h-8 flex items-center justify-center rounded-lg bg-red-50 text-red-400 hover:bg-red-100 transition-colors cursor-pointer">
                   ✕
                 </button>
               </div>
@@ -563,7 +570,40 @@ onMounted(() => {
         </div>
       </div>
     </div>
+    <div class="flex items-center justify-center gap-3 mt-8 pb-10">
+      <!-- 이전 페이지 버튼 (작게) -->
+      <button
+        @click="changePage(pagination.currentPage - 1)"
+        :disabled="pagination.currentPage === 0"
+        class="w-7 h-7 flex items-center justify-center rounded border border-gray-200 bg-white disabled:opacity-30 disabled:cursor-not-allowed hover:bg-gray-50 transition-colors cursor-pointer"
+      >
+        <span class="text-[10px] text-gray-500">◀</span>
+      </button>
 
+      <!-- 페이지 번호 -->
+      <div class="flex items-center gap-1">
+        <button
+          v-for="pageIdx in visiblePages"
+          :key="pageIdx"
+          @click="changePage(pageIdx)"
+          class="min-w-[28px] h-7 px-2 flex items-center justify-center rounded text-xs font-bold transition-all cursor-pointer"
+          :class="pagination.currentPage === pageIdx
+        ? 'text-[#F37321] border-b-2 border-[#F37321] rounded-none'
+        : 'text-gray-400 hover:text-gray-600'"
+        >
+          {{ pageIdx + 1 }}
+        </button>
+      </div>
+
+      <!-- 다음 페이지 버튼 (작게) -->
+      <button
+        @click="changePage(pagination.currentPage + 1)"
+        :disabled="pagination.currentPage >= pagination.totalPage - 1"
+        class="w-7 h-7 flex items-center justify-center rounded border border-gray-200 bg-white disabled:opacity-30 disabled:cursor-not-allowed hover:bg-gray-50 transition-colors cursor-pointer"
+      >
+        <span class="text-[10px] text-gray-500">▶</span>
+      </button>
+    </div>
 
   </div>
 </template>

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -8,6 +8,9 @@ import {getProductList, getCategoryList, getMenuList, getMenuItemList} from '@/a
 const showCategoryModal = ref(false)
 const newCategoryInput = ref('')
 const UNIT_OPTIONS = ['g', 'kg', 'ml', 'L', '개', '봉', '묶음', 'ea', '기타']
+//  검색 및 필터링
+const searchQuery = ref('')
+const selectedCategoryIdx = ref('') // 제품 드롭다운 필터용 상태
 
 
 //  상품 목록
@@ -18,7 +21,7 @@ const productListRes = async () => {
 }
 
 //  메뉴 데이터
-const menus = ref([])
+const menus = reactive([])
 const pagination = reactive({
   totalPage: 0,
   totalCount: 0,
@@ -33,7 +36,7 @@ const getMenuRes = async (page = 0)=>{
   }
 
   const res = await getMenuList(searchReq, page, pagination.currentSize)
-  menus.value = res.data.result.menuList
+  menus.splice(0, menus.length, ...res.data.result.menuList)
 
   pagination.totalPage = res.data.result.totalPage
   pagination.totalCount = res.data.result.totalCount
@@ -45,9 +48,7 @@ const selectCategory = (idx) => {
   getMenuRes(0); // 페이지를 0으로 초기화하여 재조회
 }
 
-//  검색 및 필터링
-const searchQuery = ref('')
-const selectedCategoryIdx = ref('') // 제품 드롭다운 필터용 상태
+
 
 // 카테고리
 const categories = ref([])
@@ -59,9 +60,8 @@ const categoryRes = async () => {
 
 // --- 카테고리 필터링 (클라이언트 사이드) ---
 const filteredMenus = computed(() => {
-  return menus.value; // 서버에서 이미 필터링된 결과를 받아오므로 그대로 반환
+  return menus; // 서버에서 이미 필터링된 결과를 받아오므로 그대로 반환
 })
-
 
 
 //  메뉴 등록 / 수정 모달
@@ -217,6 +217,13 @@ const visiblePages = computed(() => {
   return pages;
 });
 
+const changePage = (page) => {
+  // 0보다 작거나 마지막 페이지(totalPage - 1)보다 크면 무시[cite: 1]
+  if (page < 0 || page >= pagination.totalPage) return
+  getMenuRes(page)
+}
+
+
 
 onMounted(() => {
   getMenuRes()
@@ -247,7 +254,7 @@ onMounted(() => {
       </div>
     </div>
 
-    <!-- 텍스트 검색 및 드롭다운 -->
+    <!-- 텍스트 검색 -->
     <div class="flex items-center gap-3 mb-4 flex-wrap">
       <div class="relative">
         <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
@@ -282,7 +289,7 @@ onMounted(() => {
       </div>
     </div>
 
-    <!-- ── 검색 ── -->
+    <!-- ── 리스트 ── -->
     <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
       <div class="overflow-x-auto">
         <table class="w-full text-sm text-left">

--- a/frontend/src/views/RecipeView.vue
+++ b/frontend/src/views/RecipeView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {ref, computed, onMounted, reactive} from 'vue'
 import {Plus, Search, Image as ImageIcon, ChevronDown, Tag} from 'lucide-vue-next'
-import { getProductList } from '@/api/menu/index.js'
+import { getProductList, getCategoryList } from '@/api/menu/index.js'
 // ─────────────────────────────────────────────
 //  상태 관리 (카테고리 관리 관련 추가)
 // ─────────────────────────────────────────────
@@ -9,14 +9,10 @@ const categoriesList = ref([]) // 서버에서 받아온 카테고리 객체 배
 const showCategoryModal = ref(false)
 const newCategoryInput = ref('')
 
-// ─────────────────────────────────────────────
-//  상품 목록 (제품 관리에서 연동 가정)
-// ─────────────────────────────────────────────
+//  상품 목록
 const products = ref([])
-
 const productListRes = async () => {
   const res  = await getProductList()
-  console.log(res.data)
   products.value = res.data
 }
 
@@ -53,7 +49,13 @@ const menus = ref([
 // ─────────────────────────────────────────────
 const searchQuery = ref('')
 const selectedProductId = ref('') // 제품 드롭다운 필터용 상태
-const categories = ['전체', '커피', '음료', '버블티', '스무디/에이드', '디저트']
+
+// 카테고리
+const categories = ref([])
+const categoryRes = async () => {
+  const res = await getCategoryList()
+  categories.value = res.data.result
+}
 
 const filteredMenus = computed(() => {
   let list = menus.value
@@ -238,6 +240,7 @@ function formatPrice(price) {
 onMounted(() => {
   productListRes()
   fetchCategories()
+  categoryRes()
 })
 </script>
 

--- a/jenkins/backend/Jenkinsfile
+++ b/jenkins/backend/Jenkinsfile
@@ -69,12 +69,24 @@ spec:
         stage('Deploy to Kubernetes') {
             steps {
                 container('kubectl') {
-                    sh """
-                        kubectl apply -f k8s/backend/deployment.yaml
-                        kubectl apply -f k8s/backend/service.yaml
-                        kubectl set image deployment/nexus-backend nexus-backend=${IMAGE_REPO}:${BUILD_NUMBER}
-                        kubectl rollout status deployment/nexus-backend
-                    """
+                    script {
+                        sh 'kubectl apply -f k8s/backend/deployment-blue.yaml'
+                        sh 'kubectl apply -f k8s/backend/deployment-green.yaml'
+                        sh 'kubectl apply -f k8s/backend/service.yaml'
+
+                        def currentSlot = sh(
+                            script: "kubectl get svc nexus-backend-service -o jsonpath='{.spec.selector.slot}'",
+                            returnStdout: true
+                        ).trim()
+
+                        def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
+
+                        sh "kubectl set image deployment/nexus-backend-${newSlot} nexus-backend=${IMAGE_REPO}:${BUILD_NUMBER}"
+                        sh "kubectl rollout status deployment/nexus-backend-${newSlot} --timeout=120s"
+                        sh "kubectl patch svc nexus-backend-service -p '{\"spec\":{\"selector\":{\"slot\":\"${newSlot}\"}}}'"
+
+                        echo "Switched traffic to ${newSlot} slot"
+                    }
                 }
             }
         }

--- a/jenkins/backend/Jenkinsfile
+++ b/jenkins/backend/Jenkinsfile
@@ -1,4 +1,5 @@
 pipeline {
+    // Jenkins 에이전트를 K8s Pod로 실행 (빌드용 컨테이너 3개를 하나의 Pod에 구성)
     agent {
         kubernetes {
             yaml """
@@ -7,54 +8,61 @@ kind: Pod
 spec:
   serviceAccountName: jenkins
   containers:
-  - name: gradle
+  - name: gradle                                    # Java 빌드용 (bootJar)
     image: eclipse-temurin:17-jdk-alpine
     command: ['sleep', 'infinity']
-  - name: kaniko
+  - name: kaniko                                    # Docker 이미지 빌드 & Push용 (Docker 데몬 불필요)
     image: gcr.io/kaniko-project/executor:debug
     command: ['sleep', 'infinity']
-  - name: kubectl
+  - name: kubectl                                   # K8s 클러스터 배포용
     image: bitnami/kubectl:latest
     command: ['sleep', 'infinity']
     securityContext:
-      runAsUser: 0
+      runAsUser: 0                                  # kubectl 실행을 위해 root 권한 필요
 """
         }
     }
 
     environment {
-        IMAGE_REPO = 'deatytim/nexusback'
+        IMAGE_REPO = 'deatytim/nexusback'           // Docker Hub 이미지 저장소
     }
 
     stages {
+        // 소스코드 체크아웃
         stage('Checkout') {
             steps {
                 checkout scm
             }
         }
 
+        // Spring Boot JAR 빌드
         stage('Build JAR') {
             steps {
                 container('gradle') {
                     dir('backend') {
+                        // gradlew 실행 권한 부여 후 테스트 제외하고 JAR 생성
                         sh 'chmod +x gradlew && ./gradlew bootJar -x test'
                     }
                 }
             }
         }
 
+        // Docker 이미지 빌드 및 Docker Hub Push
         stage('Build & Push Docker Image') {
             steps {
                 container('kaniko') {
+                    // Jenkins에 저장된 Docker Hub 자격증명 주입
                     withCredentials([usernamePassword(
                         credentialsId: 'dockerhub-credentials',
                         usernameVariable: 'DOCKER_USER',
                         passwordVariable: 'DOCKER_PASS'
                     )]) {
                         sh """
+                            # Kaniko용 Docker Hub 인증 설정
                             AUTH=\$(printf "%s:%s" "\$DOCKER_USER" "\$DOCKER_PASS" | base64 | tr -d '\\n')
                             mkdir -p /kaniko/.docker
                             printf '{"auths":{"https://index.docker.io/v1/":{"auth":"%s"}}}' "\$AUTH" > /kaniko/.docker/config.json
+                            # 이미지 빌드 후 빌드번호 태그 + latest 태그로 Push
                             /kaniko/executor \\
                                 --context=\$WORKSPACE/backend \\
                                 --dockerfile=\$WORKSPACE/docker/backend/Dockerfile \\
@@ -66,23 +74,32 @@ spec:
             }
         }
 
+        // Blue/Green 무중단 배포
+        // 1) 매니페스트 적용 → 2) 현재 슬롯 확인 → 3) 비활성 슬롯에 배포
+        // → 4) Ready 대기 → 5) Service selector 전환으로 트래픽 스위칭
         stage('Deploy to Kubernetes') {
             steps {
                 container('kubectl') {
                     script {
+                        // 1) blue/green 매니페스트 및 service 적용
                         sh 'kubectl apply -f k8s/backend/deployment-blue.yaml'
                         sh 'kubectl apply -f k8s/backend/deployment-green.yaml'
                         sh 'kubectl apply -f k8s/backend/service.yaml'
 
+                        // 2) 현재 트래픽을 받고 있는 슬롯 확인
                         def currentSlot = sh(
                             script: "kubectl get svc nexus-backend-service -o jsonpath='{.spec.selector.slot}'",
                             returnStdout: true
                         ).trim()
 
+                        // 3) 비활성 슬롯에 새 이미지 배포
                         def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
-
                         sh "kubectl set image deployment/nexus-backend-${newSlot} nexus-backend=${IMAGE_REPO}:${BUILD_NUMBER}"
+
+                        // 4) 새 pod가 Ready 상태가 될 때까지 대기
                         sh "kubectl rollout status deployment/nexus-backend-${newSlot} --timeout=120s"
+
+                        // 5) Service selector를 새 슬롯으로 전환 → 트래픽 즉시 이동
                         sh "kubectl patch svc nexus-backend-service -p '{\"spec\":{\"selector\":{\"slot\":\"${newSlot}\"}}}'"
 
                         echo "Switched traffic to ${newSlot} slot"

--- a/jenkins/frontend/Jenkinsfile
+++ b/jenkins/frontend/Jenkinsfile
@@ -69,13 +69,25 @@ spec:
         stage('Deploy to Kubernetes') {
             steps {
                 container('kubectl') {
-                    sh """
-                        kubectl apply -f k8s/frontend/deployment.yaml
-                        kubectl apply -f k8s/frontend/service.yaml
-                        kubectl apply -f k8s/ingress.yaml
-                        kubectl set image deployment/nexus-frontend nexus-frontend=${IMAGE_REPO}:${BUILD_NUMBER}
-                        kubectl rollout status deployment/nexus-frontend
-                    """
+                    script {
+                        sh 'kubectl apply -f k8s/frontend/deployment-blue.yaml'
+                        sh 'kubectl apply -f k8s/frontend/deployment-green.yaml'
+                        sh 'kubectl apply -f k8s/frontend/service.yaml'
+                        sh 'kubectl apply -f k8s/ingress.yaml'
+
+                        def currentSlot = sh(
+                            script: "kubectl get svc nexus-frontend-service -o jsonpath='{.spec.selector.slot}'",
+                            returnStdout: true
+                        ).trim()
+
+                        def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
+
+                        sh "kubectl set image deployment/nexus-frontend-${newSlot} nexus-frontend=${IMAGE_REPO}:${BUILD_NUMBER}"
+                        sh "kubectl rollout status deployment/nexus-frontend-${newSlot} --timeout=120s"
+                        sh "kubectl patch svc nexus-frontend-service -p '{\"spec\":{\"selector\":{\"slot\":\"${newSlot}\"}}}'"
+
+                        echo "Switched traffic to ${newSlot} slot"
+                    }
                 }
             }
         }

--- a/jenkins/frontend/Jenkinsfile
+++ b/jenkins/frontend/Jenkinsfile
@@ -1,4 +1,5 @@
 pipeline {
+    // Jenkins 에이전트를 K8s Pod로 실행 (빌드용 컨테이너 3개를 하나의 Pod에 구성)
     agent {
         kubernetes {
             yaml """
@@ -7,54 +8,61 @@ kind: Pod
 spec:
   serviceAccountName: jenkins
   containers:
-  - name: node
+  - name: node                                      # Frontend 빌드용 (npm)
     image: node:20-alpine
     command: ['sleep', 'infinity']
-  - name: kaniko
+  - name: kaniko                                    # Docker 이미지 빌드 & Push용 (Docker 데몬 불필요)
     image: gcr.io/kaniko-project/executor:debug
     command: ['sleep', 'infinity']
-  - name: kubectl
+  - name: kubectl                                   # K8s 클러스터 배포용
     image: bitnami/kubectl:latest
     command: ['sleep', 'infinity']
     securityContext:
-      runAsUser: 0
+      runAsUser: 0                                  # kubectl 실행을 위해 root 권한 필요
 """
         }
     }
 
     environment {
-        IMAGE_REPO = 'deatytim/nexusfront'
+        IMAGE_REPO = 'deatytim/nexusfront'          // Docker Hub 이미지 저장소
     }
 
     stages {
+        // 소스코드 체크아웃
         stage('Checkout') {
             steps {
                 checkout scm
             }
         }
 
+        // Frontend 빌드 (Vue.js)
         stage('Build') {
             steps {
                 container('node') {
                     dir('frontend') {
+                        // 의존성 클린 설치 후 프로덕션 빌드 (dist 폴더 생성)
                         sh 'npm ci && npm run build'
                     }
                 }
             }
         }
 
+        // Docker 이미지 빌드 및 Docker Hub Push
         stage('Build & Push Docker Image') {
             steps {
                 container('kaniko') {
+                    // Jenkins에 저장된 Docker Hub 자격증명 주입
                     withCredentials([usernamePassword(
                         credentialsId: 'dockerhub-credentials',
                         usernameVariable: 'DOCKER_USER',
                         passwordVariable: 'DOCKER_PASS'
                     )]) {
                         sh """
+                            # Kaniko용 Docker Hub 인증 설정
                             AUTH=\$(printf "%s:%s" "\$DOCKER_USER" "\$DOCKER_PASS" | base64 | tr -d '\\n')
                             mkdir -p /kaniko/.docker
                             printf '{"auths":{"https://index.docker.io/v1/":{"auth":"%s"}}}' "\$AUTH" > /kaniko/.docker/config.json
+                            # 이미지 빌드 후 빌드번호 태그 + latest 태그로 Push
                             /kaniko/executor \\
                                 --context=\$WORKSPACE/frontend \\
                                 --dockerfile=\$WORKSPACE/docker/frontend/Dockerfile \\
@@ -66,24 +74,33 @@ spec:
             }
         }
 
+        // Blue/Green 무중단 배포
+        // 1) 매니페스트 적용 → 2) 현재 슬롯 확인 → 3) 비활성 슬롯에 배포
+        // → 4) Ready 대기 → 5) Service selector 전환으로 트래픽 스위칭
         stage('Deploy to Kubernetes') {
             steps {
                 container('kubectl') {
                     script {
+                        // 1) blue/green 매니페스트, service, ingress 적용
                         sh 'kubectl apply -f k8s/frontend/deployment-blue.yaml'
                         sh 'kubectl apply -f k8s/frontend/deployment-green.yaml'
                         sh 'kubectl apply -f k8s/frontend/service.yaml'
                         sh 'kubectl apply -f k8s/ingress.yaml'
 
+                        // 2) 현재 트래픽을 받고 있는 슬롯 확인
                         def currentSlot = sh(
                             script: "kubectl get svc nexus-frontend-service -o jsonpath='{.spec.selector.slot}'",
                             returnStdout: true
                         ).trim()
 
+                        // 3) 비활성 슬롯에 새 이미지 배포
                         def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
-
                         sh "kubectl set image deployment/nexus-frontend-${newSlot} nexus-frontend=${IMAGE_REPO}:${BUILD_NUMBER}"
+
+                        // 4) 새 pod가 Ready 상태가 될 때까지 대기
                         sh "kubectl rollout status deployment/nexus-frontend-${newSlot} --timeout=120s"
+
+                        // 5) Service selector를 새 슬롯으로 전환 → 트래픽 즉시 이동
                         sh "kubectl patch svc nexus-frontend-service -p '{\"spec\":{\"selector\":{\"slot\":\"${newSlot}\"}}}'"
 
                         echo "Switched traffic to ${newSlot} slot"

--- a/k8s/backend/deployment-blue.yaml
+++ b/k8s/backend/deployment-blue.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nexus-backend-blue
+  labels:
+    app: nexus-backend
+    slot: blue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nexus-backend
+      slot: blue
+  template:
+    metadata:
+      labels:
+        app: nexus-backend
+        slot: blue
+    spec:
+      containers:
+        - name: nexus-backend
+          image: deatytim/nexusback:latest
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: nexus-backend-config
+            - secretRef:
+                name: nexus-backend-secret
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30

--- a/k8s/backend/deployment-blue.yaml
+++ b/k8s/backend/deployment-blue.yaml
@@ -1,10 +1,12 @@
+# Blue/Green 배포 - Blue 슬롯
+# Service의 selector.slot 값을 blue/green으로 전환하여 트래픽을 제어합니다.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nexus-backend-blue
   labels:
     app: nexus-backend
-    slot: blue
+    slot: blue            # blue/green 슬롯 구분용 라벨
 spec:
   replicas: 1
   selector:

--- a/k8s/backend/deployment-green.yaml
+++ b/k8s/backend/deployment-green.yaml
@@ -1,18 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nexus-backend
+  name: nexus-backend-green
   labels:
     app: nexus-backend
+    slot: green
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: nexus-backend
+      slot: green
   template:
     metadata:
       labels:
         app: nexus-backend
+        slot: green
     spec:
       containers:
         - name: nexus-backend

--- a/k8s/backend/deployment-green.yaml
+++ b/k8s/backend/deployment-green.yaml
@@ -1,10 +1,12 @@
+# Blue/Green 배포 - Green 슬롯
+# Service의 selector.slot 값을 blue/green으로 전환하여 트래픽을 제어합니다.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nexus-backend-green
   labels:
     app: nexus-backend
-    slot: green
+    slot: green            # blue/green 슬롯 구분용 라벨
 spec:
   replicas: 1
   selector:

--- a/k8s/backend/service.yaml
+++ b/k8s/backend/service.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   selector:
     app: nexus-backend
+    slot: blue
   ports:
     - protocol: TCP
       port: 8080

--- a/k8s/backend/service.yaml
+++ b/k8s/backend/service.yaml
@@ -1,3 +1,5 @@
+# Blue/Green 배포용 Service
+# slot 값을 Jenkins 파이프라인에서 blue <-> green으로 patch하여 트래픽을 전환합니다.
 apiVersion: v1
 kind: Service
 metadata:
@@ -5,7 +7,7 @@ metadata:
 spec:
   selector:
     app: nexus-backend
-    slot: blue
+    slot: blue              # Jenkins에서 kubectl patch로 blue <-> green 전환
   ports:
     - protocol: TCP
       port: 8080

--- a/k8s/frontend/deployment-blue.yaml
+++ b/k8s/frontend/deployment-blue.yaml
@@ -1,18 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nexus-frontend
+  name: nexus-frontend-blue
   labels:
     app: nexus-frontend
+    slot: blue
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: nexus-frontend
+      slot: blue
   template:
     metadata:
       labels:
         app: nexus-frontend
+        slot: blue
     spec:
       containers:
         - name: nexus-frontend

--- a/k8s/frontend/deployment-blue.yaml
+++ b/k8s/frontend/deployment-blue.yaml
@@ -1,10 +1,12 @@
+# Blue/Green 배포 - Blue 슬롯
+# Service의 selector.slot 값을 blue/green으로 전환하여 트래픽을 제어합니다.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nexus-frontend-blue
   labels:
     app: nexus-frontend
-    slot: blue
+    slot: blue            # blue/green 슬롯 구분용 라벨
 spec:
   replicas: 1
   selector:

--- a/k8s/frontend/deployment-green.yaml
+++ b/k8s/frontend/deployment-green.yaml
@@ -1,10 +1,12 @@
+# Blue/Green 배포 - Green 슬롯
+# Service의 selector.slot 값을 blue/green으로 전환하여 트래픽을 제어합니다.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nexus-frontend-green
   labels:
     app: nexus-frontend
-    slot: green
+    slot: green            # blue/green 슬롯 구분용 라벨
 spec:
   replicas: 1
   selector:

--- a/k8s/frontend/deployment-green.yaml
+++ b/k8s/frontend/deployment-green.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nexus-frontend-green
+  labels:
+    app: nexus-frontend
+    slot: green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nexus-frontend
+      slot: green
+  template:
+    metadata:
+      labels:
+        app: nexus-frontend
+        slot: green
+    spec:
+      containers:
+        - name: nexus-frontend
+          image: deatytim/nexusfront:latest
+          ports:
+            - containerPort: 80

--- a/k8s/frontend/service.yaml
+++ b/k8s/frontend/service.yaml
@@ -1,3 +1,5 @@
+# Blue/Green 배포용 Service
+# slot 값을 Jenkins 파이프라인에서 blue <-> green으로 patch하여 트래픽을 전환합니다.
 apiVersion: v1
 kind: Service
 metadata:
@@ -5,7 +7,7 @@ metadata:
 spec:
   selector:
     app: nexus-frontend
-    slot: blue
+    slot: blue              # Jenkins에서 kubectl patch로 blue <-> green 전환
   ports:
     - protocol: TCP
       port: 80

--- a/k8s/frontend/service.yaml
+++ b/k8s/frontend/service.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   selector:
     app: nexus-frontend
+    slot: blue
   ports:
     - protocol: TCP
       port: 80


### PR DESCRIPTION
## Summary
- Blue/Green 무중단 배포 전환 (K8s 매니페스트 분리 + Jenkinsfile 수정)
- S3 이미지 롤백 구현, 결제/정산/메뉴/배송/대시보드 등 기능 추가 및 수정 통합

## 변경 파일
- k8s/backend/deployment-blue.yaml, deployment-green.yaml (신규)
- k8s/frontend/deployment-blue.yaml, deployment-green.yaml (신규)
- k8s/backend/service.yaml, k8s/frontend/service.yaml
- jenkins/backend/Jenkinsfile, jenkins/frontend/Jenkinsfile
- backend 도메인 코드 (orders, delivery, payment, menu, dashboard 등)
- frontend 컴포넌트 (메뉴, 알림, 배송, 대시보드 등)

## 주요 변경 사항
- Backend/Frontend Deployment를 blue/green 슬롯으로 분리하여 무중단 배포 구현
- Jenkinsfile Deploy 단계를 슬롯 확인 → 비활성 슬롯 배포 → Service selector 전환 흐름으로 변경
- S3 이미지 업로드 실패 시 롤백 처리 구현
- 결제 미완 목록 조회 및 합계 저장 기능 추가
- 정산 목록 조회 기능 추가
- 배송 스케줄러 상태 전환 흐름 수정
- 가맹점 대시보드 매출 차트 타입 캐스팅 오류 수정
- 메뉴 카테고리 필터 및 상세 조회 기능 구현

## DB & Infrastructure
- DB 변경 없음
- K8s Deployment 2벌 운영으로 pod 수 증가 (backend 1→2, frontend 1→2)

## Test Plan
- [ ] main push 후 Jenkins 파이프라인 정상 실행 확인
- [ ] Blue/Green 슬롯 전환 시 다운타임 없는지 확인
- [ ] 배포 후 전체 서비스 정상 동작 확인

## Issue
  - Closes #630
  - Closes #631
  - Closes #632
  - Closes #633