### PR TITLE
[Feat] #692 - 발주 승인 시 매출채권(HeadIncome) 자동 생성  

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -8,6 +8,8 @@ import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.domain.inventory.InventoryMovementService;
 import com.example.nexus.domain.inventory.model.InventoryMovementDto;
 import com.example.nexus.domain.delivery.DeliveryService;
+import com.example.nexus.domain.head.HeadIncomeRepository;
+import com.example.nexus.domain.head.model.HeadIncome;
 import com.example.nexus.domain.notification.HeadNotificationService;
 import com.example.nexus.domain.notification.StoreNotificationService;
 import com.example.nexus.domain.orders.model.*;
@@ -46,6 +48,7 @@ public class OrdersService {
     private final HeadNotificationService headNotificationService;
     private final StoreNotificationService storeNotificationService;
     private final DeliveryService deliveryService;
+    private final HeadIncomeRepository headIncomeRepository;
 
     // 자동 발주 제안 검색 조회 (AUTO + WAITING 상태 대상)
     // 매장명 키워드 검색 + 페이징 처리
@@ -182,6 +185,7 @@ public class OrdersService {
 
         applyOutboundForOrder(orders, "발주 승인(이상) ordersIdx=");
         orders.approve();
+        createHeadIncome(orders);
         deliveryService.startDeliveryByOrders(orders);
     }
 
@@ -206,8 +210,20 @@ public class OrdersService {
         for (Orders orders : confirmedOrders) {
             applyOutboundForOrder(orders, "발주 일괄승인 ordersIdx=");
             orders.approve();
+            createHeadIncome(orders);
             deliveryService.startDeliveryByOrders(orders);
         }
+    }
+
+    // 발주 승인 시 매출채권(HeadIncome) 생성
+    private void createHeadIncome(Orders orders) {
+        HeadIncome headIncome = new HeadIncome();
+        headIncome.setPrice(orders.getPrice());
+        headIncome.setStatus(false);
+        headIncome.setSettlementIdx(null);
+        headIncome.setStore(orders.getStore());
+        headIncome.setOrders(orders);
+        headIncomeRepository.save(headIncome);
     }
 
     // 발주 승인 시 품목별 출고 처리 (재고 차감)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 발주 승인 시 HEAD_INCOME 테이블에 매출채권 레코드를 자동 생성하도록 구현                                                                                                                                                        
                                                                                                                                                                                                                                  
## 변경 파일                                                                                                                                                                                                                      
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`

## 주요 변경 사항
- HeadIncomeRepository 의존성 추가
- 개별 승인(approve) 시 HeadIncome 레코드 생성
- 일괄 승인(approveAllConfirmed) 시 HeadIncome 레코드 생성
- 스케줄러(자정 자동 승인)도 approveAllConfirmed 호출하므로 자동 적용
- 생성 시 settlement_idx = null, status = false(미정산)로 초기화

## Test Plan
- [ ] 이상 발주 개별 승인 후 HEAD_INCOME 레코드 생성 확인
- [ ] 확정 발주 일괄 승인 후 HEAD_INCOME 레코드 생성 확인
- [ ] settlement_idx가 null, status가 false인지 확인

## Issue
- Closes #692