### PR TITLE
[Fix] #697 - 발주 관리 테이블 페이지네이션 10개 단위 그룹핑 적용

### DIFF
--- a/frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { formatPrice } from '../orderUtils'
 
@@ -10,6 +10,16 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['open-detail', 'approve', 'reject', 'search', 'page-change'])
+
+const visiblePages = computed(() => {
+  const range = 10
+  const group = Math.floor(props.currentPage / range)
+  const start = group * range
+  const end = Math.min(start + range, props.totalPages)
+  const pages = []
+  for (let i = start; i < end; i++) pages.push(i)
+  return pages
+})
 
 const dateFrom = ref('')
 const dateTo = ref('')
@@ -125,13 +135,13 @@ function resetFilters() {
         @click="$emit('page-change', currentPage - 1)">
         <ChevronLeft class="w-4 h-4" />
       </button>
-      <button v-for="page in totalPages" :key="page"
+      <button v-for="page in visiblePages" :key="page"
         class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-        :class="currentPage === page - 1
+        :class="currentPage === page
           ? 'bg-[#F37321] text-white'
           : 'text-gray-500 hover:bg-gray-50'"
-        @click="$emit('page-change', page - 1)">
-        {{ page }}
+        @click="$emit('page-change', page)">
+        {{ page + 1 }}
       </button>
       <button
         class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"

--- a/frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { formatPrice } from '../orderUtils'
 
@@ -10,16 +10,6 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['open-detail', 'approve', 'reject', 'search', 'page-change'])
-
-const visiblePages = computed(() => {
-  const range = 10
-  const group = Math.floor(props.currentPage / range)
-  const start = group * range
-  const end = Math.min(start + range, props.totalPages)
-  const pages = []
-  for (let i = start; i < end; i++) pages.push(i)
-  return pages
-})
 
 const dateFrom = ref('')
 const dateTo = ref('')
@@ -135,13 +125,13 @@ function resetFilters() {
         @click="$emit('page-change', currentPage - 1)">
         <ChevronLeft class="w-4 h-4" />
       </button>
-      <button v-for="page in visiblePages" :key="page"
+      <button v-for="page in totalPages" :key="page"
         class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-        :class="currentPage === page
+        :class="currentPage === page - 1
           ? 'bg-[#F37321] text-white'
           : 'text-gray-500 hover:bg-gray-50'"
-        @click="$emit('page-change', page)">
-        {{ page + 1 }}
+        @click="$emit('page-change', page - 1)">
+        {{ page }}
       </button>
       <button
         class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"

--- a/frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { formatPrice } from '../orderUtils'
 
@@ -14,6 +14,16 @@ const emit = defineEmits(['open-detail', 'approve', 'reject', 'search', 'page-ch
 const dateFrom = ref('')
 const dateTo = ref('')
 const search = ref('')
+
+const visiblePages = computed(() => {
+  const range = 10
+  const group = Math.floor(props.currentPage / range)
+  const start = group * range
+  const end = Math.min(start + range, props.totalPages)
+  const pages = []
+  for (let i = start; i < end; i++) pages.push(i)
+  return pages
+})
 
 function emitSearch() {
   emit('search', {
@@ -125,13 +135,13 @@ function resetFilters() {
         @click="$emit('page-change', currentPage - 1)">
         <ChevronLeft class="w-4 h-4" />
       </button>
-      <button v-for="page in totalPages" :key="page"
+      <button v-for="page in visiblePages" :key="page"
         class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-        :class="currentPage === page - 1
+        :class="currentPage === page
           ? 'bg-[#F37321] text-white'
           : 'text-gray-500 hover:bg-gray-50'"
-        @click="$emit('page-change', page - 1)">
-        {{ page }}
+        @click="$emit('page-change', page)">
+        {{ page + 1 }}
       </button>
       <button
         class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"

--- a/frontend/src/components/orders/hq/HqAutoOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqAutoOrderTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { statusClass, formatPrice } from '../orderUtils'
 
@@ -12,6 +12,16 @@ const props = defineProps({
 const emit = defineEmits(['open-detail', 'search', 'page-change'])
 
 const search = ref('')
+
+const visiblePages = computed(() => {
+  const range = 10
+  const group = Math.floor(props.currentPage / range)
+  const start = group * range
+  const end = Math.min(start + range, props.totalPages)
+  const pages = []
+  for (let i = start; i < end; i++) pages.push(i)
+  return pages
+})
 
 function emitSearch() {
   emit('search', {
@@ -85,13 +95,13 @@ function resetSearch() {
         @click="$emit('page-change', currentPage - 1)">
         <ChevronLeft class="w-4 h-4" />
       </button>
-      <button v-for="page in totalPages" :key="page"
+      <button v-for="page in visiblePages" :key="page"
         class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-        :class="currentPage === page - 1
+        :class="currentPage === page
           ? 'bg-[#F37321] text-white'
           : 'text-gray-500 hover:bg-gray-50'"
-        @click="$emit('page-change', page - 1)">
-        {{ page }}
+        @click="$emit('page-change', page)">
+        {{ page + 1 }}
       </button>
       <button
         class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"

--- a/frontend/src/components/orders/hq/HqAutoOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqAutoOrderTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { statusClass, formatPrice } from '../orderUtils'
 
@@ -12,16 +12,6 @@ const props = defineProps({
 const emit = defineEmits(['open-detail', 'search', 'page-change'])
 
 const search = ref('')
-
-const visiblePages = computed(() => {
-  const range = 10
-  const group = Math.floor(props.currentPage / range)
-  const start = group * range
-  const end = Math.min(start + range, props.totalPages)
-  const pages = []
-  for (let i = start; i < end; i++) pages.push(i)
-  return pages
-})
 
 function emitSearch() {
   emit('search', {
@@ -95,13 +85,13 @@ function resetSearch() {
         @click="$emit('page-change', currentPage - 1)">
         <ChevronLeft class="w-4 h-4" />
       </button>
-      <button v-for="page in visiblePages" :key="page"
+      <button v-for="page in totalPages" :key="page"
         class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-        :class="currentPage === page
+        :class="currentPage === page - 1
           ? 'bg-[#F37321] text-white'
           : 'text-gray-500 hover:bg-gray-50'"
-        @click="$emit('page-change', page)">
-        {{ page + 1 }}
+        @click="$emit('page-change', page - 1)">
+        {{ page }}
       </button>
       <button
         class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"

--- a/frontend/src/components/orders/hq/HqConfirmedOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqConfirmedOrderTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { statusClass, formatPrice } from '../orderUtils'
 
@@ -12,6 +12,16 @@ const props = defineProps({
 const emit = defineEmits(['open-detail', 'search', 'page-change'])
 
 const search = ref('')
+
+const visiblePages = computed(() => {
+  const range = 10
+  const group = Math.floor(props.currentPage / range)
+  const start = group * range
+  const end = Math.min(start + range, props.totalPages)
+  const pages = []
+  for (let i = start; i < end; i++) pages.push(i)
+  return pages
+})
 
 function emitSearch() {
   emit('search', {
@@ -85,13 +95,13 @@ function resetSearch() {
         @click="$emit('page-change', currentPage - 1)">
         <ChevronLeft class="w-4 h-4" />
       </button>
-      <button v-for="page in totalPages" :key="page"
+      <button v-for="page in visiblePages" :key="page"
         class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-        :class="currentPage === page - 1
+        :class="currentPage === page
           ? 'bg-[#F37321] text-white'
           : 'text-gray-500 hover:bg-gray-50'"
-        @click="$emit('page-change', page - 1)">
-        {{ page }}
+        @click="$emit('page-change', page)">
+        {{ page + 1 }}
       </button>
       <button
         class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"

--- a/frontend/src/components/orders/hq/HqConfirmedOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqConfirmedOrderTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { statusClass, formatPrice } from '../orderUtils'
 
@@ -12,16 +12,6 @@ const props = defineProps({
 const emit = defineEmits(['open-detail', 'search', 'page-change'])
 
 const search = ref('')
-
-const visiblePages = computed(() => {
-  const range = 10
-  const group = Math.floor(props.currentPage / range)
-  const start = group * range
-  const end = Math.min(start + range, props.totalPages)
-  const pages = []
-  for (let i = start; i < end; i++) pages.push(i)
-  return pages
-})
 
 function emitSearch() {
   emit('search', {
@@ -95,13 +85,13 @@ function resetSearch() {
         @click="$emit('page-change', currentPage - 1)">
         <ChevronLeft class="w-4 h-4" />
       </button>
-      <button v-for="page in visiblePages" :key="page"
+      <button v-for="page in totalPages" :key="page"
         class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-        :class="currentPage === page
+        :class="currentPage === page - 1
           ? 'bg-[#F37321] text-white'
           : 'text-gray-500 hover:bg-gray-50'"
-        @click="$emit('page-change', page)">
-        {{ page + 1 }}
+        @click="$emit('page-change', page - 1)">
+        {{ page }}
       </button>
       <button
         class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"

--- a/frontend/src/components/orders/hq/HqOrderHistoryTable.vue
+++ b/frontend/src/components/orders/hq/HqOrderHistoryTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { statusClass, formatPrice } from '../orderUtils'
 
@@ -10,16 +10,6 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['open-detail', 'search', 'page-change'])
-
-const visiblePages = computed(() => {
-  const range = 10
-  const group = Math.floor(props.currentPage / range)
-  const start = group * range
-  const end = Math.min(start + range, props.totalPages)
-  const pages = []
-  for (let i = start; i < end; i++) pages.push(i)
-  return pages
-})
 
 const filterType = ref('')
 const dateFrom = ref('')
@@ -127,13 +117,13 @@ function resetFilters() {
         @click="$emit('page-change', currentPage - 1)">
         <ChevronLeft class="w-4 h-4" />
       </button>
-      <button v-for="page in visiblePages" :key="page"
+      <button v-for="page in totalPages" :key="page"
         class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-        :class="currentPage === page
+        :class="currentPage === page - 1
           ? 'bg-[#F37321] text-white'
           : 'text-gray-500 hover:bg-gray-50'"
-        @click="$emit('page-change', page)">
-        {{ page + 1 }}
+        @click="$emit('page-change', page - 1)">
+        {{ page }}
       </button>
       <button
         class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"

--- a/frontend/src/components/orders/hq/HqOrderHistoryTable.vue
+++ b/frontend/src/components/orders/hq/HqOrderHistoryTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { statusClass, formatPrice } from '../orderUtils'
 
@@ -10,6 +10,16 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['open-detail', 'search', 'page-change'])
+
+const visiblePages = computed(() => {
+  const range = 10
+  const group = Math.floor(props.currentPage / range)
+  const start = group * range
+  const end = Math.min(start + range, props.totalPages)
+  const pages = []
+  for (let i = start; i < end; i++) pages.push(i)
+  return pages
+})
 
 const filterType = ref('')
 const dateFrom = ref('')
@@ -117,13 +127,13 @@ function resetFilters() {
         @click="$emit('page-change', currentPage - 1)">
         <ChevronLeft class="w-4 h-4" />
       </button>
-      <button v-for="page in totalPages" :key="page"
+      <button v-for="page in visiblePages" :key="page"
         class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-        :class="currentPage === page - 1
+        :class="currentPage === page
           ? 'bg-[#F37321] text-white'
           : 'text-gray-500 hover:bg-gray-50'"
-        @click="$emit('page-change', page - 1)">
-        {{ page }}
+        @click="$emit('page-change', page)">
+        {{ page + 1 }}
       </button>
       <button
         class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"

--- a/frontend/src/components/orders/hq/HqOrderHistoryTable.vue
+++ b/frontend/src/components/orders/hq/HqOrderHistoryTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { statusClass, formatPrice } from '../orderUtils'
 
@@ -15,6 +15,16 @@ const filterType = ref('')
 const dateFrom = ref('')
 const dateTo = ref('')
 const search = ref('')
+
+const visiblePages = computed(() => {
+  const range = 10
+  const group = Math.floor(props.currentPage / range)
+  const start = group * range
+  const end = Math.min(start + range, props.totalPages)
+  const pages = []
+  for (let i = start; i < end; i++) pages.push(i)
+  return pages
+})
 
 function emitSearch() {
   emit('search', {
@@ -117,13 +127,13 @@ function resetFilters() {
         @click="$emit('page-change', currentPage - 1)">
         <ChevronLeft class="w-4 h-4" />
       </button>
-      <button v-for="page in totalPages" :key="page"
+      <button v-for="page in visiblePages" :key="page"
         class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-        :class="currentPage === page - 1
+        :class="currentPage === page
           ? 'bg-[#F37321] text-white'
           : 'text-gray-500 hover:bg-gray-50'"
-        @click="$emit('page-change', page - 1)">
-        {{ page }}
+        @click="$emit('page-change', page)">
+        {{ page + 1 }}
       </button>
       <button
         class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"

--- a/frontend/src/components/orders/store/StoreOrderHistoryTable.vue
+++ b/frontend/src/components/orders/store/StoreOrderHistoryTable.vue
@@ -1,14 +1,25 @@
 <script setup>
+import { computed } from 'vue'
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { ORDER_STATUS_LABEL, ORDER_TYPE_LABEL, storeStatusClass } from '../orderUtils'
 
-defineProps({
+const props = defineProps({
   orders: { type: Array, required: true },
   currentPage: { type: Number, default: 0 },
   totalPages: { type: Number, default: 0 },
 })
 
 const emit = defineEmits(['open-detail', 'cancel', 'page-change'])
+
+const visiblePages = computed(() => {
+  const range = 10
+  const group = Math.floor(props.currentPage / range)
+  const start = group * range
+  const end = Math.min(start + range, props.totalPages)
+  const pages = []
+  for (let i = start; i < end; i++) pages.push(i)
+  return pages
+})
 </script>
 
 <template>
@@ -72,13 +83,13 @@ const emit = defineEmits(['open-detail', 'cancel', 'page-change'])
       @click="emit('page-change', currentPage - 1)">
       <ChevronLeft class="w-4 h-4" />
     </button>
-    <button v-for="page in totalPages" :key="page"
+    <button v-for="page in visiblePages" :key="page"
       class="w-8 h-8 rounded text-sm font-semibold cursor-pointer"
-      :class="currentPage === page - 1
+      :class="currentPage === page
         ? 'bg-[#F37321] text-white'
         : 'text-gray-500 hover:bg-gray-50'"
-      @click="emit('page-change', page - 1)">
-      {{ page }}
+      @click="emit('page-change', page)">
+      {{ page + 1 }}
     </button>
     <button
       class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"


### PR DESCRIPTION
## Summary
- 발주 관리 테이블의 페이지네이션을 전체 페이지 번호 나열 방식에서 10개씩 그룹핑 방식으로 변경

## 변경 파일
- `frontend/src/components/orders/hq/HqAutoOrderTable.vue`
- `frontend/src/components/orders/hq/HqConfirmedOrderTable.vue`
- `frontend/src/components/orders/hq/HqOrderHistoryTable.vue`
- `frontend/src/components/orders/hq/HqAbnormalOrderTable.vue`
- `frontend/src/components/orders/store/StoreOrderHistoryTable.vue`

## 주요 변경 사항
- 각 테이블 컴포넌트에 `visiblePages` computed 추가하여 현재 페이지 기준 10개 단위로 페이지 번호 그룹핑
- 본사 발주 테이블 4개(자동발주, 확정, 이력, 이상발주) 및 가맹점 발주 이력 테이블 1개 적용
- 0-based 페이지 인덱스에 맞춰 active 상태 비교 및 emit 로직 수정

## Test Plan
- [ ] 본사 발주 관리 각 탭(자동발주/확정/이력/이상발주)에서 페이지가 10개 초과 시 그룹핑 동작 확인
- [ ] 가맹점 발주 이력에서 페이지 그룹핑 동작 확인
- [ ] 그룹 경계(10→11페이지, 20→21페이지)에서 다음 그룹 전환 확인

## Issue
- Closes #697