### PR TITLE
[Fix] #697 - 프론트엔드 데이터 접근 오류 및 prop 경고 수정

### DIFF
--- a/frontend/src/components/orders/hq/HqOrderDetailModal.vue
+++ b/frontend/src/components/orders/hq/HqOrderDetailModal.vue
@@ -61,14 +61,8 @@ defineEmits(['close'])
                 <tr>
                   <th class="px-4 py-2.5 text-left text-[10px] font-bold text-gray-400 uppercase">품목명</th>
                   <th class="px-4 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase">수량</th>
-                  <template v-if="order.type === '이상'">
-                    <th class="px-4 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase">평균수량</th>
-                    <th class="px-4 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase">초과율</th>
-                  </template>
-                  <template v-else>
-                    <th class="px-4 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase">단가</th>
-                    <th class="px-4 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase">금액</th>
-                  </template>
+                  <th class="px-4 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase">단가</th>
+                  <th class="px-4 py-2.5 text-right text-[10px] font-bold text-gray-400 uppercase">금액</th>
                 </tr>
               </thead>
             </table>
@@ -90,17 +84,8 @@ defineEmits(['close'])
                       </div>
                     </td>
                     <td class="px-4 py-2.5 text-right font-semibold" :class="item.isAbnormal ? 'text-red-600' : 'text-gray-900'">{{ item.qty.toLocaleString() }}</td>
-                    <template v-if="order.type === '이상'">
-                      <td class="px-4 py-2.5 text-right text-gray-500">{{ item.avgQty?.toLocaleString() ?? '-' }}</td>
-                      <td class="px-4 py-2.5 text-right">
-                        <span v-if="item.isAbnormal" class="text-xs font-black px-2 py-0.5 rounded bg-red-50 text-red-600 border border-red-200">+{{ item.ratio }}%</span>
-                        <span v-else class="text-xs text-gray-400">+{{ item.ratio }}%</span>
-                      </td>
-                    </template>
-                    <template v-else>
-                      <td class="px-4 py-2.5 text-right text-xs text-gray-500">{{ item.unitPrice ? item.unitPrice.toLocaleString() + '원' : '-' }}</td>
-                      <td class="px-4 py-2.5 text-right font-bold text-[#F37321] whitespace-nowrap">{{ item.unitPrice ? formatPrice(item.unitPrice * item.qty) : '-' }}</td>
-                    </template>
+                    <td class="px-4 py-2.5 text-right text-xs text-gray-500">{{ item.unitPrice ? item.unitPrice.toLocaleString() + '원' : '-' }}</td>
+                    <td class="px-4 py-2.5 text-right font-bold text-[#F37321] whitespace-nowrap">{{ item.unitPrice ? formatPrice(item.unitPrice * item.qty) : '-' }}</td>
                   </tr>
                 </tbody>
               </table>
@@ -112,7 +97,7 @@ defineEmits(['close'])
                 <col class="w-[22%]" />
                 <col class="w-[28%]" />
               </colgroup>
-              <tfoot v-if="order.type !== '이상'" class="bg-gray-50 border-t border-gray-200">
+              <tfoot class="bg-gray-50 border-t border-gray-200">
                 <tr>
                   <td class="px-4 py-2.5 text-left text-xs font-bold text-gray-500">합계</td>
                   <td class="px-4 py-2.5"></td>

--- a/frontend/src/components/orders/store/StoreManualOrderModal.vue
+++ b/frontend/src/components/orders/store/StoreManualOrderModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { reactive, ref, onMounted } from 'vue'
+import { reactive, ref, watch } from 'vue'
 import { Plus } from 'lucide-vue-next'
 import { formatPrice } from '../orderUtils'
 import { getProductList } from '@/api/product'
@@ -8,7 +8,7 @@ import { useToast } from '@/composables/useToast'
 
 const { toast, showToast } = useToast()
 
-defineProps({
+const props = defineProps({
   visible: { type: Boolean, required: true },
 })
 
@@ -17,10 +17,12 @@ const emit = defineEmits(['close', 'submit'])
 const products = ref([])
 const form = reactive({ items: [] })
 
-onMounted(async () => {
+watch(() => props.visible, async (val) => {
+  if (!val) return
+  form.items = []
   try {
-    const productRes = await getProductList()
-    products.value = productRes.data
+    const productRes = await getProductList(0, 1000)
+    products.value = productRes.data.result.productList ?? []
   } catch (e) {
     console.error('상품 목록 조회 실패', e)
   }
@@ -90,7 +92,7 @@ function submit() {
               </div>
               <input v-else v-model="item.productKeyword" @input="item.showDropdown = true" @focus="item.showDropdown = true" @blur="item.showDropdown = false" placeholder="상품명 검색"
                 class="w-full px-3 py-2 rounded border border-gray-200 text-sm focus:border-blue-400 focus:ring-2 focus:ring-blue-100 outline-none" />
-              <ul v-if="!item.product && item.showDropdown && filterProducts(item).length > 0"
+              <ul v-if="!item.product && item.showDropdown"
                 class="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded shadow-lg max-h-60 overflow-y-auto">
                 <li v-for="p in filterProducts(item)" :key="p.idx" @mousedown.prevent @click="selectProduct(item, p)"
                   class="px-3 py-2 text-sm hover:bg-blue-50 cursor-pointer">

--- a/frontend/src/composables/useAddOrderItem.js
+++ b/frontend/src/composables/useAddOrderItem.js
@@ -10,8 +10,8 @@ export function useAddOrderItem(fetchPendingOrders, showToast) {
     addItemForm.value = { ordersIdx: order.idx, productIdx: null, productName: '', keyword: '', showDropdown: false, count: 1 }
     if (productList.value.length === 0) {
       try {
-        const res = await getProductList()
-        productList.value = res.data || []
+        const res = await getProductList(0, 1000)
+        productList.value = res.data.result.productList ?? []
       } catch (e) {
         console.error('상품 목록 조회 실패', e)
       }

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -9,12 +9,12 @@ import { useToast } from '@/composables/useToast'
 
 const { toast, showToast } = useToast()
 
-const confirmState = ref({ open: false, type: '', title: '', confirmText: '확인', action: null })
+const confirmState = ref({ open: false, type: 'info', title: '', confirmText: '확인', action: null })
 function openConfirm({ type, title, confirmText, action }) {
   confirmState.value = { open: true, type, title, confirmText, action }
 }
 function closeConfirm() {
-  confirmState.value = { open: false, type: '', title: '', confirmText: '확인', action: null }
+  confirmState.value = { open: false, type: 'info', title: '', confirmText: '확인', action: null }
 }
 async function handleConfirm() {
   const action = confirmState.value.action


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 발주 관련 프론트엔드의 API 응답 접근 오류, prop 경고, dead code를 수정                                                                                                                                                          
                                                                                                                                                                                                                                  
## 변경 파일                                                                                                                                                                                                                      
- `frontend/src/components/orders/store/StoreManualOrderModal.vue`                                                                                                                                                                
- `frontend/src/components/orders/hq/HqOrderDetailModal.vue`                                                                                                                                                                      
- `frontend/src/views/hq/HqOrderManageView.vue`
- `frontend/src/composables/useAddOrderItem.js`

## 주요 변경 사항
- 수동 발주 생성 모달: API 응답 접근 경로 수정, 전체 제품 조회, 모달 열릴 때 품목 초기화, filterProducts 중복 호출 제거
- 자동 발주 제안 품목 추가: useAddOrderItem의 API 응답 접근 경로 및 size 파라미터 수정
- ConfirmModal type prop 초기값을 빈 문자열에서 'info'로 변경하여 validator 경고 해소
- 발주 상세 모달: order.type === '이상' 도달 불가 조건 분기 제거, 단가/금액 컬럼으로 통일

## Test Plan
- [ ] 점주 수동 발주 생성 시 제품 드롭다운 정상 표시 확인
- [ ] 점주 자동 발주 제안에서 품목 추가 시 제품 드롭다운 정상 표시 확인
- [ ] 수동 발주 모달 취소 후 재진입 시 품목 초기화 확인
- [ ] 본사 발주 관리 페이지 ConfirmModal 경고 미발생 확인
- [ ] 본사 발주 상세 모달 단가/금액 컬럼 정상 표시 확인

## Issue
- Closes #697