### PR TITLE
[Fix] #688 - 백엔드 로직 오류 및 NPE 방어 코드 수정

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -42,10 +42,12 @@ public class DashboardDto {
         private String status;
 
         public static DeliveryItem from(Delivery entity) {
+            var orders = entity.getOrders();
             return DeliveryItem.builder()
                     .deliveryIdx(entity.getIdx())
-                    .ordersIdx(entity.getOrders().getIdx())
-                    .storeName(entity.getOrders().getStore().getStoreName())
+                    .ordersIdx(orders != null ? orders.getIdx() : null)
+                    .storeName(orders != null && orders.getStore() != null
+                            ? orders.getStore().getStoreName() : null)
                     .status(entity.getDeliveryStatus().name())
                     .build();
         }

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/StoreDashboardDto.java
@@ -89,7 +89,7 @@ public class StoreDashboardDto {
                     .deliveryIdx(entity.getIdx())
                     .ordersIdx(entity.getOrders().getIdx())
                     .status(entity.getDeliveryStatus().name())
-                    .estimatedArrival(entity.getEstimatedArrivalAt().toLocalDate().toString())
+                    .estimatedArrival(entity.getEstimatedArrivalAt() != null ? entity.getEstimatedArrivalAt().toLocalDate().toString() : null)
                     .build();
         }
     }

--- a/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationService.java
+++ b/backend/src/main/java/com/example/nexus/domain/notification/StoreNotificationService.java
@@ -72,7 +72,7 @@ public class StoreNotificationService {
     @Transactional
     public void markAsRead(Long notificationIdx) {
         StoreNotification notification = storeNotificationRepository.findById(notificationIdx)
-                .orElseThrow(() -> new IllegalArgumentException("알림을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
         notification.markAsRead();
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -153,7 +154,8 @@ public class OrdersService {
         List<Orders> dangerOrders = ordersRepository.findAllByIsDangerTrue();
 
         for (Orders orders : dangerOrders) {
-            int totalQty = orders.getOrdersItemList().stream().mapToInt(OrdersItem::getCount).sum();
+            List<OrdersItem> items = orders.getOrdersItemList() != null ? orders.getOrdersItemList() : Collections.emptyList();
+            int totalQty = items.stream().mapToInt(OrdersItem::getCount).sum();
 
             LocalDateTime since = orders.getCreatedAt().minusMonths(req.getPeriod());
 
@@ -352,7 +354,8 @@ public class OrdersService {
         }
 
         // 이상 발주 재판정: 점주가 아이템을 수정했을 수 있으므로 확정 시점에 재평가
-        int totalQty = orders.getOrdersItemList().stream().mapToInt(OrdersItem::getCount).sum();
+        List<OrdersItem> items = orders.getOrdersItemList() != null ? orders.getOrdersItemList() : Collections.emptyList();
+        int totalQty = items.stream().mapToInt(OrdersItem::getCount).sum();
         boolean isDanger = evaluateDanger(store.getIdx(), totalQty, orders.getCreatedAt(), orders.getIdx());
         orders.markDanger(isDanger);
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -97,7 +97,9 @@ public class OrdersService {
     // 기간, 키워드 조건으로 필터링 + 페이징 처리
     // 각 발주에 대해 같은 매장의 최근 N개월 평균 수량 계산
     public Page<DangerDto.DangerListRes> findDangerOrders(LocalDate startDate, LocalDate endDate, String keyword, Pageable pageable) {
-        Specification<Orders> spec = OrdersSpecification.isDangerTrue();
+        Specification<Orders> spec = OrdersSpecification.isDangerTrue()
+                .and(OrdersSpecification.statusIn(List.of(
+                        OrdersStatus.CONFIRMED, OrdersStatus.APPROVE, OrdersStatus.REJECT)));
 
         if (startDate != null) {
             spec = spec.and(OrdersSpecification.createdAfter(startDate));

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 
 public class DangerDto {
 
@@ -42,9 +44,8 @@ public class DangerDto {
         private Integer ratio;
 
         public static DangerListRes from(Orders entity, Integer avgQty) {
-            int totalQty = entity.getOrdersItemList().stream()
-                    .mapToInt(OrdersItem::getCount)
-                    .sum();
+            List<OrdersItem> items = entity.getOrdersItemList() != null ? entity.getOrdersItemList() : Collections.emptyList();
+            int totalQty = items.stream().mapToInt(OrdersItem::getCount).sum();
             int ratioValue = avgQty > 0 ? (totalQty - avgQty) * 100 / avgQty : 0;
 
             return DangerListRes.builder()

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -42,8 +43,9 @@ public class OrdersDto {
                     .reason(entity.getReason())
                     .createdAt(entity.getCreatedAt())
                     .storeName(entity.getStore().getStoreName())
-                    .ordersItemList(entity.getOrdersItemList().stream()
-                            .map(OrdersItemDto.OrdersItemRes::from).toList())
+                    .ordersItemList(entity.getOrdersItemList() != null
+                            ? entity.getOrdersItemList().stream().map(OrdersItemDto.OrdersItemRes::from).toList()
+                            : Collections.emptyList())
                     .deliveryIdx(entity.getDelivery() != null ? entity.getDelivery().getIdx() : null)
                     .build();
         }
@@ -58,9 +60,10 @@ public class OrdersDto {
                     .reason(entity.getReason())
                     .createdAt(entity.getCreatedAt())
                     .storeName(entity.getStore().getStoreName())
-                    .ordersItemList(entity.getOrdersItemList().stream()
-                            .map(item -> OrdersItemDto.OrdersItemRes.from(item, stockMap.get(item.getProduct().getIdx())))
-                            .toList())
+                    .ordersItemList(entity.getOrdersItemList() != null ? entity.getOrdersItemList().stream()
+                                    .map(item -> OrdersItemDto.OrdersItemRes.from(item, stockMap.get(item.getProduct().getIdx())))
+                                    .toList()
+                            : Collections.emptyList())
                     .deliveryIdx(entity.getDelivery() != null ? entity.getDelivery().getIdx() : null)
                     .build();
         }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 발주, 대시보드, 알림 모듈의 런타임 오류 유발 가능 로직을 수정                                                                                                                                                                   
                                                                                                                                                                                                                                  
## 변경 파일                                              
- `OrdersService.java`
- `OrdersDto.java`
- `DangerDto.java`
- `SettlementController.java`
- `StoreDashboardDto.java`
- `DashboardDto.java`
- `StoreNotificationService.java`

## 주요 변경 사항
- 이상 발주 조회 시 CONFIRMED, APPROVE, REJECT 상태만 조회하도록 필터 추가
- ordersItemList Lazy 로딩 시 null 체크 추가하여 NPE 방어
- SettlementController에서 잘못된 파라미터로 호출하던 불필요한 루프 제거
- SettlementController totalPrice int → long 변경하여 오버플로우 방지
- StoreDashboardDto estimatedArrivalAt null 체크 추가
- DashboardDto Lazy-loaded 엔티티 체인 null 체크 추가
- StoreNotificationService 예외 타입을 BaseException으로 통일

## Test Plan
- [ ] 이상 발주 목록에서 승인/반려 정상 동작 확인
- [ ] 이상 발주 목록에서 처리완료 건 노출 확인
- [ ] 가맹점 대시보드 배송 목록 정상 조회 확인
- [ ] 본사 대시보드 배송 지연 목록 정상 조회 확인
- [ ] 가맹점 알림 읽음 처리 정상 동작 확인

## Issue
- Closes #688