### PR TITLE
[Feat] #709 - AI 보고서 챗봇 기본 응답 기능 구현 (Backend)

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/report/ReportController.java
+++ b/backend/src/main/java/com/example/nexus/domain/report/ReportController.java
@@ -1,6 +1,11 @@
 package com.example.nexus.domain.report;
 
+
+import com.example.nexus.common.model.BaseResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +14,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ReportController {
     private final ReportService reportService;
+
+    // 사용자 메세지 통신
+    @PostMapping("/generate")
+    public ResponseEntity<BaseResponse> requestReport(@RequestBody ChatRequest request) {
+        String result = reportService.handleChatbotRequest(request.message());
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    // 사용자 메세지 응답 DTO
+    record ChatRequest(String message) {}
 }

--- a/backend/src/main/java/com/example/nexus/domain/report/ReportController.java
+++ b/backend/src/main/java/com/example/nexus/domain/report/ReportController.java
@@ -2,6 +2,8 @@ package com.example.nexus.domain.report;
 
 
 import com.example.nexus.common.model.BaseResponse;
+import com.example.nexus.domain.report.model.ReportDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,11 +19,9 @@ public class ReportController {
 
     // 사용자 메세지 통신
     @PostMapping("/generate")
-    public ResponseEntity<BaseResponse> requestReport(@RequestBody ChatRequest request) {
+    public ResponseEntity<BaseResponse> requestReport(@Valid @RequestBody ReportDto.ChatRequest request) {
         String result = reportService.handleChatbotRequest(request.message());
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
-    // 사용자 메세지 응답 DTO
-    record ChatRequest(String message) {}
 }

--- a/backend/src/main/java/com/example/nexus/domain/report/ReportService.java
+++ b/backend/src/main/java/com/example/nexus/domain/report/ReportService.java
@@ -1,6 +1,7 @@
 package com.example.nexus.domain.report;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -9,13 +10,13 @@ public class ReportService {
     private final ChatClient chatClient;
 
     // AI에게 성격(프롬포트)를 고정해 두기 위해서 생성자를 직접 생성
-    public ReportService(ReportRepository reportRepository, ChatClient.Builder chatClientBuilder) {
+    public ReportService(ReportRepository reportRepository,
+                         ChatClient.Builder chatClientBuilder,
+                         @Value("${report.ai.system-prompt}") String systemPrompt) {
         this.reportRepository = reportRepository;
 
         this.chatClient = chatClientBuilder
-                .defaultSystem("당신은 프랜차이즈 본사의 데이터 분석 전문가입니다. " +
-                        "전달받은 수치 데이터를 바탕으로 전문적인 마크다운 형식의 보고서를 작성합니다. " +
-                        "친절하지만 간결한 비즈니스 톤을 유지하세요.")
+                .defaultSystem(systemPrompt)
                 .build();
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/report/ReportService.java
+++ b/backend/src/main/java/com/example/nexus/domain/report/ReportService.java
@@ -1,20 +1,28 @@
 package com.example.nexus.domain.report;
 
-import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class ReportService {
     private final ReportRepository reportRepository;
+    private final ChatClient chatClient;
+
+    // AI에게 성격(프롬포트)를 고정해 두기 위해서 생성자를 직접 생성
+    public ReportService(ReportRepository reportRepository, ChatClient.Builder chatClientBuilder) {
+        this.reportRepository = reportRepository;
+
+        this.chatClient = chatClientBuilder
+                .defaultSystem("당신은 프랜차이즈 본사의 데이터 분석 전문가입니다. " +
+                        "전달받은 수치 데이터를 바탕으로 전문적인 마크다운 형식의 보고서를 작성합니다. " +
+                        "친절하지만 간결한 비즈니스 톤을 유지하세요.")
+                .build();
+    }
 
     public String handleChatbotRequest(String userMessage) {
-        // TODO: 1. 사용자의 질문(userMessage)을 분석해서 필요한 데이터 기간/매장을 파악한다.
-        // TODO: 2. DB에서 해당 매출/재고 데이터를 조회해온다.
-        // TODO: 3. 데이터를 프롬프트에 담아 AI에게 보고서 생성을 요청한다.
-        // TODO: 4. AI가 준 답변을 파일로 만들고 ReportRepository에 저장한다.
-
-        // 일단 프론트와 잘 연결되는지 확인하기 위한 임시 응답
-        return "요청하신 [" + userMessage + "]에 대한 보고서 생성을 시작합니다. 완료되면 보고서 목록에서 확인해주세요!";
+        return chatClient.prompt()
+                .user(userMessage)
+                .call()
+                .content();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/report/ReportService.java
+++ b/backend/src/main/java/com/example/nexus/domain/report/ReportService.java
@@ -7,4 +7,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ReportService {
     private final ReportRepository reportRepository;
+
+    public String handleChatbotRequest(String userMessage) {
+        // TODO: 1. 사용자의 질문(userMessage)을 분석해서 필요한 데이터 기간/매장을 파악한다.
+        // TODO: 2. DB에서 해당 매출/재고 데이터를 조회해온다.
+        // TODO: 3. 데이터를 프롬프트에 담아 AI에게 보고서 생성을 요청한다.
+        // TODO: 4. AI가 준 답변을 파일로 만들고 ReportRepository에 저장한다.
+
+        // 일단 프론트와 잘 연결되는지 확인하기 위한 임시 응답
+        return "요청하신 [" + userMessage + "]에 대한 보고서 생성을 시작합니다. 완료되면 보고서 목록에서 확인해주세요!";
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/report/model/ReportDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/report/model/ReportDto.java
@@ -1,0 +1,11 @@
+package com.example.nexus.domain.report.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class ReportDto {
+
+    public record ChatRequest(
+            @NotBlank(message = "메시지는 비어있을 수 없습니다.")
+            String message
+    ) {}
+}

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -62,6 +62,15 @@ management:
 portone:
   portone_secret: ${PORTONE_SECRET}
 
+
+# AI 챗봇의 시스템 프롬프트 메세지
+report:
+  ai:
+    system-prompt: >
+      당신은 프랜차이즈 본사의 데이터 분석 전문가입니다.
+      전달받은 수치 데이터를 바탕으로 전문적인 마크다운 형식의 보고서를 작성합니다.
+      친절하지만 간결한 비즈니스 톤을 유지하세요.
+
 logging:
   level:
     org.springframework.security: DEBUG


### PR DESCRIPTION
## Summary
- `Report` AI 보고서 챗봇 기능을 위한 초기 통신 파이프라인 구축 및 Spring AI(GPT-4o) 기초 연동 완료

## 변경 파일
- `backend/src/main/java/com/example/nexus/domain/report/ReportController.java`
- `backend/src/main/java/com/example/nexus/domain/report/ReportService.java`


## 주요 변경 사항
- [x] ReportController 내 챗봇 메시지 수신 API (/report/generate) 구현
- [x] ReportService 내 Spring AI ChatClient 연동 및 페르소나 설정

## Test Plan
- [x] Postman 통한 /report/generate 호출 테스트 완료

## Issue
- Closes #709 