### PR TITLE
[Feat] #730 - 가맹점별 발주 정산 내역 조회

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersItemRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersItemRepository.java
@@ -3,10 +3,13 @@ package com.example.nexus.domain.orders;
 import com.example.nexus.domain.orders.model.OrdersItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Arrays;
 import java.util.List;
 
 public interface OrdersItemRepository extends JpaRepository<OrdersItem, Long> {
 
     // 발주용 - 특정 발주서의 품목 목록 조회
     List<OrdersItem> findByOrdersIdx(Long ordersIdx);
+
+    List<OrdersItem> findByOrdersIdxIn(List<Long> ordersIdxList);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersSettlementController.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersSettlementController.java
@@ -1,0 +1,43 @@
+package com.example.nexus.domain.orders;
+
+import com.example.nexus.common.model.BaseResponse;
+import com.example.nexus.domain.orders.model.OrdersSettlementDto;
+import com.example.nexus.domain.user.model.AuthUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@RequestMapping("/store")
+@RestController
+@RequiredArgsConstructor
+public class OrdersSettlementController {
+
+    private final OrdersSettlementService ordersSettlementService;
+
+    // [가맹점] 로그인한 가맹점주의 발주 정산 내역 조회
+    @GetMapping("/order/settlement")
+    public ResponseEntity<BaseResponse<OrdersSettlementDto.TotalOrderSettlementRes>> getOrderSettlement(
+            @AuthenticationPrincipal AuthUserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        if (userDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        OrdersSettlementDto.TotalOrderSettlementRes result = ordersSettlementService.getOrderSettlement(
+                userDetails.getIdx(), year, month, page, size
+        );
+
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersSettlementRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersSettlementRepository.java
@@ -1,0 +1,57 @@
+package com.example.nexus.domain.orders;
+
+import com.example.nexus.domain.orders.model.Orders;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+
+public interface OrdersSettlementRepository extends JpaRepository<Orders, Long> {
+    // 해당 월 전체 발주 금액 합계 (총 납부액)
+    @Query("""
+            SELECT COALESCE(SUM(o.price), 0)
+            FROM Orders o
+            WHERE o.store.idx = :storeIdx
+              AND o.createdAt >= :start
+              AND o.createdAt < :end
+            """)
+    Long sumTotalAmountByMonth(
+            @Param("storeIdx") Long storeIdx,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
+    // 해당 월 APPROVE 상태 발주 금액 합계 (납부 예상 금액)
+    @Query("""
+            SELECT COALESCE(SUM(o.price), 0)
+            FROM Orders o
+            WHERE o.store.idx = :storeIdx
+              AND o.createdAt >= :start
+              AND o.createdAt < :end
+              AND o.ordersStatus = 'APPROVE'
+            """)
+    Long sumExpectedAmountByMonth(
+            @Param("storeIdx") Long storeIdx,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
+    // 해당 월 발주 내역 페이징 조회 (최신순)
+    @Query("""
+            SELECT o
+            FROM Orders o
+            WHERE o.store.idx = :storeIdx
+              AND o.createdAt >= :start
+              AND o.createdAt < :end
+            ORDER BY o.createdAt DESC
+            """)
+    Page<Orders> findOrderHistoryByMonth(
+            @Param("storeIdx") Long storeIdx,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable
+    );
+}

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersSettlementService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersSettlementService.java
@@ -1,0 +1,100 @@
+package com.example.nexus.domain.orders;
+
+import com.example.nexus.common.exception.BaseException;
+import com.example.nexus.common.model.BaseResponseStatus;
+import com.example.nexus.common.model.PageResponse;
+import com.example.nexus.domain.orders.model.Orders;
+import com.example.nexus.domain.orders.model.OrdersItem;
+import com.example.nexus.domain.orders.model.OrdersSettlementDto;
+import com.example.nexus.domain.store.StoreRepository;
+import com.example.nexus.domain.store.model.Store;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class OrdersSettlementService {
+    private final StoreRepository storeRepository;
+    private final OrdersSettlementRepository ordersSettlementRepository;
+    private final OrdersItemRepository ordersItemRepository;
+
+    @Transactional(readOnly = true)
+    public OrdersSettlementDto.TotalOrderSettlementRes getOrderSettlement(Long userIdx, int year, int month, int page, int size) {
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
+
+        LocalDateTime start = LocalDateTime.of(LocalDate.of(year, month, 1), LocalTime.MIN);
+        LocalDateTime end = start.plusMonths(1);
+
+        // 총 납부액 (해당 월 전체 발주 합계)
+        Long totalAmount = ordersSettlementRepository.sumTotalAmountByMonth(store.getIdx(), start, end);
+
+        // 납부 예상 금액 (APPROVE 상태만)
+        Long expectedPayAmount = ordersSettlementRepository.sumExpectedAmountByMonth(store.getIdx(), start, end);
+
+        // 발주 내역 페이징 조회
+        Page<Orders> ordersPage = ordersSettlementRepository.findOrderHistoryByMonth(
+                store.getIdx(), start, end, PageRequest.of(page, size)
+        );
+
+        // 발주 idx 목록으로 ordersItem 한 번에 조회 (N+1 방지)
+        List<Long> ordersIdxList = ordersPage.getContent().stream()
+                .map(Orders::getIdx)
+                .toList();
+
+        Map<Long, List<OrdersItem>> itemMap;
+        if (ordersIdxList.isEmpty()) itemMap = Map.of();
+        else itemMap = ordersItemRepository.findByOrdersIdxIn(ordersIdxList)
+                .stream()
+                .collect(Collectors.groupingBy(item -> item.getOrders().getIdx()));
+
+        List<OrdersSettlementDto.OrderSettlementItemRes> content = ordersPage.getContent().stream()
+                .map(order -> {
+                    List<OrdersItem> items = itemMap.getOrDefault(order.getIdx(), List.of());
+
+                    // 제품명 " + " 로 이어붙이기
+                    String productNames = items.stream()
+                            .map(item -> item.getProduct().getProductName())
+                            .collect(Collectors.joining(" , "));
+
+                    // 수량 합계
+                    int totalCount = items.stream()
+                            .mapToInt(OrdersItem::getCount)
+                            .sum();
+
+                    return OrdersSettlementDto.OrderSettlementItemRes.builder()
+                            .ordersIdx(order.getIdx())
+                            .createdDate(order.getCreatedAt().toLocalDate())
+                            .productNames(productNames)
+                            .totalCount(totalCount)
+                            .price(order.getPrice())
+                            .ordersStatus(order.getOrdersStatus())
+                            .build();
+                })
+                .toList();
+
+        PageResponse<OrdersSettlementDto.OrderSettlementItemRes> orderHistory = PageResponse.<OrdersSettlementDto.OrderSettlementItemRes>builder()
+                .content(content)
+                .number(ordersPage.getNumber())
+                .size(ordersPage.getSize())
+                .totalPages(ordersPage.getTotalPages())
+                .totalElements(ordersPage.getTotalElements())
+                .build();
+
+        return OrdersSettlementDto.TotalOrderSettlementRes.builder()
+                .totalAmount(totalAmount != null ? totalAmount : 0L)
+                .expectedPayAmount(expectedPayAmount != null ? expectedPayAmount : 0L)
+                .orderHistory(orderHistory)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersSettlementDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersSettlementDto.java
@@ -1,0 +1,31 @@
+package com.example.nexus.domain.orders.model;
+
+import com.example.nexus.common.enums.OrdersStatus;
+import com.example.nexus.common.model.PageResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class OrdersSettlementDto {
+    // 최종 응답: 상단 요약 + 하단 페이징 리스트
+    @Getter
+    @Builder
+    public static class TotalOrderSettlementRes {
+        private Long totalAmount;
+        private Long expectedPayAmount;
+        private PageResponse<OrderSettlementItemRes> orderHistory;
+    }
+
+    // 발주 정산 리스트 단건
+    @Getter
+    @Builder
+    public static class OrderSettlementItemRes {
+        private Long ordersIdx;
+        private LocalDate createdDate;
+        private String productNames;
+        private Integer totalCount;
+        private Long price;
+        private OrdersStatus ordersStatus;
+    }
+}


### PR DESCRIPTION
## 📋 Summary
-  로그인한 가맹점 발주 정산 목록 조회

## 📂 변경 파일
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersSettlementController.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersSettlementService.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersSettlementRepository.java`
- `backend/src/main/java/com/example/nexus/domain/orders/model/OrdersSettlementDto.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersItemRepository.java`

## ✨ 주요 변경 사항
- [ ] OrdersSettlementController 로그인한 가맹점 발주 정산 내역 service실행
- [ ] OrdersSettlementService 로그인한 가맹점 발주 정산 내역 연, 월 기준으로 조회
- [ ] 해당 월 전체 발주 금액 합계 (status = approve인 것만 합산)
- [ ] 발주 내역은 페이징 해서 가져오게 함
- [ ] OrdersItemRepository orderIdx로 데이터 한번만 가져오게 함
- [ ] OrdersSettlementDto 생성

Closes #730