### PR TITLE
[Design] #673 - 본사 메뉴·주문 페이지 alert()을 공통 Toast로 교체 

### DIFF
--- a/frontend/src/components/orders/store/StorePendingOrderList.vue
+++ b/frontend/src/components/orders/store/StorePendingOrderList.vue
@@ -13,7 +13,7 @@ defineProps({
 
 const emit = defineEmits(['confirm', 'reject', 'refresh', 'delete-item'])
 
-const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, clearAddItemProduct, submitAddItem } = useAddOrderItem(() => emit('refresh'))
+const { addItemForm, openAddItemForm, filteredProducts, selectAddItemProduct, clearAddItemProduct, submitAddItem } = useAddOrderItem(() => emit('refresh'), showToast)
 
 function sortedItems(order) {
   return [...(order.ordersItemList || [])].sort((a, b) => b.idx - a.idx)

--- a/frontend/src/composables/useAddOrderItem.js
+++ b/frontend/src/composables/useAddOrderItem.js
@@ -2,7 +2,7 @@ import { ref } from 'vue'
 import ordersApi from '@/api/orders'
 import { getProductList } from '@/api/product'
 
-export function useAddOrderItem(fetchPendingOrders) {
+export function useAddOrderItem(fetchPendingOrders, showToast) {
   const addItemForm = ref(null)
   const productList = ref([])
 
@@ -38,8 +38,8 @@ export function useAddOrderItem(fetchPendingOrders) {
 
   async function submitAddItem(order) {
     const form = addItemForm.value
-    if (!form.productIdx) { alert('품목을 선택해주세요.'); return }
-    if (!form.count || form.count < 1) { alert('수량을 입력해주세요.'); return }
+    if (!form.productIdx) { showToast('품목을 선택해주세요.', 'error'); return }
+    if (!form.count || form.count < 1) { showToast('수량을 입력해주세요.', 'error'); return }
     try {
       await ordersApi.addStoreOrderItem(order.idx, {
         productIdx: form.productIdx,
@@ -49,7 +49,7 @@ export function useAddOrderItem(fetchPendingOrders) {
       fetchPendingOrders()
     } catch (e) {
       console.error('품목 추가 실패', e)
-      alert('품목 추가에 실패했습니다.')
+      showToast('품목 추가에 실패했습니다.', 'error')
     }
   }
 

--- a/frontend/src/views/hq/RecipeView.vue
+++ b/frontend/src/views/hq/RecipeView.vue
@@ -3,6 +3,10 @@ import {ref, computed, onMounted, reactive, watch} from 'vue'
 import {Plus, Search, Image as ImageIcon, Tag, Trash2, ChevronRight, ChevronLeft} from 'lucide-vue-next'
 import {getProductList, getCategoryList, getMenuList, getMenuItemList, getPresignedUrl, postNewRegister, putMenuUpdate, putMenuDelete, postMenuCategoryRegister, deleteCategory} from '@/api/menu/index.js'
 import axios from 'axios'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+
+const { toast, showToast } = useToast()
 
 const showCategoryModal = ref(false)
 const newCategoryInput = ref('')
@@ -128,7 +132,7 @@ async function openEditMenuModal(menu) {
     showMenuModal.value = true;
   } catch (error) {
     console.error("수정 데이터 로드 실패:", error);
-    alert("메뉴 상세 정보를 불러오는 중 오류가 발생했습니다.");
+    showToast("메뉴 상세 정보를 불러오는 중 오류가 발생했습니다.", 'error');
   }
 }
 
@@ -162,7 +166,7 @@ function handleImageChange(e) {
 
   const allowedTypes = ['image/jpg', 'image/jpeg', 'image/png'];
   if (!allowedTypes.includes(file.type)) {
-    alert('JPG, PNG 형식의 이미지 파일만 업로드할 수 있습니다.');
+    showToast('JPG, PNG 형식의 이미지 파일만 업로드할 수 있습니다.', 'error');
     e.target.value = '';
     return;
   }
@@ -184,7 +188,7 @@ async function uploadFileToS3() {
     });
     return s3Path;
   } catch {
-    alert("파일 업로드 중 오류가 발생했습니다. 다시 시도해주세요.")
+    showToast("파일 업로드 중 오류가 발생했습니다. 다시 시도해주세요.", 'error')
   }
 }
 
@@ -241,7 +245,7 @@ async function saveMenu() {
       : await postNewRegister(dto);
 
     if (res.data.code === 2000) {
-      alert(editTarget.value ? "메뉴가 수정되었습니다." : "신규 메뉴가 등록되었습니다.");
+      showToast(editTarget.value ? "메뉴가 수정되었습니다." : "신규 메뉴가 등록되었습니다.");
 
       if (!editTarget.value) menus.value.length = 0; // 등록일 때만 목록 초기화
       await getMenuRes();
@@ -252,7 +256,7 @@ async function saveMenu() {
 
   }catch (error) {
     const serverMessage = error.response?.data?.message || error.message;
-    alert(`등록 실패 : ${serverMessage}`);
+    showToast(`등록 실패 : ${serverMessage}`, 'error');
   }
 }
 
@@ -268,14 +272,14 @@ async function addCategoryAction() {
     const res = await postMenuCategoryRegister(categoryName)
     console.log(res)
     if (res.data.code === 2000) {
-      alert("카테고리가 등록되었습니다.");
+      showToast("카테고리가 등록되었습니다.");
 
       newCategoryInput.value = ''
       await categoryRes()
     }
   } catch (error) {
     const serverMessage = error.response?.data?.message || error.message;
-    alert(`등록 실패 : ${serverMessage}`);
+    showToast(`등록 실패 : ${serverMessage}`, 'error');
   }
 }
 
@@ -285,13 +289,13 @@ async function deleteCategoryAction(idx, name) {
   try {
     const res = await deleteCategory(idx)
     if (res.data.code === 2000) {
-      alert("카테고리가 삭제되었습니다.");
+      showToast("카테고리가 삭제되었습니다.");
       await categoryRes()
     }
 
   } catch (error) {
     const serverMessage = error.response?.data?.message || error.message;
-    alert(`등록 실패 : ${serverMessage}`);
+    showToast(`등록 실패 : ${serverMessage}`, 'error');
   }
 }
 
@@ -313,7 +317,7 @@ async function confirmDelete() {
   if (deleteTarget.value) {
     const res = await putMenuDelete(deleteTarget.value.idx)
     if (res.data.code === 2000) {
-      alert("메뉴가 삭제되었습니다.");
+      showToast("메뉴가 삭제되었습니다.");
       await getMenuRes();
     }
   }
@@ -366,6 +370,7 @@ onMounted(() => {
 
 <template>
   <div class="p-5 space-y-4">
+    <Toast :toast="toast" />
     <div class="flex items-center justify-between">
       <div>
         <h1 class="text-xl font-bold text-gray-900 tracking-tight">메뉴 관리</h1>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- RecipeView, useAddOrderItem composable의 alert()을 공통 Toast 컴포넌트로 교체                                                                                                                                                   
                                                                                                                                                                                                                                  
## 변경 파일
- frontend/src/views/hq/RecipeView.vue
- frontend/src/composables/useAddOrderItem.js
- frontend/src/components/orders/store/StorePendingOrderList.vue

## 주요 변경 사항
- RecipeView에 Toast 컴포넌트 및 useToast 추가, alert() 8건을 showToast()로 교체
- useAddOrderItem composable에 showToast를 파라미터로 전달받도록 변경, alert() 3건 교체
- StorePendingOrderList에서 useAddOrderItem 호출 시 showToast 전달

## Test Plan
- [x] 본사 메뉴 등록/수정/삭제 시 Toast 정상 표시 확인
- [x] 카테고리 등록/삭제 시 Toast 정상 표시 확인
- [x] 이미지 업로드 검증 실패 시 Toast 에러 표시 확인
- [x] 가맹점 주문 품목 추가 시 유효성 검증 Toast 표시 확인

## Issue
- Closes #673