### PR TITLE
[Design] #673 - 브라우저 alert()을 공통 Toast 컴포넌트로 교체

### DIFF
--- a/frontend/src/components/common/Toast.vue
+++ b/frontend/src/components/common/Toast.vue
@@ -1,0 +1,27 @@
+<template>
+  <transition
+    enter-active-class="transition ease-out duration-200"
+    enter-from-class="opacity-0 translate-y-2"
+    enter-to-class="opacity-100 translate-y-0"
+    leave-active-class="transition ease-in duration-150"
+    leave-from-class="opacity-100"
+    leave-to-class="opacity-0">
+    <div
+      v-if="show"
+      class="fixed bottom-8 right-8 bg-gray-800 text-white px-5 py-3 rounded-xl shadow-xl flex items-center gap-3 z-50">
+      <CheckCircle v-if="type === 'success'" class="w-5 h-5 text-green-400 shrink-0" />
+      <AlertCircle v-else class="w-5 h-5 text-red-400 shrink-0" />
+      <span class="text-sm font-medium">{{ message }}</span>
+    </div>
+  </transition>
+</template>
+
+<script setup>
+import { CheckCircle, AlertCircle } from 'lucide-vue-next'
+
+defineProps({
+  show: { type: Boolean, default: false },
+  message: { type: String, default: '' },
+  type: { type: String, default: 'success' },
+})
+</script>

--- a/frontend/src/components/orders/store/StoreManualOrderModal.vue
+++ b/frontend/src/components/orders/store/StoreManualOrderModal.vue
@@ -3,6 +3,10 @@ import { reactive, ref, onMounted } from 'vue'
 import { Plus } from 'lucide-vue-next'
 import { formatPrice } from '../orderUtils'
 import { getProductList } from '@/api/product'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 defineProps({
   visible: { type: Boolean, required: true },
@@ -47,12 +51,12 @@ function clearProduct(item) {
 
 function submit() {
   if (form.items.length === 0) {
-    alert('품목을 입력해주세요.')
+    showToast('품목을 입력해주세요.', 'error')
     return
   }
   const validItems = form.items.filter(i => i.product)
   if (validItems.length === 0) {
-    alert('품목을 선택해주세요.')
+    showToast('품목을 선택해주세요.', 'error')
     return
   }
   emit('submit', {
@@ -123,5 +127,6 @@ function submit() {
           class="flex-1 py-2.5 rounded bg-blue-500 text-white text-sm font-bold hover:bg-blue-600 cursor-pointer">발주 생성</button>
       </div>
     </div>
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>

--- a/frontend/src/components/orders/store/StorePendingOrderList.vue
+++ b/frontend/src/components/orders/store/StorePendingOrderList.vue
@@ -2,6 +2,10 @@
 import { ClipboardList } from 'lucide-vue-next'
 import { useAddOrderItem } from '@/composables/useAddOrderItem'
 import ordersApi from '@/api/orders'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 defineProps({
   orders: { type: Array, required: true },
@@ -26,7 +30,7 @@ function onCountChange(item) {
       await ordersApi.updateStoreItemCount(item.idx, { count: item.count })
     } catch (e) {
       console.error('수량 수정 실패', e)
-      alert('수량 수정에 실패했습니다.')
+      showToast('수량 수정에 실패했습니다.', 'error')
       emit('refresh')
     }
   }, 500))
@@ -190,5 +194,6 @@ function onCountChange(item) {
       <p class="text-sm">현재 검토 대기 중인 발주서가 없습니다.</p>
       <p class="text-xs mt-1 text-gray-400">발주가 필요한 경우 본사에 문의하세요.</p>
     </div>
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>

--- a/frontend/src/composables/useToast.js
+++ b/frontend/src/composables/useToast.js
@@ -1,0 +1,12 @@
+import { ref } from 'vue'
+
+export function useToast(duration = 3000) {
+  const toast = ref({ show: false, message: '', type: 'success' })
+
+  function showToast(message, type = 'success') {
+    toast.value = { show: true, message, type }
+    setTimeout(() => { toast.value.show = false }, duration)
+  }
+
+  return { toast, showToast }
+}

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -116,6 +116,7 @@
         </div>
       </div>
     </div>
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
 
@@ -123,6 +124,10 @@
 import { ref, onMounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import api from '@/plugins/axiosinterceptor'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 const auth = useAuthStore()
 const isEditing = ref(false)
@@ -159,15 +164,15 @@ async function loadMyPage() {
 onMounted(loadMyPage)
 
 function saveProfile() {
-  alert('프로필 정보가 업데이트되었습니다.')
+  showToast('프로필 정보가 업데이트되었습니다.')
   isEditing.value = false
 }
 
 function changePassword() {
-  if (!pwForm.value.current) { alert('현재 비밀번호를 입력해주세요.'); return }
-  if (pwForm.value.next.length < 8) { alert('새 비밀번호는 8자 이상이어야 합니다.'); return }
-  if (pwForm.value.next !== pwForm.value.confirm) { alert('새 비밀번호가 일치하지 않습니다.'); return }
-  alert('비밀번호가 변경되었습니다.')
+  if (!pwForm.value.current) { showToast('현재 비밀번호를 입력해주세요.', 'error'); return }
+  if (pwForm.value.next.length < 8) { showToast('새 비밀번호는 8자 이상이어야 합니다.', 'error'); return }
+  if (pwForm.value.next !== pwForm.value.confirm) { showToast('새 비밀번호가 일치하지 않습니다.', 'error'); return }
+  showToast('비밀번호가 변경되었습니다.')
   pwForm.value = { current: '', next: '', confirm: '' }
 }
 </script>

--- a/frontend/src/views/hq/AdminAccountCreateView.vue
+++ b/frontend/src/views/hq/AdminAccountCreateView.vue
@@ -202,12 +202,17 @@
         </div>
       </div>
     </div>
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
 
 <script setup>
 import { reactive, ref } from 'vue'
 import api from '@/plugins/axiosinterceptor'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 const STORAGE_KEY = 'nexus_admin_accounts'
 
@@ -293,7 +298,7 @@ async function submitForm() {
 
   if (formMode.value === 'create') {
     if (accounts.value.some((account) => account.email.toLowerCase() === normalizedEmail)) {
-      alert('이미 존재하는 이메일 입니다.')
+      showToast('이미 존재하는 이메일 입니다.', 'error')
       return
     }
 
@@ -324,10 +329,10 @@ async function submitForm() {
         tempPassword = (match?.[1] ?? responseData).trim()
       }
 
-      if (tempPassword) alert(`임시 비밀번호: ${tempPassword}`)
-      else alert('계정이 생성되었습니다.')
+      if (tempPassword) showToast(`임시 비밀번호: ${tempPassword}`)
+      else showToast('계정이 생성되었습니다.')
     } catch (e) {
-      alert('계정 생성에 실패했습니다.')
+      showToast('계정 생성에 실패했습니다.', 'error')
       return
     }
   } else {
@@ -339,7 +344,7 @@ async function submitForm() {
           : account
       )
     )
-    alert('계정이 수정되었습니다.')
+    showToast('계정이 수정되었습니다.')
   }
 
   closeFormModal()
@@ -359,6 +364,6 @@ function confirmDelete() {
   if (!selectedAccount.value) return
   saveAccounts(accounts.value.filter((account) => account.id !== selectedAccount.value.id))
   closeDeleteModal()
-  alert('계정이 삭제되었습니다.')
+  showToast('계정이 삭제되었습니다.')
 }
 </script>

--- a/frontend/src/views/hq/DeliveryView.vue
+++ b/frontend/src/views/hq/DeliveryView.vue
@@ -240,12 +240,17 @@
         </div>
       </div>
     </div>
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { getAllDeliveries, updateDelayReason } from '@/api/delivery'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 // 상태
 const deliveries   = ref([])
@@ -437,7 +442,7 @@ async function saveDelayReason() {
     closeModal()
   } catch (err) {
     console.error('[DeliveryView] 지연 사유 저장 실패:', err)
-    alert('지연 사유 저장에 실패했습니다. 다시 시도해 주세요.')
+    showToast('지연 사유 저장에 실패했습니다. 다시 시도해 주세요.', 'error')
   } finally {
     isSaving.value = false
   }

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -3,6 +3,10 @@ import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Settings, CheckCheck } from 'lucide-vue-next'
 import ordersApi from '@/api/orders'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 import HqAutoOrderTable from '@/components/orders/hq/HqAutoOrderTable.vue'
 import HqConfirmedOrderTable from '@/components/orders/hq/HqConfirmedOrderTable.vue'
 import HqOrderHistoryTable from '@/components/orders/hq/HqOrderHistoryTable.vue'
@@ -155,17 +159,17 @@ function onConfirmedPageChange(page) {
 
 async function approveAllConfirmed() {
   if (confirmedOrders.value.length === 0) {
-    alert('승인할 확정 발주가 없습니다.')
+    showToast('승인할 확정 발주가 없습니다.', 'error')
     return
   }
   if (!confirm(`확정 발주 ${confirmedOrders.value.length}건을 전체 승인하시겠습니까?`)) return
   try {
     await ordersApi.approveAllConfirmed()
-    alert('전체 승인이 완료되었습니다.')
+    showToast('전체 승인이 완료되었습니다.')
     await fetchConfirmedOrders()
   } catch (e) {
     console.error('전체 승인 실패', e)
-    alert('전체 승인에 실패했습니다.')
+    showToast('전체 승인에 실패했습니다.', 'error')
   }
 }
 
@@ -250,22 +254,22 @@ async function approveAbnormal(o) {
   if (!confirm(`${o.store} 발주를 승인하시겠습니까?`)) return
   try {
     await ordersApi.approveDangerOrder(o.id)
-    alert(`${o.store} 발주 승인 처리되었습니다.`)
+    showToast(`${o.store} 발주 승인 처리되었습니다.`)
     await fetchAbnormalOrders()
   } catch (e) {
     console.error('이상 발주 승인 실패', e)
-    alert('승인 처리에 실패했습니다.')
+    showToast('승인 처리에 실패했습니다.', 'error')
   }
 }
 async function rejectAbnormal(o) {
   if (!confirm(`${o.store} 발주를 반려하시겠습니까?`)) return
   try {
     await ordersApi.rejectDangerOrder(o.id)
-    alert(`${o.store} 발주 반려 처리되었습니다.`)
+    showToast(`${o.store} 발주 반려 처리되었습니다.`)
     await fetchAbnormalOrders()
   } catch (e) {
     console.error('이상 발주 반려 실패', e)
-    alert('반려 처리에 실패했습니다.')
+    showToast('반려 처리에 실패했습니다.', 'error')
   }
 }
 
@@ -322,5 +326,6 @@ async function rejectAbnormal(o) {
     <!-- Modals -->
     <HqOrderDetailModal :order="selectedOrder" @close="selectedOrder = null" />
     <HqDangerSettingsModal :visible="showSettings" :init-threshold="dangerSettings.ratio" :init-months="dangerSettings.period" @close="showSettings = false" @save="saveDangerSettings" />
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>

--- a/frontend/src/views/hq/ProductView.vue
+++ b/frontend/src/views/hq/ProductView.vue
@@ -187,6 +187,7 @@
         </div>
       </div>
     </div>
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
 
@@ -195,6 +196,10 @@ import { ref, computed, onMounted } from 'vue'
 import { Trash2, Search, Tag, Plus } from 'lucide-vue-next'
 import { createCategory, readCategoryList, deleteCategory } from '@/api/category'
 import { getProductList, addNewProduct, updateProduct, deleteProduct, searchProduct } from '@/api/product'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 // --- 상태 관리 ---
 const categories = ref([])
@@ -302,17 +307,17 @@ async function handleSaveProduct() {
     if (form.value.idx) {
       // 수정 (PUT)
       await updateProduct(form.value.idx, dto)
-      alert('제품 정보가 수정되었습니다.')
+      showToast('제품 정보가 수정되었습니다.')
     } else {
       // 신규 등록 (POST)
       await addNewProduct(dto)
-      alert('새 제품이 등록되었습니다.')
+      showToast('새 제품이 등록되었습니다.')
     }
     showModal.value = false
     await fetchProducts() // 목록 새로고침
   } catch (error) {
     console.error('제품 저장 실패:', error)
-    alert('저장 중 오류가 발생했습니다.')
+    showToast('저장 중 오류가 발생했습니다.', 'error')
   }
 }
 
@@ -323,7 +328,7 @@ async function handleDeleteProduct(idx) {
     await fetchProducts()
   } catch (error) {
     console.error('삭제 실패:', error)
-    alert('삭제 중 오류가 발생했습니다.')
+    showToast('삭제 중 오류가 발생했습니다.', 'error')
   }
 }
 
@@ -336,7 +341,7 @@ async function addCategoryAction() {
     newCategoryInput.value = ''
     await fetchCategories()
   } catch (error) {
-    alert('카테고리 등록 실패')
+    showToast('카테고리 등록 실패', 'error')
   }
 }
 
@@ -347,7 +352,7 @@ async function deleteCategoryAction(idx, name) {
     await fetchCategories()
     if (selectedCategory.value === name) selectedCategory.value = '전체'
   } catch (error) {
-    alert('삭제 실패: 해당 카테고리를 사용하는 제품이 있을 수 있습니다.')
+    showToast('삭제 실패: 해당 카테고리를 사용하는 제품이 있을 수 있습니다.', 'error')
   }
 }
 </script>

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -148,12 +148,17 @@
         </div>
       </div>
     </div>
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
 
 <script setup>
 import { ref } from 'vue'
 import { FileText, Download, Newspaper, Lightbulb, ExternalLink, X } from 'lucide-vue-next'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 const tabs = [
   { label: '보고서', value: 'report' },
@@ -228,6 +233,6 @@ function firstLine(content) {
 }
 
 function handleDownload(report) {
-  alert(`${report.report_title} 다운로드 준비 중입니다.`)
+  showToast(`${report.report_title} 다운로드 준비 중입니다.`)
 }
 </script>

--- a/frontend/src/views/hq/SettlementView.vue
+++ b/frontend/src/views/hq/SettlementView.vue
@@ -185,12 +185,17 @@
       </div>
     </Teleport>
 
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
 
 <script setup>
 import { ref, computed } from 'vue'
 import { Download } from 'lucide-vue-next'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 const selectedMonth = ref('2026-04')
 const activeTab = ref('입점 매장 정산')
@@ -226,12 +231,12 @@ const filteredSettlements = computed(() => {
 })
 
 function downloadStatement(row) {
-  alert(`[INCOME_003] ${row.name} 거래 명세서(PDF) 다운로드`)
+  showToast(`${row.name} 거래 명세서(PDF) 다운로드`)
 }
 
 // 모달 '예' 클릭 시 실행 함수
 function confirmClosing() {
-  alert(`${selectedMonth.value} 재고 마감이 완료되었습니다.`)
+  showToast(`${selectedMonth.value} 재고 마감이 완료되었습니다.`)
   isModalOpen.value = false
 }
 

--- a/frontend/src/views/hq/StoreView.vue
+++ b/frontend/src/views/hq/StoreView.vue
@@ -3,6 +3,10 @@ import { ref, reactive, onMounted, computed, nextTick } from 'vue'
 import { Plus, Search, FileText, ChevronDown } from 'lucide-vue-next'
 import { getStoreList , getStoreDetailList, getPresignedUrl, postNewRegister, putStoreUpdate} from '@/api/store/index.js'
 import axios from 'axios'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 
 const searchQuery = ref('')
@@ -225,7 +229,7 @@ async function saveStore() {
       const res = await putStoreUpdate(editTarget.value.idx, updateData);
 
       if (res.data.code === 2000) {
-        alert("가맹점 정보가 수정되었습니다.");
+        showToast('가맹점 정보가 수정되었습니다.');
         await storeListRes(pagination.currentPage); // 현재 페이지 목록 새로고침[cite: 14]
         showModal.value = false;
       }
@@ -246,7 +250,7 @@ async function saveStore() {
       const res = await postNewRegister(storeRegDto);
 
       if (res.data.code === 2000) {
-        alert("가맹점이 등록되었습니다.");
+        showToast('가맹점이 등록되었습니다.');
         storesList.length = 0;
         await storeListRes();
       }
@@ -261,7 +265,7 @@ async function saveStore() {
     const serverCode = error.response?.data?.code || "Unknown Code";
 
     console.error("서버 에러 상세:", error.response?.data);
-    alert(`등록 실패 (${serverCode}): ${serverMessage}`);
+    showToast(`등록 실패 (${serverCode}): ${serverMessage}`, 'error');
   }
 }
 // <script setup> 내부에 추가
@@ -285,7 +289,7 @@ const isFormValid = computed(() => {
 // S3 미리보기 (뷰어)
 function viewPdf() {
   const filePath = detailTarget.value?.filePath;
-  if (!filePath) return alert('파일이 없습니다.');
+  if (!filePath) return showToast('파일이 없습니다.', 'error');
 
   const s3BaseUrl = 'https://nexus-store-archive.s3.ap-northeast-2.amazonaws.com/';
   window.open(s3BaseUrl + filePath, '_blank'); // 새 탭에서 열기
@@ -294,7 +298,7 @@ function viewPdf() {
 // S3 다운로드
 async function downloadPdf() {
   const filePath = detailTarget.value?.filePath;
-  if (!filePath) return alert('파일이 없습니다.');
+  if (!filePath) return showToast('파일이 없습니다.', 'error');
 
   const s3BaseUrl = 'https://nexus-store-archive.s3.ap-northeast-2.amazonaws.com/';
   const fileUrl = s3BaseUrl + filePath;
@@ -324,7 +328,7 @@ async function downloadPdf() {
   } catch (error) {
     console.error('다운로드 중 오류 발생:', error);
     // 만약 CORS 에러가 난다면, 가장 단순한 방법인 window.open을 백업으로 사용합니다.
-    alert('브라우저 보안 정책으로 인해 직접 다운로드가 제한되었습니다. 새 탭에서 파일을 엽니다.');
+    showToast('브라우저 보안 정책으로 인해 직접 다운로드가 제한되었습니다. 새 탭에서 파일을 엽니다.', 'error');
     window.open(fileUrl, '_blank');
   }
 }
@@ -763,6 +767,6 @@ onMounted(() => {
         <span class="text-[10px] text-gray-500">▶</span>
       </button>
     </div>
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
-

--- a/frontend/src/views/store/PosView.vue
+++ b/frontend/src/views/store/PosView.vue
@@ -186,9 +186,6 @@ const filteredMenus = computed(() => {
 const totalPrice = computed(() => cart.value.reduce((s, i) => s + i.price * i.quantity, 0))
 const totalQuantity = computed(() => cart.value.reduce((s, i) => s + i.quantity, 0))
 
-function showToastMsg(msg, type = 'success') {
-  showToast(msg, type)
-}
 
 function extractApiErrorMessage(error, fallback = '영업 마감 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.') {
   const message = error?.response?.data?.message
@@ -228,7 +225,7 @@ async function loadMenusAndCategories() {
     menus.value = menuAcc
   } catch (e) {
     console.error(e)
-    showToastMsg('메뉴를 불러오지 못했습니다. 로그인·API 주소를 확인해 주세요.')
+    showToast('메뉴를 불러오지 못했습니다. 로그인·API 주소를 확인해 주세요.')
     menus.value = []
   } finally {
     loadingMenus.value = false
@@ -292,10 +289,10 @@ async function processPayment(method) {
     showPaymentModal.value = false
     cart.value = []
     await loadTodaySettlement()
-    showToastMsg(`${methodKr} 결제가 완료되었습니다.`)
+    showToast(`${methodKr} 결제가 완료되었습니다.`)
   } catch (e) {
     console.error(e)
-    showToastMsg('결제 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.')
+    showToast('결제 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.')
   }
 }
 
@@ -306,7 +303,7 @@ function toggleStoreStatus() {
     Object.assign(salesData.value, { isClosed: false, total: 0, card: 0, cash: 0, count: 0 })
     saveClosedStatus(false)
     paymentHistory.value = []
-    showToastMsg('새로운 영업이 시작되었습니다.')
+    showToast('새로운 영업이 시작되었습니다.')
   }
 }
 
@@ -320,11 +317,11 @@ async function confirmClose() {
     saveClosedStatus(true)
     showCloseModal.value = false
     await loadTodaySettlement()
-    showToastMsg(closeMessage || '영업이 마감되었습니다. AI 자동 발주서가 생성되었습니다.')
+    showToast(closeMessage || '영업이 마감되었습니다. AI 자동 발주서가 생성되었습니다.')
   } catch (e) {
     console.error(e)
     showCloseModal.value = false
-    showToastMsg(extractApiErrorMessage(e))
+    showToast(extractApiErrorMessage(e))
   } finally {
     isClosingStore.value = false
   }

--- a/frontend/src/views/store/PosView.vue
+++ b/frontend/src/views/store/PosView.vue
@@ -35,7 +35,7 @@
       :payment-history="paymentHistory"
       @toggle-store-status="toggleStoreStatus" />
 
-    <PosToast :show="toast.show" :message="toast.message" />
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
 
     <PosPaymentMethodModal
       :open="showPaymentModal"
@@ -60,7 +60,8 @@ import PosHeaderBar from '@/components/pos/PosHeaderBar.vue'
 import PosMenuBoard from '@/components/pos/PosMenuBoard.vue'
 import PosCartPanel from '@/components/pos/PosCartPanel.vue'
 import PosSettlementPanel from '@/components/pos/PosSettlementPanel.vue'
-import PosToast from '@/components/pos/PosToast.vue'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
 import PosPaymentMethodModal from '@/components/pos/PosPaymentMethodModal.vue'
 import PosCloseStoreModal from '@/components/pos/PosCloseStoreModal.vue'
 
@@ -73,11 +74,10 @@ const showPaymentModal = ref(false)
 const showCloseModal = ref(false)
 const isClosingStore = ref(false)
 const currentTime = ref('')
-const toast = ref({ show: false, message: '' })
+const { toast, showToast } = useToast()
 const loadingMenus = ref(true)
 
 let timer = null
-let toastTimer = null
 
 const categories = ref(['전체'])
 const menus = ref([])
@@ -186,10 +186,8 @@ const filteredMenus = computed(() => {
 const totalPrice = computed(() => cart.value.reduce((s, i) => s + i.price * i.quantity, 0))
 const totalQuantity = computed(() => cart.value.reduce((s, i) => s + i.quantity, 0))
 
-function showToastMsg(msg) {
-  toast.value = { show: true, message: msg }
-  clearTimeout(toastTimer)
-  toastTimer = setTimeout(() => { toast.value.show = false }, 3000)
+function showToastMsg(msg, type = 'success') {
+  showToast(msg, type)
 }
 
 function extractApiErrorMessage(error, fallback = '영업 마감 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.') {
@@ -239,7 +237,7 @@ async function loadMenusAndCategories() {
 
 function addToCart(menu) {
   if (salesData.value.isClosed) {
-    alert('영업이 마감되어 주문을 추가할 수 없습니다.')
+    showToast('영업이 마감되어 주문을 추가할 수 없습니다.', 'error')
     return
   }
   const existing = cart.value.find((i) => i.menuIdx === menu.idx)
@@ -349,6 +347,5 @@ onMounted(() => {
 
 onUnmounted(() => {
   clearInterval(timer)
-  clearTimeout(toastTimer)
 })
 </script>

--- a/frontend/src/views/store/StoreInventoryView.vue
+++ b/frontend/src/views/store/StoreInventoryView.vue
@@ -29,6 +29,7 @@
       @apply-adjustments="applyLotAdjustments"
       @close="closeDetail"
     />
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
 
@@ -37,6 +38,10 @@ import { ref, computed, onMounted } from 'vue'
 import { changePosInventoryCount, getPosInventoryList } from '@/api/pos'
 import InventoryDetailModal from '@/components/inventory/InventoryDetailModal.vue'
 import StoreInventoryTable from '@/components/inventory/StoreInventoryTable.vue'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 const detailTitleId = 'store-inv-detail-title'
 const detailItem = ref(null)
@@ -148,10 +153,10 @@ async function applyLotAdjustments(changes) {
     )
     await fetchInventory()
     closeDetail()
-    alert('lot 재고 보정이 완료되었습니다.')
+    showToast('lot 재고 보정이 완료되었습니다.')
   } catch (error) {
     console.error('Failed to update POS inventory:', error)
-    alert('lot 재고 보정에 실패했습니다.')
+    showToast('lot 재고 보정에 실패했습니다.', 'error')
   }
 }
 

--- a/frontend/src/views/store/StoreOrderManageView.vue
+++ b/frontend/src/views/store/StoreOrderManageView.vue
@@ -9,6 +9,10 @@ import StoreOrderConfirmModal from '@/components/orders/store/StoreOrderConfirmM
 import StoreOrderRejectModal from '@/components/orders/store/StoreOrderRejectModal.vue'
 import StoreItemDeleteModal from '@/components/orders/store/StoreItemDeleteModal.vue'
 import ordersApi from '@/api/orders'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 const activeTab = ref('pending')
 const selectedOrder = ref(null)
@@ -81,11 +85,11 @@ async function confirmOrder() {
     const idx = pendingOrders.value.indexOf(order)
     if (idx > -1) pendingOrders.value.splice(idx, 1)
     isConfirmModalOpen.value = false
-    alert('발주서가 확정되었습니다.')
+    showToast('발주서가 확정되었습니다.')
     fetchOrderHistory()
   } catch (e) {
     console.error('발주서 확정 실패', e)
-    alert('발주서 확정에 실패했습니다.')
+    showToast('발주서 확정에 실패했습니다.', 'error')
   }
 }
 
@@ -101,10 +105,10 @@ async function rejectOrder() {
     const idx = pendingOrders.value.indexOf(order)
     if (idx > -1) pendingOrders.value.splice(idx, 1)
     isRejectModalOpen.value = false
-    alert('발주서가 거절되었습니다.')
+    showToast('발주서가 거절되었습니다.')
   } catch (e) {
     console.error('발주서 거절 실패', e)
-    alert('발주서 거절에 실패했습니다.')
+    showToast('발주서 거절에 실패했습니다.', 'error')
   }
 }
 
@@ -121,7 +125,7 @@ async function confirmDeleteItem() {
     fetchPendingOrders()
   } catch (e) {
     console.error('품목 삭제 실패', e)
-    alert('품목 삭제에 실패했습니다.')
+    showToast('품목 삭제에 실패했습니다.', 'error')
   }
 }
 
@@ -130,10 +134,10 @@ async function cancelOrder(order) {
   try {
     await ordersApi.cancelOrder(order.idx)
     order.ordersStatus = 'CANCELLED'
-    alert('발주가 취소되었습니다.')
+    showToast('발주가 취소되었습니다.')
   } catch (e) {
     console.error('발주 취소 실패', e)
-    alert('발주 취소에 실패했습니다.')
+    showToast('발주 취소에 실패했습니다.', 'error')
   }
 }
 
@@ -142,12 +146,12 @@ const showManualForm = ref(false)
 async function submitManualOrder(data) {
   try {
     await ordersApi.createStoreManualOrder(data)
-    alert('발주가 생성되었습니다.')
+    showToast('발주가 생성되었습니다.')
     showManualForm.value = false
     activeTab.value = 'pending'
   } catch (e) {
     console.error('수동 발주 생성 실패', e)
-    alert('발주 생성에 실패했습니다.')
+    showToast('발주 생성에 실패했습니다.', 'error')
   }
 }
 </script>
@@ -194,5 +198,6 @@ async function submitManualOrder(data) {
 
     <StoreItemDeleteModal :item="deleteTarget.item" :visible="isDeleteModalOpen"
       @close="isDeleteModalOpen = false" @confirm="confirmDeleteItem" />
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>

--- a/frontend/src/views/store/StoreRecipeView.vue
+++ b/frontend/src/views/store/StoreRecipeView.vue
@@ -338,12 +338,17 @@
         </div>
       </div>
     </div>
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
 
 <script setup>
 import { ref, computed , onMounted} from 'vue'
 import {Plus, Trash2, Search, Image as ImageIcon, ChevronDown, Tag} from 'lucide-vue-next'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 // ─────────────────────────────────────────────
 //  상품 목록 (매장 제품 관리의 제품코드와 동일하게 맞춤)
@@ -560,7 +565,7 @@ async function addCategoryAction() {
     newCategoryInput.value = ''
     await fetchCategories()
   } catch (error) {
-    alert('카테고리 등록 실패')
+    showToast('카테고리 등록 실패', 'error')
   }
 }
 
@@ -570,7 +575,7 @@ async function deleteCategoryAction(idx, name) {
     await deleteCategory(idx)
     await fetchCategories()
   } catch (error) {
-    alert('삭제 실패: 해당 카테고리를 사용하는 데이터가 있을 수 있습니다.')
+    showToast('삭제 실패: 해당 카테고리를 사용하는 데이터가 있을 수 있습니다.', 'error')
   }
 }
 

--- a/frontend/src/views/store/StoreSettlementView.vue
+++ b/frontend/src/views/store/StoreSettlementView.vue
@@ -203,12 +203,17 @@
         </div>
       </div>
     </div>
+    <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
 
 <script setup>
 import { Download } from 'lucide-vue-next'
 import { ref, computed } from 'vue'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 const activeTab = ref('sales')
 
@@ -318,6 +323,6 @@ const paidAmount = computed(() =>
 )
 
 function downloadStatement(row){
-  alert(`${row.item} 다운로드`)
+  showToast(`${row.item} 다운로드`)
 }
 </script>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 모든 프론트엔드 페이지의 브라우저 alert()을 공통 Toast 컴포넌트로 교체 (RecipeView 제외)                                                                                                                                        
                                                                                                                                                                                                                                
## 변경 파일                                              
- `components/common/Toast.vue` (신규)
- `composables/useToast.js` (신규)
- `views/hq/AdminAccountCreateView.vue`
- `views/hq/HqOrderManageView.vue`
- `views/hq/StoreView.vue`
- `views/hq/DeliveryView.vue`
- `views/hq/ProductView.vue`
- `views/hq/SettlementView.vue`
- `views/hq/ReportView.vue`
- `views/store/StoreOrderManageView.vue`
- `views/store/PosView.vue`
- `views/store/StoreRecipeView.vue`
- `views/store/StoreSettlementView.vue`
- `views/store/StoreInventoryView.vue`
- `views/ProfileView.vue`
- `components/orders/store/StoreManualOrderModal.vue`
- `components/orders/store/StorePendingOrderList.vue`

## 주요 변경 사항
- 공통 Toast.vue 컴포넌트 및 useToast composable 생성
- 본사 7개 페이지 alert()을 Toast로 교체
- 가맹점 5개 페이지 alert()을 Toast로 교체
- 공통 1개 페이지(ProfileView) alert()을 Toast로 교체
- 컴포넌트 2개(StoreManualOrderModal, StorePendingOrderList) alert()을 Toast로 교체
- PosView의 PosToast 제거 및 showToastMsg 불필요 래퍼 제거

## Test Plan
- [ ] 각 페이지에서 성공/에러 Toast가 정상 표시되는지 확인
- [ ] POS 페이지 결제, 영업 시작/마감 Toast 동작 확인

## Issue
- Closes #673