### PR TITLE
[Design] #682 - 공통 ConfirmModal 컴포넌트 구현 및 confirm() 교체 

### DIFF
--- a/frontend/src/components/common/ConfirmModal.vue
+++ b/frontend/src/components/common/ConfirmModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="open" class="fixed inset-0 bg-gray-900/40 backdrop-blur-sm z-50 flex items-center justify-center p-4" @click.self="$emit('close')">
+  <div v-if="open" class="fixed inset-0 bg-gray-900/40 backdrop-blur-sm z-[60] flex items-center justify-center p-4" @click.self="$emit('close')">
     <div class="bg-white rounded-xl border border-gray-200 shadow-xl w-full max-w-sm text-center p-8">
       <div
         class="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-5"
@@ -7,7 +7,7 @@
         <component :is="iconComponent" class="w-8 h-8" :class="iconColorClass" />
       </div>
       <h2 class="text-xl font-bold text-gray-900 mb-2">{{ title }}</h2>
-      <p v-if="message" class="text-sm text-gray-500 mb-8 leading-relaxed">{{ message }}</p>
+      <p v-if="message" class="text-sm text-gray-500 mb-8 leading-relaxed whitespace-pre-line">{{ message }}</p>
       <div class="flex gap-3">
         <button
           type="button"

--- a/frontend/src/components/common/ConfirmModal.vue
+++ b/frontend/src/components/common/ConfirmModal.vue
@@ -1,0 +1,56 @@
+<template>
+  <div v-if="open" class="fixed inset-0 bg-gray-900/40 backdrop-blur-sm z-50 flex items-center justify-center p-4" @click.self="$emit('close')">
+    <div class="bg-white rounded-xl border border-gray-200 shadow-xl w-full max-w-sm text-center p-8">
+      <div
+        class="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-5"
+        :class="iconBgClass">
+        <component :is="iconComponent" class="w-8 h-8" :class="iconColorClass" />
+      </div>
+      <h2 class="text-xl font-bold text-gray-900 mb-2">{{ title }}</h2>
+      <p v-if="message" class="text-sm text-gray-500 mb-8 leading-relaxed">{{ message }}</p>
+      <div class="flex gap-3">
+        <button
+          type="button"
+          class="flex-1 py-3 bg-white border border-gray-200 text-gray-600 rounded-xl text-sm font-bold hover:bg-gray-50 transition-colors cursor-pointer"
+          @click="$emit('close')">
+          {{ cancelText }}
+        </button>
+        <button
+          type="button"
+          class="flex-1 py-3 text-white rounded-xl text-sm font-bold shadow-sm transition-colors cursor-pointer"
+          :class="confirmBtnClass"
+          @click="$emit('confirm')">
+          {{ confirmText }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { AlertCircle, AlertTriangle, Info } from 'lucide-vue-next'
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  title: { type: String, required: true },
+  message: { type: String, default: '' },
+  confirmText: { type: String, default: '확인' },
+  cancelText: { type: String, default: '취소' },
+  type: { type: String, default: 'info', validator: v => ['danger', 'warning', 'info'].includes(v) },
+})
+
+defineEmits(['close', 'confirm'])
+
+const typeConfig = {
+  danger:  { icon: AlertCircle,   iconBg: 'bg-red-50',    iconColor: 'text-red-500',    btn: 'bg-red-500 hover:bg-red-600' },
+  warning: { icon: AlertTriangle, iconBg: 'bg-orange-50',  iconColor: 'text-orange-500', btn: 'bg-orange-500 hover:bg-orange-600' },
+  info:    { icon: Info,          iconBg: 'bg-blue-50',    iconColor: 'text-blue-500',   btn: 'bg-blue-500 hover:bg-blue-600' },
+}
+
+const config = computed(() => typeConfig[props.type])
+const iconComponent = computed(() => config.value.icon)
+const iconBgClass = computed(() => config.value.iconBg)
+const iconColorClass = computed(() => config.value.iconColor)
+const confirmBtnClass = computed(() => config.value.btn)
+</script>

--- a/frontend/src/views/hq/AdminAccountCreateView.vue
+++ b/frontend/src/views/hq/AdminAccountCreateView.vue
@@ -176,32 +176,14 @@
       </div>
     </div>
 
-    <div v-if="isDeleteModalOpen" class="fixed inset-0 z-50 flex items-center justify-center">
-      <div class="absolute inset-0 bg-black/40" @click="closeDeleteModal"></div>
-      <div class="relative w-full max-w-sm bg-white rounded-lg border border-gray-200 shadow-xl p-6">
-        <h3 class="text-base font-bold text-gray-900">계정 삭제</h3>
-        <p class="text-sm text-gray-600 mt-2">
-          <span class="font-semibold">{{ selectedAccount?.name }}</span> 계정을 삭제하시겠습니까?
-        </p>
-        <p class="text-xs text-gray-400 mt-1">삭제된 계정은 복구할 수 없습니다.</p>
-        <div class="flex gap-3 mt-5">
-          <button
-            type="button"
-            @click="closeDeleteModal"
-            class="flex-1 py-2.5 rounded border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 cursor-pointer"
-          >
-            취소
-          </button>
-          <button
-            type="button"
-            @click="confirmDelete"
-            class="flex-1 py-2.5 rounded bg-red-500 text-white text-sm font-bold hover:bg-red-600 cursor-pointer"
-          >
-            삭제
-          </button>
-        </div>
-      </div>
-    </div>
+    <ConfirmModal
+      :open="isDeleteModalOpen"
+      :title="`${selectedAccount?.name} 계정을 삭제하시겠습니까?`"
+      message="삭제된 계정은 복구할 수 없습니다."
+      confirm-text="삭제"
+      type="danger"
+      @close="closeDeleteModal"
+      @confirm="confirmDelete" />
     <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
 </template>
@@ -210,6 +192,7 @@
 import { reactive, ref } from 'vue'
 import api from '@/plugins/axiosinterceptor'
 import Toast from '@/components/common/Toast.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import { useToast } from '@/composables/useToast'
 
 const { toast, showToast } = useToast()

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -4,9 +4,23 @@ import { useRoute, useRouter } from 'vue-router'
 import { Settings, CheckCheck } from 'lucide-vue-next'
 import ordersApi from '@/api/orders'
 import Toast from '@/components/common/Toast.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import { useToast } from '@/composables/useToast'
 
 const { toast, showToast } = useToast()
+
+const confirmState = ref({ open: false, type: '', title: '', confirmText: '확인', action: null })
+function openConfirm({ type, title, confirmText, action }) {
+  confirmState.value = { open: true, type, title, confirmText, action }
+}
+function closeConfirm() {
+  confirmState.value = { open: false, type: '', title: '', confirmText: '확인', action: null }
+}
+async function handleConfirm() {
+  const action = confirmState.value.action
+  closeConfirm()
+  if (action) await action()
+}
 import HqAutoOrderTable from '@/components/orders/hq/HqAutoOrderTable.vue'
 import HqConfirmedOrderTable from '@/components/orders/hq/HqConfirmedOrderTable.vue'
 import HqOrderHistoryTable from '@/components/orders/hq/HqOrderHistoryTable.vue'
@@ -157,20 +171,26 @@ function onConfirmedPageChange(page) {
   fetchConfirmedOrders(confirmedSearchParams.value, page)
 }
 
-async function approveAllConfirmed() {
+function approveAllConfirmed() {
   if (confirmedOrders.value.length === 0) {
     showToast('승인할 확정 발주가 없습니다.', 'error')
     return
   }
-  if (!confirm(`확정 발주 ${confirmedOrders.value.length}건을 전체 승인하시겠습니까?`)) return
-  try {
-    await ordersApi.approveAllConfirmed()
-    showToast('전체 승인이 완료되었습니다.')
-    await fetchConfirmedOrders()
-  } catch (e) {
-    console.error('전체 승인 실패', e)
-    showToast('전체 승인에 실패했습니다.', 'error')
-  }
+  openConfirm({
+    type: 'warning',
+    title: `확정 발주 ${confirmedOrders.value.length}건을 전체 승인하시겠습니까?`,
+    confirmText: '전체 승인',
+    action: async () => {
+      try {
+        await ordersApi.approveAllConfirmed()
+        showToast('전체 승인이 완료되었습니다.')
+        await fetchConfirmedOrders()
+      } catch (e) {
+        console.error('전체 승인 실패', e)
+        showToast('전체 승인에 실패했습니다.', 'error')
+      }
+    },
+  })
 }
 
 // Tab routing
@@ -250,27 +270,39 @@ async function saveDangerSettings({ threshold, months }) {
 }
 
 // Abnormal order actions
-async function approveAbnormal(o) {
-  if (!confirm(`${o.store} 발주를 승인하시겠습니까?`)) return
-  try {
-    await ordersApi.approveDangerOrder(o.id)
-    showToast(`${o.store} 발주 승인 처리되었습니다.`)
-    await fetchAbnormalOrders()
-  } catch (e) {
-    console.error('이상 발주 승인 실패', e)
-    showToast('승인 처리에 실패했습니다.', 'error')
-  }
+function approveAbnormal(o) {
+  openConfirm({
+    type: 'info',
+    title: `${o.store} 발주를 승인하시겠습니까?`,
+    confirmText: '승인',
+    action: async () => {
+      try {
+        await ordersApi.approveDangerOrder(o.id)
+        showToast(`${o.store} 발주 승인 처리되었습니다.`)
+        await fetchAbnormalOrders()
+      } catch (e) {
+        console.error('이상 발주 승인 실패', e)
+        showToast('승인 처리에 실패했습니다.', 'error')
+      }
+    },
+  })
 }
-async function rejectAbnormal(o) {
-  if (!confirm(`${o.store} 발주를 반려하시겠습니까?`)) return
-  try {
-    await ordersApi.rejectDangerOrder(o.id)
-    showToast(`${o.store} 발주 반려 처리되었습니다.`)
-    await fetchAbnormalOrders()
-  } catch (e) {
-    console.error('이상 발주 반려 실패', e)
-    showToast('반려 처리에 실패했습니다.', 'error')
-  }
+function rejectAbnormal(o) {
+  openConfirm({
+    type: 'danger',
+    title: `${o.store} 발주를 반려하시겠습니까?`,
+    confirmText: '반려',
+    action: async () => {
+      try {
+        await ordersApi.rejectDangerOrder(o.id)
+        showToast(`${o.store} 발주 반려 처리되었습니다.`)
+        await fetchAbnormalOrders()
+      } catch (e) {
+        console.error('이상 발주 반려 실패', e)
+        showToast('반려 처리에 실패했습니다.', 'error')
+      }
+    },
+  })
 }
 
 </script>
@@ -327,5 +359,12 @@ async function rejectAbnormal(o) {
     <HqOrderDetailModal :order="selectedOrder" @close="selectedOrder = null" />
     <HqDangerSettingsModal :visible="showSettings" :init-threshold="dangerSettings.ratio" :init-months="dangerSettings.period" @close="showSettings = false" @save="saveDangerSettings" />
     <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
+    <ConfirmModal
+      :open="confirmState.open"
+      :title="confirmState.title"
+      :confirm-text="confirmState.confirmText"
+      :type="confirmState.type"
+      @close="closeConfirm"
+      @confirm="handleConfirm" />
   </div>
 </template>

--- a/frontend/src/views/hq/ProductView.vue
+++ b/frontend/src/views/hq/ProductView.vue
@@ -188,6 +188,13 @@
       </div>
     </div>
     <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
+    <ConfirmModal
+      :open="confirmState.open"
+      :title="confirmState.title"
+      :confirm-text="confirmState.confirmText"
+      type="danger"
+      @close="closeConfirm"
+      @confirm="handleConfirm" />
   </div>
 </template>
 
@@ -197,9 +204,23 @@ import { Trash2, Search, Tag, Plus } from 'lucide-vue-next'
 import { createCategory, readCategoryList, deleteCategory } from '@/api/category'
 import { getProductList, addNewProduct, updateProduct, deleteProduct, searchProduct } from '@/api/product'
 import Toast from '@/components/common/Toast.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import { useToast } from '@/composables/useToast'
 
 const { toast, showToast } = useToast()
+
+const confirmState = ref({ open: false, title: '', confirmText: '확인', action: null })
+function openConfirm({ title, confirmText, action }) {
+  confirmState.value = { open: true, title, confirmText, action }
+}
+function closeConfirm() {
+  confirmState.value = { open: false, title: '', confirmText: '확인', action: null }
+}
+async function handleConfirm() {
+  const action = confirmState.value.action
+  closeConfirm()
+  if (action) await action()
+}
 
 // --- 상태 관리 ---
 const categories = ref([])
@@ -321,15 +342,20 @@ async function handleSaveProduct() {
   }
 }
 
-async function handleDeleteProduct(idx) {
-  if (!confirm('이 제품을 삭제하시겠습니까?')) return
-  try {
-    await deleteProduct(idx)
-    await fetchProducts()
-  } catch (error) {
-    console.error('삭제 실패:', error)
-    showToast('삭제 중 오류가 발생했습니다.', 'error')
-  }
+function handleDeleteProduct(idx) {
+  openConfirm({
+    title: '이 제품을 삭제하시겠습니까?',
+    confirmText: '삭제',
+    action: async () => {
+      try {
+        await deleteProduct(idx)
+        await fetchProducts()
+      } catch (error) {
+        console.error('삭제 실패:', error)
+        showToast('삭제 중 오류가 발생했습니다.', 'error')
+      }
+    },
+  })
 }
 
 // --- 카테고리 액션 (기존 코드 유지) ---
@@ -345,14 +371,19 @@ async function addCategoryAction() {
   }
 }
 
-async function deleteCategoryAction(idx, name) {
-  if (!confirm(`'${name}' 카테고리를 삭제하시겠습니까?`)) return
-  try {
-    await deleteCategory(idx)
-    await fetchCategories()
-    if (selectedCategory.value === name) selectedCategory.value = '전체'
-  } catch (error) {
-    showToast('삭제 실패: 해당 카테고리를 사용하는 제품이 있을 수 있습니다.', 'error')
-  }
+function deleteCategoryAction(idx, name) {
+  openConfirm({
+    title: `'${name}' 카테고리를 삭제하시겠습니까?`,
+    confirmText: '삭제',
+    action: async () => {
+      try {
+        await deleteCategory(idx)
+        await fetchCategories()
+        if (selectedCategory.value === name) selectedCategory.value = '전체'
+      } catch (error) {
+        showToast('삭제 실패: 해당 카테고리를 사용하는 제품이 있을 수 있습니다.', 'error')
+      }
+    },
+  })
 }
 </script>

--- a/frontend/src/views/hq/RecipeView.vue
+++ b/frontend/src/views/hq/RecipeView.vue
@@ -618,21 +618,14 @@ onMounted(() => {
         </div>
       </div>
     </div>
-    <!-- 삭제 확인 모달-->
-    <div v-if="showDeleteConfirm" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div class="absolute inset-0 bg-black/40 " @click="showDeleteConfirm = false"></div>
-      <div class="relative bg-white rounded-xl w-full max-w-sm border border-gray-200 shadow-xl p-8 text-center animate-in fade-in zoom-in-95 duration-200">
-        <div class="text-4xl mb-4">🗑️</div>
-        <h3 class="font-bold text-gray-900 text-base mb-2">메뉴를 삭제하시겠습니까?</h3>
-        <p class="text-xs text-gray-400 mb-6">이 작업은 되돌릴 수 없습니다.</p>
-        <div class="flex gap-3">
-          <button @click="showDeleteConfirm = false" class="flex-1 py-2.5 rounded-lg border border-gray-200 text-sm font-bold text-gray-500 hover:bg-gray-50 transition-colors cursor-pointer">취소
-          </button>
-          <button @click="confirmDelete" class="flex-1 py-2.5 rounded-lg bg-red-500 text-white text-sm font-bold hover:bg-red-600 transition-colors cursor-pointer">삭제
-          </button>
-        </div>
-      </div>
-    </div>
+    <ConfirmModal
+      :open="showDeleteConfirm"
+      title="메뉴를 삭제하시겠습니까?"
+      message="이 작업은 되돌릴 수 없습니다."
+      confirm-text="삭제"
+      type="danger"
+      @close="showDeleteConfirm = false"
+      @confirm="confirmDelete" />
     <div v-if="showCategoryModal" class="fixed inset-0 z-50 flex items-center justify-center">
       <div class="absolute inset-0 bg-black/40" @click="showCategoryModal = false"></div>
       <div class="relative bg-white rounded-lg w-full max-w-md border border-gray-200 shadow-xl">

--- a/frontend/src/views/hq/RecipeView.vue
+++ b/frontend/src/views/hq/RecipeView.vue
@@ -4,9 +4,18 @@ import {Plus, Search, Image as ImageIcon, Tag, Trash2, ChevronRight, ChevronLeft
 import {getProductList, getCategoryList, getMenuList, getMenuItemList, getPresignedUrl, postNewRegister, putMenuUpdate, putMenuDelete, postMenuCategoryRegister, deleteCategory} from '@/api/menu/index.js'
 import axios from 'axios'
 import Toast from '@/components/common/Toast.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import { useToast } from '@/composables/useToast'
 
 const { toast, showToast } = useToast()
+
+const confirmState = ref({ open: false, idx: null, name: '' })
+function openDeleteCategoryConfirm(idx, name) {
+  confirmState.value = { open: true, idx, name }
+}
+function closeConfirm() {
+  confirmState.value = { open: false, idx: null, name: '' }
+}
 
 const showCategoryModal = ref(false)
 const newCategoryInput = ref('')
@@ -284,8 +293,9 @@ async function addCategoryAction() {
 }
 
 // 카테고리 삭제
-async function deleteCategoryAction(idx, name) {
-  if (!confirm(`'${name}' 카테고리를 삭제하시겠습니까?`)) return
+async function deleteCategoryAction() {
+  const { idx, name } = confirmState.value
+  closeConfirm()
   try {
     const res = await deleteCategory(idx)
     if (res.data.code === 2000) {
@@ -371,6 +381,13 @@ onMounted(() => {
 <template>
   <div class="p-5 space-y-4">
     <Toast :toast="toast" />
+    <ConfirmModal
+      :open="confirmState.open"
+      :title="`'${confirmState.name}' 카테고리를 삭제하시겠습니까?`"
+      confirm-text="삭제"
+      type="danger"
+      @close="closeConfirm"
+      @confirm="deleteCategoryAction" />
     <div class="flex items-center justify-between">
       <div>
         <h1 class="text-xl font-bold text-gray-900 tracking-tight">메뉴 관리</h1>
@@ -637,7 +654,7 @@ onMounted(() => {
               <div v-for="cat in categories" :key="cat.categoryIdx"
                    class="flex items-center justify-between px-4 py-2.5 hover:bg-gray-50">
                 <span class="text-sm font-medium text-gray-700">{{ cat.menuCategoryName }}</span>
-                <button @click="deleteCategoryAction(cat.categoryIdx, cat.menuCategoryName)" class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer">
+                <button @click="openDeleteCategoryConfirm(cat.categoryIdx, cat.menuCategoryName)" class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer">
                   <Trash2 class="w-3.5 h-3.5" />
                 </button>
               </div>

--- a/frontend/src/views/hq/SettlementView.vue
+++ b/frontend/src/views/hq/SettlementView.vue
@@ -155,35 +155,15 @@
       </table>
     </div>
 
-    <Teleport to="body">
-      <div v-if="isModalOpen" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
-        <div class="bg-white rounded-xl shadow-xl max-w-sm w-full overflow-hidden">
-          <div class="p-6 text-center">
-            <div class="mb-4 flex justify-center text-amber-500">
-              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-            </div>
-            <h3 class="text-lg font-bold text-gray-900 mb-2">마감 확인</h3>
-            <p class="text-sm text-gray-600 leading-relaxed">
-              마감된 기간의 데이터는 입력 및 수정이 불가합니다.<br/>마감하시겠습니까?
-            </p>
-          </div>
-          <div class="flex border-t border-gray-100">
-            <button
-              @click="isModalOpen = false"
-              class="flex-1 px-4 py-3 text-sm font-semibold text-gray-500 hover:bg-gray-50 transition-colors"
-            >
-              아니오
-            </button>
-            <button
-              @click="confirmClosing"
-              class="flex-1 px-4 py-3 text-sm font-semibold text-[#F37321] hover:bg-orange-50 border-l border-gray-100 transition-colors"
-            >
-              예
-            </button>
-          </div>
-        </div>
-      </div>
-    </Teleport>
+    <ConfirmModal
+      :open="isModalOpen"
+      title="마감 확인"
+      :message="'마감된 기간의 데이터는 입력 및 수정이 불가합니다.\n마감하시겠습니까?'"
+      confirm-text="예"
+      cancel-text="아니오"
+      type="warning"
+      @close="isModalOpen = false"
+      @confirm="confirmClosing" />
 
     <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </div>
@@ -193,6 +173,7 @@
 import { ref, computed } from 'vue'
 import { Download } from 'lucide-vue-next'
 import Toast from '@/components/common/Toast.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import { useToast } from '@/composables/useToast'
 
 const { toast, showToast } = useToast()

--- a/frontend/src/views/store/PosView.vue
+++ b/frontend/src/views/store/PosView.vue
@@ -48,6 +48,15 @@
       :loading="isClosingStore"
       @close="showCloseModal = false"
       @confirm="confirmClose" />
+
+    <ConfirmModal
+      :open="confirmState.open"
+      :title="confirmState.title"
+      :message="confirmState.message"
+      :confirm-text="confirmState.confirmText"
+      :type="confirmState.type"
+      @close="closeConfirm"
+      @confirm="handleConfirm" />
   </div>
 </template>
 
@@ -64,6 +73,7 @@ import Toast from '@/components/common/Toast.vue'
 import { useToast } from '@/composables/useToast'
 import PosPaymentMethodModal from '@/components/pos/PosPaymentMethodModal.vue'
 import PosCloseStoreModal from '@/components/pos/PosCloseStoreModal.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 
 const auth = useAuthStore()
 
@@ -75,6 +85,18 @@ const showCloseModal = ref(false)
 const isClosingStore = ref(false)
 const currentTime = ref('')
 const { toast, showToast } = useToast()
+const confirmState = ref({ open: false, title: '', message: '', type: 'info', confirmText: '확인', action: null })
+function openConfirm({ title, message, type, confirmText, action }) {
+  confirmState.value = { open: true, title, message: message || '', type: type || 'info', confirmText: confirmText || '확인', action }
+}
+function closeConfirm() {
+  confirmState.value = { open: false, title: '', message: '', type: 'info', confirmText: '확인', action: null }
+}
+async function handleConfirm() {
+  const action = confirmState.value.action
+  closeConfirm()
+  if (action) await action()
+}
 const loadingMenus = ref(true)
 
 let timer = null
@@ -266,7 +288,13 @@ function removeFromCart(menuIdx) {
 }
 
 function clearCart() {
-  if (cart.value.length > 0 && confirm('장바구니를 모두 비우시겠습니까?')) cart.value = []
+  if (cart.value.length === 0) return
+  openConfirm({
+    title: '장바구니를 모두 비우시겠습니까?',
+    type: 'warning',
+    confirmText: '비우기',
+    action: () => { cart.value = [] },
+  })
 }
 
 function openPaymentModal() {
@@ -299,11 +327,19 @@ async function processPayment(method) {
 function toggleStoreStatus() {
   if (!salesData.value.isClosed) {
     showCloseModal.value = true
-  } else if (confirm('새로운 영업을 시작하시겠습니까?\n기존 매출 및 결제 내역이 모두 초기화됩니다.')) {
-    Object.assign(salesData.value, { isClosed: false, total: 0, card: 0, cash: 0, count: 0 })
-    saveClosedStatus(false)
-    paymentHistory.value = []
-    showToast('새로운 영업이 시작되었습니다.')
+  } else {
+    openConfirm({
+      title: '새로운 영업을 시작하시겠습니까?',
+      message: '기존 매출 및 결제 내역이 모두 초기화됩니다.',
+      type: 'warning',
+      confirmText: '영업 시작',
+      action: () => {
+        Object.assign(salesData.value, { isClosed: false, total: 0, card: 0, cash: 0, count: 0 })
+        saveClosedStatus(false)
+        paymentHistory.value = []
+        showToast('새로운 영업이 시작되었습니다.')
+      },
+    })
   }
 }
 

--- a/frontend/src/views/store/StoreOrderManageView.vue
+++ b/frontend/src/views/store/StoreOrderManageView.vue
@@ -10,9 +10,23 @@ import StoreOrderRejectModal from '@/components/orders/store/StoreOrderRejectMod
 import StoreItemDeleteModal from '@/components/orders/store/StoreItemDeleteModal.vue'
 import ordersApi from '@/api/orders'
 import Toast from '@/components/common/Toast.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import { useToast } from '@/composables/useToast'
 
 const { toast, showToast } = useToast()
+
+const confirmState = ref({ open: false, title: '', confirmText: '확인', action: null })
+function openConfirm({ title, confirmText, action }) {
+  confirmState.value = { open: true, title, confirmText, action }
+}
+function closeConfirm() {
+  confirmState.value = { open: false, title: '', confirmText: '확인', action: null }
+}
+async function handleConfirm() {
+  const action = confirmState.value.action
+  closeConfirm()
+  if (action) await action()
+}
 
 const activeTab = ref('pending')
 const selectedOrder = ref(null)
@@ -129,16 +143,21 @@ async function confirmDeleteItem() {
   }
 }
 
-async function cancelOrder(order) {
-  if (!confirm('발주를 취소하시겠습니까?')) return
-  try {
-    await ordersApi.cancelOrder(order.idx)
-    order.ordersStatus = 'CANCELLED'
-    showToast('발주가 취소되었습니다.')
-  } catch (e) {
-    console.error('발주 취소 실패', e)
-    showToast('발주 취소에 실패했습니다.', 'error')
-  }
+function cancelOrder(order) {
+  openConfirm({
+    title: '발주를 취소하시겠습니까?',
+    confirmText: '취소',
+    action: async () => {
+      try {
+        await ordersApi.cancelOrder(order.idx)
+        order.ordersStatus = 'CANCELLED'
+        showToast('발주가 취소되었습니다.')
+      } catch (e) {
+        console.error('발주 취소 실패', e)
+        showToast('발주 취소에 실패했습니다.', 'error')
+      }
+    },
+  })
 }
 
 const showManualForm = ref(false)
@@ -199,5 +218,12 @@ async function submitManualOrder(data) {
     <StoreItemDeleteModal :item="deleteTarget.item" :visible="isDeleteModalOpen"
       @close="isDeleteModalOpen = false" @confirm="confirmDeleteItem" />
     <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
+    <ConfirmModal
+      :open="confirmState.open"
+      :title="confirmState.title"
+      :confirm-text="confirmState.confirmText"
+      type="danger"
+      @close="closeConfirm"
+      @confirm="handleConfirm" />
   </div>
 </template>

--- a/frontend/src/views/store/StoreRecipeView.vue
+++ b/frontend/src/views/store/StoreRecipeView.vue
@@ -324,7 +324,7 @@
               <div v-for="cat in categoriesList" :key="cat.idx"
                    class="flex items-center justify-between px-4 py-2.5 hover:bg-gray-50 transition-colors">
                 <span class="text-sm font-medium text-gray-700">{{ cat.categoryName }}</span>
-                <button @click="deleteCategoryAction(cat.idx, cat.categoryName)" class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer">
+                <button @click="openDeleteCategoryConfirm(cat.idx, cat.categoryName)" class="text-gray-300 hover:text-red-500 transition-colors cursor-pointer">
                   <Trash2 class="w-3.5 h-3.5" />
                 </button>
               </div>
@@ -339,6 +339,13 @@
       </div>
     </div>
     <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
+    <ConfirmModal
+      :open="confirmState.open"
+      :title="`'${confirmState.name}' 카테고리를 삭제하시겠습니까?`"
+      confirm-text="삭제"
+      type="danger"
+      @close="closeConfirm"
+      @confirm="deleteCategoryAction" />
   </div>
 </template>
 
@@ -346,9 +353,18 @@
 import { ref, computed , onMounted} from 'vue'
 import {Plus, Trash2, Search, Image as ImageIcon, ChevronDown, Tag} from 'lucide-vue-next'
 import Toast from '@/components/common/Toast.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import { useToast } from '@/composables/useToast'
 
 const { toast, showToast } = useToast()
+
+const confirmState = ref({ open: false, idx: null, name: '' })
+function openDeleteCategoryConfirm(idx, name) {
+  confirmState.value = { open: true, idx, name }
+}
+function closeConfirm() {
+  confirmState.value = { open: false, idx: null, name: '' }
+}
 
 // ─────────────────────────────────────────────
 //  상품 목록 (매장 제품 관리의 제품코드와 동일하게 맞춤)
@@ -569,8 +585,9 @@ async function addCategoryAction() {
   }
 }
 
-async function deleteCategoryAction(idx, name) {
-  if (!confirm(`'${name}' 카테고리를 삭제하시겠습니까?`)) return
+async function deleteCategoryAction() {
+  const { idx } = confirmState.value
+  closeConfirm()
   try {
     await deleteCategory(idx)
     await fetchCategories()

--- a/frontend/src/views/store/StoreRecipeView.vue
+++ b/frontend/src/views/store/StoreRecipeView.vue
@@ -280,27 +280,14 @@
       </div>
     </div>
 
-    <!-- ══════════════════════════════════════════
-         삭제 확인 모달
-    ══════════════════════════════════════════ -->
-    <div v-if="showDeleteConfirm" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div class="absolute inset-0 bg-black/40 " @click="showDeleteConfirm = false"></div>
-      <div class="relative bg-white rounded-xl w-full max-w-sm border border-gray-200 shadow-xl p-8 text-center animate-in fade-in zoom-in-95 duration-200">
-        <div class="text-4xl mb-4">🗑️</div>
-        <h3 class="font-bold text-gray-900 text-base mb-2">메뉴를 삭제하시겠습니까?</h3>
-        <p class="text-xs text-gray-400 mb-6">이 작업은 되돌릴 수 없습니다.</p>
-        <div class="flex gap-3">
-          <button @click="showDeleteConfirm = false"
-                  class="flex-1 py-2.5 rounded-lg border border-gray-200 text-sm font-bold text-gray-500 hover:bg-gray-50 transition-colors cursor-pointer">
-            취소
-          </button>
-          <button @click="confirmDelete"
-                  class="flex-1 py-2.5 rounded-lg bg-red-500 text-white text-sm font-bold hover:bg-red-600 transition-colors cursor-pointer">
-            삭제
-          </button>
-        </div>
-      </div>
-    </div>
+    <ConfirmModal
+      :open="showDeleteConfirm"
+      title="메뉴를 삭제하시겠습니까?"
+      message="이 작업은 되돌릴 수 없습니다."
+      confirm-text="삭제"
+      type="danger"
+      @close="showDeleteConfirm = false"
+      @confirm="confirmDelete" />
     <div v-if="showCategoryModal" class="fixed inset-0 z-[60] flex items-center justify-center p-4">
       <div class="absolute inset-0 bg-black/40" @click="showCategoryModal = false"></div>
       <div class="relative bg-white rounded-xl w-full max-w-md border border-gray-200 shadow-xl overflow-hidden animate-in fade-in zoom-in-95 duration-200">


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 네이티브 confirm()과 인라인 확인 모달을 공통 ConfirmModal 컴포넌트로 통합

## 변경 파일
- frontend/src/components/common/ConfirmModal.vue (신규)
- frontend/src/views/hq/RecipeView.vue
- frontend/src/views/hq/HqOrderManageView.vue
- frontend/src/views/hq/ProductView.vue
- frontend/src/views/hq/SettlementView.vue
- frontend/src/views/hq/AdminAccountCreateView.vue
- frontend/src/views/store/PosView.vue
- frontend/src/views/store/StoreOrderManageView.vue
- frontend/src/views/store/StoreRecipeView.vue

## 주요 변경 사항
- ConfirmModal 공통 컴포넌트 생성 (type: danger/warning/info, 동적 title/message/버튼 텍스트, z-[60], whitespace-pre-line 지원)
- 네이티브 confirm() 10건 교체 (본사 6건, 가맹점 4건)
- 인라인 삭제/확인 모달 3건을 ConfirmModal로 교체 (RecipeView, StoreRecipeView, AdminAccountCreateView)
- SettlementView 마감 확인 모달을 ConfirmModal로 교체 (Teleport 제거)

## Test Plan
- [x] 본사 메뉴 관리 - 메뉴 삭제, 카테고리 삭제 시 ConfirmModal 표시 확인
- [x] 본사 제품 관리 - 제품 삭제, 카테고리 삭제 시 ConfirmModal 표시 확인
- [x] 본사 발주 관리 - 전체 승인, 개별 승인, 반려 시 ConfirmModal 표시 확인
- [x] 본사 정산 관리 - 마감 확인 시 ConfirmModal 표시 확인
- [x] 본사 계정 관리 - 계정 삭제 시 ConfirmModal 표시 확인
- [x] POS - 장바구니 비우기, 영업 시작 시 ConfirmModal 표시 확인
- [x] 가맹점 발주 관리 - 발주 취소 시 ConfirmModal 표시 확인
- [x] 가맹점 메뉴 관리 - 메뉴 삭제, 카테고리 삭제 시 ConfirmModal 표시 확인
- [x] 카테고리 관리 모달 위에 ConfirmModal이 z-index 정상 표시되는지 확인

## Issue
- Closes #682