### PR TITLE
[Fea] #148 - 본인 가맹점 매출 정산 목록 조회

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
@@ -12,12 +12,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.List;
-
 @RequestMapping("/delivery")
 @RestController
 @RequiredArgsConstructor
 public class DeliveryController {
+
     private final DeliveryService deliveryService;
 
     // 본사 배송 관리 페이지 전체 배송현황 리스트 조회
@@ -33,11 +32,19 @@ public class DeliveryController {
             @RequestParam(defaultValue = "10") int size) {
 
         return ResponseEntity.ok(BaseResponse.success(
-                deliveryService.getDeliveriesByHead(storeName, status, year, month, day, page, size)
+                deliveryService.getDeliveriesByHead(
+                        storeName,
+                        status,
+                        year,
+                        month,
+                        day,
+                        page,
+                        size
+                )
         ));
     }
 
-    // 본인 가맹점 배송 현황 조회 (발주 번호 및 날짜/상태 필터 추가)
+    // 본인 가맹점 배송 현황 조회
     @GetMapping("/store")
     public ResponseEntity<BaseResponse<DeliveryDto.DeliveryPageRes>> getMyStoreDeliveries(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
@@ -54,8 +61,18 @@ public class DeliveryController {
         }
 
         Long storeIdx = authUserDetails.getIdx();
+
         return ResponseEntity.ok(BaseResponse.success(
-                deliveryService.getDeliveriesForStore(storeIdx, orderIdx, status, year, month, day, page, size)
+                deliveryService.getDeliveriesForStore(
+                        storeIdx,
+                        orderIdx,
+                        status,
+                        year,
+                        month,
+                        day,
+                        page,
+                        size
+                )
         ));
     }
 
@@ -69,13 +86,18 @@ public class DeliveryController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
         }
 
-        boolean isSuccess = deliveryService.updateDelayReason(request.getDeliveryIdx(), request.getDelayReason());
+        boolean isSuccess = deliveryService.updateDelayReason(
+                request.getDeliveryIdx(),
+                request.getDelayReason()
+        );
 
         if (isSuccess) {
-            return ResponseEntity.ok(BaseResponse.success("배송 지연 사유가 성공적으로 등록되었습니다."));
-        } else {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(BaseResponse.success("존재하지 않는 배송 정보이거나 권한이 없습니다."));
+            return ResponseEntity.ok(
+                    BaseResponse.success("배송 지연 사유가 성공적으로 등록되었습니다.")
+            );
         }
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(BaseResponse.success("존재하지 않는 배송 정보이거나 권한이 없습니다."));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -21,7 +21,10 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     Delivery findByOrders(Orders orders);
 
     // 알림 스케줄러용 - 특정 상태 + 출발일이 기준 시간 이전인 배송 조회
-    List<Delivery> findByDeliveryStatusAndDepartureDateBefore(DeliveryStatus status, LocalDateTime before);
+    List<Delivery> findByDeliveryStatusAndDepartureDateBefore(
+            DeliveryStatus status,
+            LocalDateTime before
+    );
 
     // 알림 스케줄러용 - 예상도착일 초과 + 미완료 배송 조회
     @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s " +
@@ -29,7 +32,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             "AND d.deliveryStatus NOT IN (:excludeStatuses)")
     List<Delivery> findOverdueDeliveries(
             @Param("now") LocalDateTime now,
-            @Param("excludeStatuses") List<DeliveryStatus> excludeStatuses);
+            @Param("excludeStatuses") List<DeliveryStatus> excludeStatuses
+    );
 
     // 본사 배송 관리 - 필터 조회
     @Query("SELECT d FROM Delivery d " +
@@ -46,11 +50,17 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             @Param("year") Integer year,
             @Param("month") Integer month,
             @Param("day") Integer day,
-            Pageable pageable);
+            Pageable pageable
+    );
 
     // 가맹점 배송 현황 - 전체 조회
-    @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s WHERE s.idx = :storeIdx")
-    List<Delivery> findAllByOrdersStoreIdx(@Param("storeIdx") Long storeIdx);
+    @Query("SELECT d FROM Delivery d " +
+            "JOIN FETCH d.orders o " +
+            "JOIN FETCH o.store s " +
+            "WHERE s.idx = :storeIdx")
+    List<Delivery> findAllByOrdersStoreIdx(
+            @Param("storeIdx") Long storeIdx
+    );
 
     // 가맹점 배송 현황 - 필터 및 발주번호 검색 조회
     @Query("SELECT d FROM Delivery d " +
@@ -69,21 +79,30 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             @Param("year") Integer year,
             @Param("month") Integer month,
             @Param("day") Integer day,
-            Pageable pageable);
+            Pageable pageable
+    );
 
-    // 본사 대시보드 - 진행중 배송 건수 KPI (여러 상태 합산)
+    // 본사 대시보드 - 진행중 배송 건수 KPI
     long countByDeliveryStatusIn(List<DeliveryStatus> statuses);
 
     // 본사 대시보드 - 특정 상태 배송 건수 KPI
     long countByDeliveryStatus(DeliveryStatus status);
 
-    // 본사 대시보드 - 배송 비율 계산 (최근 한달 상태별 건수)
-    long countByDeliveryStatusAndDepartureDateAfter(DeliveryStatus status, LocalDateTime since);
+    // 본사 대시보드 - 배송 비율 계산
+    long countByDeliveryStatusAndDepartureDateAfter(
+            DeliveryStatus status,
+            LocalDateTime since
+    );
 
     // 본사 대시보드 - 지연 배송 목록 무한스크롤 페이징
-    Slice<Delivery> findByDeliveryStatus(DeliveryStatus status, Pageable pageable);
+    Slice<Delivery> findByDeliveryStatus(
+            DeliveryStatus status,
+            Pageable pageable
+    );
 
-    // 점주 대시보드 - 나의 배송 현황 목록 (배송완료 제외, 최신순)
-    List<Delivery> findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc(Long storeIdx, DeliveryStatus excludeStatus);
+    // 점주 대시보드 - 배송완료 제외 최신순
+    List<Delivery> findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc(
+            Long storeIdx,
+            DeliveryStatus excludeStatus
+    );
 }
-

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -6,6 +6,7 @@ import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.delivery.model.DeliveryDto;
 import com.example.nexus.domain.notification.HeadNotificationService;
 import com.example.nexus.domain.notification.StoreNotificationService;
+import com.example.nexus.domain.orders.model.Orders;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -14,39 +15,42 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.example.nexus.domain.orders.model.Orders;
-
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DeliveryService {
+
     private final DeliveryRepository deliveryRepository;
     private final HeadNotificationService headNotificationService;
     private final StoreNotificationService storeNotificationService;
 
-    // 점주 발주 확정 시 배송 생성 (READY 상태)
+    // 점주 발주 확정 시 배송 생성
     @Transactional
     public void createDelivery(Orders orders) {
+
         Delivery delivery = Delivery.builder()
                 .deliveryStatus(DeliveryStatus.READY)
                 .departureDate(LocalDateTime.now())
                 .estimatedArrivalAt(LocalDateTime.now().plusDays(1))
                 .orders(orders)
                 .build();
+
         deliveryRepository.save(delivery);
     }
 
-    // 본사 발주 승인 시 배송 시작 (READY → START) + 점주 알림
+    // 본사 발주 승인 시 배송 시작
     @Transactional
     public void startDeliveryByOrders(Orders orders) {
+
         Delivery delivery = deliveryRepository.findByOrders(orders);
-        if (delivery == null || delivery.getDeliveryStatus() != DeliveryStatus.READY) {
+
+        if (delivery == null ||
+                delivery.getDeliveryStatus() != DeliveryStatus.READY) {
             return;
         }
+
         delivery.setDeliveryStatus(DeliveryStatus.START);
 
         storeNotificationService.create(
@@ -54,54 +58,105 @@ public class DeliveryService {
                 "배송 시작 안내",
                 "주문하신 상품의 배송이 시작되었습니다. 예상 도착일: "
                         + delivery.getEstimatedArrivalAt().toLocalDate(),
-                orders.getStore());
+                orders.getStore()
+        );
     }
 
+    // 본사 배송 조회
     public DeliveryDto.DeliveryPageRes getDeliveriesByHead(
-            String storeName, DeliveryStatus status, Integer year, Integer month, Integer day, int page, int size) {
+            String storeName,
+            DeliveryStatus status,
+            Integer year,
+            Integer month,
+            Integer day,
+            int page,
+            int size
+    ) {
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by("departureDate").descending());
-        Page<Delivery> deliveryPage = deliveryRepository.findAllByHeadFilters(storeName, status, year, month, day, pageable);
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by("departureDate").descending()
+        );
+
+        Page<Delivery> deliveryPage =
+                deliveryRepository.findAllByHeadFilters(
+                        storeName,
+                        status,
+                        year,
+                        month,
+                        day,
+                        pageable
+                );
 
         return DeliveryDto.DeliveryPageRes.from(deliveryPage);
     }
 
-    // 가맹점 배송 현황 조회
+    // 가맹점 배송 조회
     public DeliveryDto.DeliveryPageRes getDeliveriesForStore(
-            Long storeIdx, Long orderIdx, DeliveryStatus status, Integer year, Integer month, Integer day, int page, int size) {
+            Long storeIdx,
+            Long orderIdx,
+            DeliveryStatus status,
+            Integer year,
+            Integer month,
+            Integer day,
+            int page,
+            int size
+    ) {
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by("departureDate").descending());
-        Page<Delivery> deliveryPage = deliveryRepository.findAllByStoreFilters(storeIdx, orderIdx, status, year, month, day, pageable);
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by("departureDate").descending()
+        );
+
+        Page<Delivery> deliveryPage =
+                deliveryRepository.findAllByStoreFilters(
+                        storeIdx,
+                        orderIdx,
+                        status,
+                        year,
+                        month,
+                        day,
+                        pageable
+                );
 
         return DeliveryDto.DeliveryPageRes.from(deliveryPage);
     }
 
-    // 본사 배송 지연 사유 입력 로직 (throw/Optional 제거 및 boolean 흐름 제어 적용)
+    // 배송 지연 사유 등록
     @Transactional
-    public boolean updateDelayReason(Long deliveryIdx, String delayReason) {
+    public boolean updateDelayReason(
+            Long deliveryIdx,
+            String delayReason
+    ) {
+
         Delivery delivery = deliveryRepository.findByIdx(deliveryIdx);
 
         if (delivery == null) {
             return false;
         }
 
-        // 상태를 지연으로 변경
         delivery.setDelayReason(delayReason);
         delivery.setDeliveryStatus(DeliveryStatus.DELAY);
 
-        // 배송 지연 알림 발송 (본사)
-        String delayStoreName = delivery.getOrders().getStore().getStoreName();
+        String delayStoreName =
+                delivery.getOrders().getStore().getStoreName();
+
+        // 본사 알림
         headNotificationService.create(
                 NotificationType.DELIVERY_DELAY,
                 "배송 지연 - " + delayStoreName,
-                delayStoreName + " 배송이 지연되었습니다. 사유: " + delayReason);
+                delayStoreName + " 배송이 지연되었습니다. 사유: " + delayReason
+        );
 
-        // 배송 지연 알림 발송 (가맹점, NOTIFY_016)
+        // 가맹점 알림
         storeNotificationService.create(
                 NotificationType.DELIVERY_DELAY,
                 "배송 지연 안내",
                 "배송이 지연되었습니다. 사유: " + delayReason,
-                delivery.getOrders().getStore());
+                delivery.getOrders().getStore()
+        );
 
         return true;
     }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/model/Delivery.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/model/Delivery.java
@@ -5,7 +5,6 @@ import com.example.nexus.domain.orders.model.Orders;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -26,7 +25,7 @@ public class Delivery {
     @Column(name = "delivery_status", nullable = false)
     private DeliveryStatus deliveryStatus;
 
-    @Column(name = "delay_reason", nullable = true)
+    @Column(name = "delay_reason")
     private String delayReason;
 
     @Column(name = "dep_date", nullable = false)

--- a/backend/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java
@@ -1,6 +1,5 @@
 package com.example.nexus.domain.delivery.model;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.springframework.data.domain.Page;
 
@@ -23,6 +22,7 @@ public class DeliveryDto {
     private LocalDateTime deliveredDate;
 
     public static DeliveryDto from(Delivery delivery) {
+
         return DeliveryDto.builder()
                 .deliveryIdx(delivery.getIdx())
                 .orderIdx(delivery.getOrders().getIdx())
@@ -35,10 +35,11 @@ public class DeliveryDto {
                 .build();
     }
 
-    // 페이징 응답을 위한 DTO 추가
+    // 페이징 응답 DTO
     @Getter
     @Builder
     public static class DeliveryPageRes {
+
         private List<DeliveryDto> deliveryList;
         private int totalPage;
         private long totalCount;
@@ -46,8 +47,14 @@ public class DeliveryDto {
         private int currentSize;
 
         public static DeliveryPageRes from(Page<Delivery> page) {
+
             return DeliveryPageRes.builder()
-                    .deliveryList(page.getContent().stream().map(DeliveryDto::from).toList())
+                    .deliveryList(
+                            page.getContent()
+                                    .stream()
+                                    .map(DeliveryDto::from)
+                                    .toList()
+                    )
                     .totalPage(page.getTotalPages())
                     .totalCount(page.getTotalElements())
                     .currentPage(page.getNumber())
@@ -56,10 +63,11 @@ public class DeliveryDto {
         }
     }
 
-    // 본사 지연 사유 입력시 Request Body로 받을 정적 내부 클래스 추가
+    // 배송 지연 사유 요청 DTO
     @Getter
     @NoArgsConstructor
     public static class DelayReasonRequest {
+
         private Long deliveryIdx;
         private String delayReason;
     }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreController.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreController.java
@@ -101,14 +101,22 @@ public class StoreController {
         return ResponseEntity.ok(BaseResponse.success("성공"));
     }
 
-    // [가맹점] 로그인한 가맹점주의 월별 매출 정산 내역 조회
-    @GetMapping("/income")
-    public ResponseEntity<BaseResponse<StoreIncomeDto.MonthlyIncomeRes>> getMonthlyIncome(@AuthenticationPrincipal AuthUserDetails userDetails) {
+    // 가맹점별 매출 정산 조회
+    @GetMapping("/income/settlement")
+    public ResponseEntity<BaseResponse<StoreIncomeDto.TotalSettlementRes>> getSettlement(
+            @AuthenticationPrincipal AuthUserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
         if (userDetails == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
         }
 
-        StoreIncomeDto.MonthlyIncomeRes result = storeIncomeService.getMonthlyIncome(userDetails.getIdx());
+        StoreIncomeDto.TotalSettlementRes result = storeIncomeService.getSettlementData(
+                userDetails.getIdx(), year, month, page, size
+        );
 
         return ResponseEntity.ok(BaseResponse.success(result));
     }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreController.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreController.java
@@ -3,7 +3,9 @@ package com.example.nexus.domain.store;
 import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.common.model.PageResponse;
 import com.example.nexus.domain.store.model.StoreDto;
+import com.example.nexus.domain.store.model.StoreIncomeDto;
 import com.example.nexus.domain.store.model.StoreInventoryDto;
+import com.example.nexus.domain.user.model.AuthUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,6 +23,8 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 @RequiredArgsConstructor
 public class StoreController {
     private final StoreService storeService;
+    private final StoreIncomeService storeIncomeService;
+
 
     // [본사] 선택한 가맹점 store_idx로 재고 조회
     @GetMapping("/inventory/list/{storeIdx}")
@@ -95,5 +99,17 @@ public class StoreController {
     public ResponseEntity storeUpdate(@PathVariable(name = "storeIdx") Long storeIdx, @RequestBody StoreDto.StoreUpdateReq dto){
         storeService.storeUpdate(storeIdx, dto);
         return ResponseEntity.ok(BaseResponse.success("성공"));
+    }
+
+    // [가맹점] 로그인한 가맹점주의 월별 매출 정산 내역 조회
+    @GetMapping("/income")
+    public ResponseEntity<BaseResponse<StoreIncomeDto.MonthlyIncomeRes>> getMonthlyIncome(@AuthenticationPrincipal AuthUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        StoreIncomeDto.MonthlyIncomeRes result = storeIncomeService.getMonthlyIncome(userDetails.getIdx());
+
+        return ResponseEntity.ok(BaseResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreIncomeRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreIncomeRepository.java
@@ -1,10 +1,13 @@
 package com.example.nexus.domain.store;
 
 import com.example.nexus.domain.pos.model.PosPay;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface StoreIncomeRepository extends JpaRepository<PosPay, Long> {
@@ -18,4 +21,33 @@ public interface StoreIncomeRepository extends JpaRepository<PosPay, Long> {
             ORDER BY YEAR(p.paidAt) ASC, MONTH(p.paidAt) ASC
             """)
     List<Object[]> findMonthlyIncomeSumByStoreIdx(@Param("storeIdx") Long storeIdx);
+
+
+    // 특정 월의 전체 매출 합계
+    @Query("""
+            SELECT COALESCE(SUM(p.payAmount), 0)
+            FROM PosPay p
+            WHERE p.store.idx = :storeIdx
+              AND p.paidAt >= :start
+              AND p.paidAt < :end
+            """)
+    Long sumTotalAmountByMonth(
+            @Param("storeIdx") Long storeIdx,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
+
+    // 특정 월의 결제 내역 페이징 조회
+    @Query("""
+            SELECT p
+            FROM PosPay p
+            WHERE p.store.idx = :storeIdx
+              AND p.paidAt >= :start
+              AND p.paidAt < :end
+            ORDER BY p.paidAt DESC
+            """)
+    Page<PosPay> findPayHistoryByMonth(
+            @Param("storeIdx") Long storeIdx,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable);
 }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreIncomeRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreIncomeRepository.java
@@ -1,0 +1,21 @@
+package com.example.nexus.domain.store;
+
+import com.example.nexus.domain.pos.model.PosPay;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface StoreIncomeRepository extends JpaRepository<PosPay, Long> {
+
+
+    @Query("""
+            SELECT YEAR(p.paidAt), MONTH(p.paidAt), SUM(p.payAmount)
+            FROM PosPay p
+            WHERE p.store.idx = :storeIdx
+            GROUP BY YEAR(p.paidAt), MONTH(p.paidAt)
+            ORDER BY YEAR(p.paidAt) ASC, MONTH(p.paidAt) ASC
+            """)
+    List<Object[]> findMonthlyIncomeSumByStoreIdx(@Param("storeIdx") Long storeIdx);
+}

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreIncomeService.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreIncomeService.java
@@ -1,0 +1,41 @@
+package com.example.nexus.domain.store;
+
+import com.example.nexus.common.exception.BaseException;
+import com.example.nexus.common.model.BaseResponseStatus;
+import com.example.nexus.domain.store.model.Store;
+import com.example.nexus.domain.store.model.StoreIncomeDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StoreIncomeService {
+
+    private final StoreRepository storeRepository;
+    private final StoreIncomeRepository storeIncomeRepository;
+
+    @Transactional(readOnly = true)
+    public StoreIncomeDto.MonthlyIncomeRes getMonthlyIncome(Long userIdx) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
+
+        List<Object[]> rows = storeIncomeRepository.findMonthlyIncomeSumByStoreIdx(store.getIdx());
+
+        List<StoreIncomeDto.MonthlyIncomeItemRes> monthlyIncomes = rows.stream()
+                .map(row -> StoreIncomeDto.MonthlyIncomeItemRes.builder()
+                        .year(((Number) row[0]).intValue())
+                        .month(((Number) row[1]).intValue())
+                        .totalAmount(((Number) row[2]).longValue())
+                        .build())
+                .toList();
+
+        return StoreIncomeDto.MonthlyIncomeRes.builder()
+                .storeIdx(store.getIdx())
+                .storeName(store.getStoreName())
+                .monthlyIncomes(monthlyIncomes)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreIncomeService.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreIncomeService.java
@@ -2,13 +2,25 @@ package com.example.nexus.domain.store;
 
 import com.example.nexus.common.exception.BaseException;
 import com.example.nexus.common.model.BaseResponseStatus;
+import com.example.nexus.common.model.PageResponse;
+import com.example.nexus.domain.pos.PosOrdersItemRepository;
+import com.example.nexus.domain.pos.model.PosOrdersItem;
+import com.example.nexus.domain.pos.model.PosPay;
 import com.example.nexus.domain.store.model.Store;
 import com.example.nexus.domain.store.model.StoreIncomeDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,26 +28,64 @@ public class StoreIncomeService {
 
     private final StoreRepository storeRepository;
     private final StoreIncomeRepository storeIncomeRepository;
+    private final PosOrdersItemRepository posOrdersItemRepository;
 
     @Transactional(readOnly = true)
-    public StoreIncomeDto.MonthlyIncomeRes getMonthlyIncome(Long userIdx) {
+    public StoreIncomeDto.TotalSettlementRes getSettlementData(Long userIdx, int year, int month, int page, int size) {
+        // 가맹점 확인
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
-        List<Object[]> rows = storeIncomeRepository.findMonthlyIncomeSumByStoreIdx(store.getIdx());
+        // 날짜 범위 계산
+        LocalDateTime startOfMonth = LocalDateTime.of(LocalDate.of(year, month, 1), LocalTime.MIN);
+        LocalDateTime endOfMonth = startOfMonth.plusMonths(1);
 
-        List<StoreIncomeDto.MonthlyIncomeItemRes> monthlyIncomes = rows.stream()
-                .map(row -> StoreIncomeDto.MonthlyIncomeItemRes.builder()
-                        .year(((Number) row[0]).intValue())
-                        .month(((Number) row[1]).intValue())
-                        .totalAmount(((Number) row[2]).longValue())
-                        .build())
+        // 상단 매출 총액 조회
+        Long totalAmount = storeIncomeRepository.sumTotalAmountByMonth(store.getIdx(), startOfMonth, endOfMonth);
+
+        // 하단 결제 내역 페이징 조회
+        Pageable pageable = PageRequest.of(page, size);
+        Page<PosPay> payPage = storeIncomeRepository.findPayHistoryByMonth(store.getIdx(), startOfMonth, endOfMonth, pageable);
+
+        // 엔티티 -> DTO 변환 (메뉴명 합치기 로직 포함)
+        List<Long> payIdxList = payPage.getContent().stream().map(PosPay::getIdx).toList();
+
+        // 주문 내역(Item)들을 한 번에 가져와서 메모리에서 그룹핑 (N+1 문제 방지)
+        Map<Long, List<PosOrdersItem>> orderItemMap = posOrdersItemRepository
+                .findByPosPay_IdxIn(payIdxList)
+                .stream()
+                .collect(Collectors.groupingBy(item -> item.getPosPay().getIdx()));
+
+        List<StoreIncomeDto.PayHistoryRes> content = payPage.getContent().stream()
+                .map(pay -> {
+                    List<PosOrdersItem> items = orderItemMap.getOrDefault(pay.getIdx(), List.of());
+                    String menuNames = items.stream()
+                            .map(item -> item.getMenu().getMenuName())
+                            .collect(Collectors.joining(" + "));
+
+                    return StoreIncomeDto.PayHistoryRes.builder()
+                            .posPayIdx(pay.getIdx())
+                            .menuNames(menuNames)
+                            .payCount(items.size())
+                            .paidDate(pay.getPaidAt().toLocalDate())
+                            .payAmount(pay.getPayAmount())
+                            .build();
+                })
                 .toList();
 
-        return StoreIncomeDto.MonthlyIncomeRes.builder()
-                .storeIdx(store.getIdx())
-                .storeName(store.getStoreName())
-                .monthlyIncomes(monthlyIncomes)
+        // PageResponse 생성
+        PageResponse<StoreIncomeDto.PayHistoryRes> historyPageResponse = PageResponse.<StoreIncomeDto.PayHistoryRes>builder()
+                .content(content)
+                .number(payPage.getNumber())
+                .size(payPage.getSize())
+                .totalPages(payPage.getTotalPages())
+                .totalElements(payPage.getTotalElements())
+                .build();
+
+        // 최종 통합 DTO 반환
+        return StoreIncomeDto.TotalSettlementRes.builder()
+                .monthlyTotalAmount(totalAmount != null ? totalAmount : 0L)
+                .payHistory(historyPageResponse)
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreService.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreService.java
@@ -305,7 +305,7 @@ public class StoreService {
         LocalDateTime startDateTime = inputYearMonth.atDay(1).atStartOfDay();
 
         LocalDateTime endDateTime = inputYearMonth.atEndOfMonth().atTime(LocalTime.MAX);
-        List<StoreInventory> logs = storeInventoryRepository.findAllByWasteDateBetween(startDateTime, endDateTime);
+        List<StoreInventory> logs = storeInventoryRepository.findAllByManufacturedDateBetween(startDateTime, endDateTime);
 
         int success = 0;
         int fail = 0;

--- a/backend/src/main/java/com/example/nexus/domain/store/model/StoreIncomeDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/model/StoreIncomeDto.java
@@ -1,0 +1,47 @@
+package com.example.nexus.domain.store.model;
+
+import com.example.nexus.common.model.PageResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class StoreIncomeDto {
+
+    // 가맹점 월별 매출 현황 응답
+    @Getter
+    @Builder
+    public static class MonthlyIncomeRes {
+        private Long storeIdx;
+        private String storeName;
+        private List<MonthlyIncomeItemRes> monthlyIncomes;
+    }
+
+    @Getter
+    @Builder
+    public static class MonthlyIncomeItemRes {
+        private int year;
+        private int month;
+        private Long totalAmount;
+    }
+
+    // 결제 내역 단건 DTO
+    @Getter
+    @Builder
+    public static class PayHistoryRes {
+        private Long posPayIdx;
+        private String menuNames;
+        private int payCount;
+        private LocalDate paidDate;
+        private Long payAmount;
+    }
+
+    // 상단 총액 + 하단 페이징 리스트
+    @Getter
+    @Builder
+    public static class TotalSettlementRes {
+        private Long monthlyTotalAmount;
+        private PageResponse<PayHistoryRes> payHistory;
+    }
+}


### PR DESCRIPTION
## 📋 Summary
-  로그인한 가맹점 매출 정산 목록 조회

## 📂 변경 파일
- `backend/src/main/java/com/example/nexus/domain/store/StoreController.java`
- `backend/src/main/java/com/example/nexus/domain/store/StoreIncomeService.java`
- `backend/src/main/java/com/example/nexus/domain/store/StoreIncomeRepository.java`
- `backend/src/main/java/com/example/nexus/domain/store/model/StoreIncomeDto.java`

## ✨ 주요 변경 사항
- [ ] 로그인한 가맹점 매출 정산 조회 시 pos 결제 내역 기반으로 데이터 가져와서 총 합 금액 보여주게 구현
- [ ] 년, 월 기준으로 페이징 처리한 리스트도 불러오게 구현

Closes #148 