### PR TITLE
[Fix] #653 - 블루그린 배포 시 활성 슬롯 재시작으로 인한 다운타임 수정 

### DIFF
--- a/backend/src/main/java/com/example/nexus/test/TestController.java
+++ b/backend/src/main/java/com/example/nexus/test/TestController.java
@@ -8,6 +8,6 @@ public class TestController {
 
     @GetMapping("/test")
     public String test() {
-        return "v2";
+        return "v3";
     }
 }

--- a/jenkins/backend/Jenkinsfile
+++ b/jenkins/backend/Jenkinsfile
@@ -81,9 +81,7 @@ spec:
             steps {
                 container('kubectl') {
                     script {
-                        // 1) blue/green 매니페스트 및 service 적용
-                        sh 'kubectl apply -f k8s/backend/deployment-blue.yaml'
-                        sh 'kubectl apply -f k8s/backend/deployment-green.yaml'
+                        // 1) service 적용
                         sh 'kubectl apply -f k8s/backend/service.yaml'
 
                         // 2) 현재 트래픽을 받고 있는 슬롯 확인
@@ -92,8 +90,9 @@ spec:
                             returnStdout: true
                         ).trim()
 
-                        // 3) 비활성 슬롯에 새 이미지 배포
+                        // 3) 비활성 슬롯만 매니페스트 적용 후 새 이미지 배포
                         def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
+                        sh "kubectl apply -f k8s/backend/deployment-${newSlot}.yaml"
                         sh "kubectl set image deployment/nexus-backend-${newSlot} nexus-backend=${IMAGE_REPO}:${BUILD_NUMBER}"
 
                         // 4) 새 pod가 Ready 상태가 될 때까지 대기

--- a/jenkins/frontend/Jenkinsfile
+++ b/jenkins/frontend/Jenkinsfile
@@ -81,9 +81,7 @@ spec:
             steps {
                 container('kubectl') {
                     script {
-                        // 1) blue/green 매니페스트, service, ingress 적용
-                        sh 'kubectl apply -f k8s/frontend/deployment-blue.yaml'
-                        sh 'kubectl apply -f k8s/frontend/deployment-green.yaml'
+                        // 1) service, ingress 적용
                         sh 'kubectl apply -f k8s/frontend/service.yaml'
                         sh 'kubectl apply -f k8s/ingress.yaml'
 
@@ -93,8 +91,9 @@ spec:
                             returnStdout: true
                         ).trim()
 
-                        // 3) 비활성 슬롯에 새 이미지 배포
+                        // 3) 비활성 슬롯만 매니페스트 적용 후 새 이미지 배포
                         def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
+                        sh "kubectl apply -f k8s/frontend/deployment-${newSlot}.yaml"
                         sh "kubectl set image deployment/nexus-frontend-${newSlot} nexus-frontend=${IMAGE_REPO}:${BUILD_NUMBER}"
 
                         // 4) 새 pod가 Ready 상태가 될 때까지 대기


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 블루그린 배포 시 활성 슬롯 매니페스트가 재적용되어 다운타임이 발생하는 문제 수정
                                                                                                                                                                                                                                  
## 변경 파일                                              
- `jenkins/backend/Jenkinsfile`
- `jenkins/frontend/Jenkinsfile`

## 주요 변경 사항
- 배포 시 blue/green 매니페스트를 둘 다 apply하던 방식에서 비활성 슬롯만 apply하도록 변경
- 활성 슬롯의 파드가 불필요하게 재시작되는 문제 해결
- 백엔드/프론트엔드 Jenkinsfile 동일 적용

## Test Plan
- [ ] main 머지 후 배포 파이프라인 트리거 확인
- [ ] curl로 /api/test 호출하며 v1 → v2 무중단 전환 확인

## Issue
- Closes #653