### PR TITLE
[Chore] #653 #654 #655 - Actuator 설정 및 블루그린 배포 검증 준비 

### DIFF
--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -33,14 +33,6 @@ spring:
   sql:
     init:
       mode: never
-
-server:
-  port: 8080
-
-logging:
-  level:
-    org.springframework.security: DEBUG
-
   mail:
     host: smtp.gmail.com
     port: 587
@@ -55,5 +47,21 @@ logging:
           auth: true
           timeout: 5000
 
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always
+
 portone:
   portone_secret: ${PORTONE_SECRET}
+
+logging:
+  level:
+    org.springframework.security: DEBUG

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -13,3 +13,12 @@ spring:
 
 server:
   port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -76,7 +76,7 @@
         </form>
 
         <div class="mt-6 pt-5 border-t border-gray-100 text-center text-xs text-gray-400">
-          HANWHA Nexus SCM Platform v1.0
+          HANWHA Nexus SCM Platform v1.0 — Blue/Green 배포 테스트 v1
         </div>
       </div>
     </div>
@@ -121,7 +121,7 @@ async function handleLogin() {
     error.value = '아이디 또는 비밀번호가 올바르지 않습니다.'
     return
   }
-  
+
   if (auth.isAdmin) router.push('/dashboard')
   else if (auth.isStoreOwner) router.push('/store-dashboard')
 }

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -17,6 +17,13 @@ spec:
     - host: www.nexusscm.kro.kr
       http:
         paths:
+          - path: /actuator(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nexus-backend-service
+                port:
+                  number: 8080
           - path: /api(/|$)(.*)
             pathType: ImplementationSpecific
             backend:


### PR DESCRIPTION
## Summary
- Actuator 헬스체크 엔드포인트 노출 설정 추가 (dev/prod)
- Ingress에 /actuator 경로 프록시 설정 추가
- 블루그린 무중단 배포 검증용 임시 텍스트 추가

## 변경 파일
- `backend/src/main/resources/application-dev.yaml`
- `backend/src/main/resources/application-prod.yaml`
- `k8s/ingress.yaml`
- `frontend/src/views/LoginView.vue`

## 주요 변경 사항
- application-dev/prod.yaml에 actuator health 엔드포인트 노출 및 show-details 설정 추가
- application-dev.yaml mail 설정을 spring.mail로 위치 수정
- Ingress에 /actuator 경로를 백엔드 서비스로 프록시하도록 추가
- 로그인 페이지 하단에 블루그린 배포 테스트 문구 추가 (검증 후 제거 예정)

## Test Plan
- [ ] https://www.nexusscm.kro.kr/actuator/health 접근 확인
- [ ] 블루그린 배포 시 무중단 전환 확인

## Issue
- Closes #654
- Closes #655