### PR TITLE
[Fix] #653 - 블루그린 배포 시 service.yaml 재적용으로 인한 다운타임 수정

### DIFF
--- a/backend/src/main/java/com/example/nexus/test/TestController.java
+++ b/backend/src/main/java/com/example/nexus/test/TestController.java
@@ -8,6 +8,6 @@ public class TestController {
 
     @GetMapping("/test")
     public String test() {
-        return "v3";
+        return "v4";
     }
 }

--- a/jenkins/backend/Jenkinsfile
+++ b/jenkins/backend/Jenkinsfile
@@ -81,24 +81,20 @@ spec:
             steps {
                 container('kubectl') {
                     script {
-                        // 1) service 적용
-                        sh 'kubectl apply -f k8s/backend/service.yaml'
-
-                        // 2) 현재 트래픽을 받고 있는 슬롯 확인
+                        // 1) 현재 트래픽을 받고 있는 슬롯 확인
                         def currentSlot = sh(
                             script: "kubectl get svc nexus-backend-service -o jsonpath='{.spec.selector.slot}'",
                             returnStdout: true
                         ).trim()
 
-                        // 3) 비활성 슬롯만 매니페스트 적용 후 새 이미지 배포
+                        // 2) 비활성 슬롯에 새 이미지 배포
                         def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
-                        sh "kubectl apply -f k8s/backend/deployment-${newSlot}.yaml"
                         sh "kubectl set image deployment/nexus-backend-${newSlot} nexus-backend=${IMAGE_REPO}:${BUILD_NUMBER}"
 
-                        // 4) 새 pod가 Ready 상태가 될 때까지 대기
+                        // 3) 새 pod가 Ready 상태가 될 때까지 대기
                         sh "kubectl rollout status deployment/nexus-backend-${newSlot} --timeout=120s"
 
-                        // 5) Service selector를 새 슬롯으로 전환 → 트래픽 즉시 이동
+                        // 4) Service selector를 새 슬롯으로 전환 → 트래픽 즉시 이동
                         sh "kubectl patch svc nexus-backend-service -p '{\"spec\":{\"selector\":{\"slot\":\"${newSlot}\"}}}'"
 
                         echo "Switched traffic to ${newSlot} slot"

--- a/jenkins/frontend/Jenkinsfile
+++ b/jenkins/frontend/Jenkinsfile
@@ -81,8 +81,7 @@ spec:
             steps {
                 container('kubectl') {
                     script {
-                        // 1) service, ingress 적용
-                        sh 'kubectl apply -f k8s/frontend/service.yaml'
+                        // 1) ingress 적용
                         sh 'kubectl apply -f k8s/ingress.yaml'
 
                         // 2) 현재 트래픽을 받고 있는 슬롯 확인
@@ -91,9 +90,8 @@ spec:
                             returnStdout: true
                         ).trim()
 
-                        // 3) 비활성 슬롯만 매니페스트 적용 후 새 이미지 배포
+                        // 3) 비활성 슬롯에 새 이미지 배포
                         def newSlot = (currentSlot == 'blue') ? 'green' : 'blue'
-                        sh "kubectl apply -f k8s/frontend/deployment-${newSlot}.yaml"
                         sh "kubectl set image deployment/nexus-frontend-${newSlot} nexus-frontend=${IMAGE_REPO}:${BUILD_NUMBER}"
 
                         // 4) 새 pod가 Ready 상태가 될 때까지 대기

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -17,7 +17,7 @@ spec:
     - host: www.nexusscm.kro.kr
       http:
         paths:
-          - path: /actuator(/|$)(.*)
+          - path: /()(actuator.*)
             pathType: ImplementationSpecific
             backend:
               service:


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 배포 시 service.yaml이 매번 apply되어 selector가 blue로 리셋, 활성 슬롯 트래픽이 끊기는 문제 수정
                                                                                                                                                                                                                                  
## 변경 파일                                              
- `jenkins/backend/Jenkinsfile`
- `jenkins/frontend/Jenkinsfile`

## 주요 변경 사항
- service.yaml apply 제거 — selector가 blue로 리셋되어 활성 슬롯이 강제 변경되는 원인
- deployment 매니페스트 apply 제거 — image가 latest로 리셋되어 불필요한 롤아웃 발생하는 원인
- set image + rollout status + service patch만으로 배포 수행

## Test Plan
- [ ] main 머지 후 배포 파이프라인 트리거 확인
- [ ] curl로 /api/test 호출하며 무중단 전환 확인

## Issue
- Closes #653