### PR TITLE
[Fix] #650 - 점주 대시보드 배송 현황 목록 폰트 불일치 수정

### DIFF
--- a/frontend/src/components/dashboard/store/MyDeliveryList.vue
+++ b/frontend/src/components/dashboard/store/MyDeliveryList.vue
@@ -50,7 +50,7 @@ onMounted(async () => {
         @keydown.space.prevent="router.push('/store-delivery')">
         <div class="flex items-center justify-between gap-3">
           <div class="flex-1 min-w-0">
-            <p class="text-sm font-bold text-gray-900 font-mono">발주 #{{ d.ordersIdx }}</p>
+            <p class="text-sm font-bold text-gray-900">발주 <span class="font-mono">#{{ d.ordersIdx }}</span></p>
             <p class="text-xs text-gray-500 mt-0.5">도착 예정: {{ d.estimatedArrival }}</p>
           </div>
           <span class="text-xs px-2 py-0.5 rounded-full font-medium shrink-0 border"


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 점주 대시보드 나의 배송 현황 목록에서 font-mono가 전체 텍스트에 적용되어 한글 폰트가 다르게 보이는 문제 수정                                                                                                                    
                                                        
## 변경 파일
- `frontend/src/components/dashboard/store/MyDeliveryList.vue`

## 주요 변경 사항
- font-mono 클래스를 p 태그 전체가 아닌 숫자 부분(#ordersIdx)에만 적용되도록 span 분리

## Test Plan
- [ ] 점주 대시보드에서 나의 배송 현황 목록의 "발주 #번호" 텍스트가 다른 컴포넌트와 동일한 폰트로 표시되는지 확인

## Issue
- Closes #650