### PR TITLE
[Feat] #149 - 가맹점별 발주 정산 목록 조회 페이지 백엔드 연동

### DIFF
--- a/frontend/src/api/store/index.js
+++ b/frontend/src/api/store/index.js
@@ -34,3 +34,6 @@ export const putStoreUpdate = (storeIdx,updateData) =>
 
 export const getSettlement = (year, month, page = 0, size = 10) =>
   api.get('/store/income/settlement', { params: { year, month, page, size }})
+
+export const getOrderSettlement = (year, month, page = 0, size = 10) =>
+  api.get('/store/order/settlement', { params: { year, month, page, size }})

--- a/frontend/src/views/store/StoreSettlementView.vue
+++ b/frontend/src/views/store/StoreSettlementView.vue
@@ -105,23 +105,23 @@
         <h1 class="text-xl font-bold text-gray-900 tracking-tight">발주 정산 내역</h1>
 
         <div class="flex gap-2 mt-3">
-          <select v-model="orderYear" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white outline-none focus:border-blue-500">
+          <select v-model="orderYear" @change="fetchOrderData" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white outline-none focus:border-blue-500">
             <option value="2026">2026년</option>
             <option value="2025">2025년</option>
           </select>
-          <select v-model="orderMonth" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white outline-none focus:border-blue-500">
+          <select v-model="orderMonth" @change="fetchOrderData" class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white outline-none focus:border-blue-500">
             <option v-for="m in 12" :key="m" :value="String(m).padStart(2, '0')">{{ m }}월</option>
           </select>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-          <div class="bg-orange-50 p-6 rounded-2xl border border-orange-100 shadow-sm">
-            <p class="text-sm font-medium text-orange-600 mb-1">총 납부액</p>
-            <p class="text-2xl font-bold text-gray-900">₩ {{ totalOrderAmount.toLocaleString() }}</p>
+          <div class="bg-gray-50 p-6 rounded-2xl border border-gray-200 w-full shadow-sm text-left">
+            <p class="text-sm font-medium text-gray-500 mb-1">총 납부액</p>
+            <p class="text-2xl font-bold text-green-600">₩ {{ totalOrderAmount.toLocaleString() }}</p>
           </div>
-          <div class="bg-green-50 p-6 rounded-2xl border border-green-100 shadow-sm">
-            <p class="text-sm font-medium text-red-600 mb-1">미납금</p>
-            <p class="text-2xl font-bold text-gray-900">₩ 0</p>
+          <div class="bg-gray-50 p-6 rounded-2xl border border-gray-200 w-full shadow-sm text-left">
+            <p class="text-sm font-medium text-gray-500 mb-1">이번달 납부 예상 금액</p>
+            <p class="text-2xl font-bold text-[#F37321]">₩ {{ expectedPayAmount.toLocaleString() }}</p>
           </div>
         </div>
       </div>
@@ -138,27 +138,55 @@
           </tr>
           </thead>
           <tbody class="divide-y divide-gray-100">
-          <tr v-for="item in filteredOrders" :key="item.id" class="hover:bg-gray-50/50 transition-colors">
-            <td class="px-6 py-4 text-gray-600">{{ item.period }}</td>
-            <td class="px-6 py-4 font-semibold text-gray-900">{{ item.item }}</td>
-            <td class="px-6 py-4 text-gray-600">{{ item.count }}개</td>
-            <td class="px-6 py-4 font-bold text-gray-900">₩ {{ item.amount.toLocaleString() }}</td>
+          <tr v-for="item in orderData" :key="item.ordersIdx" class="hover:bg-gray-50/50 transition-colors">
+            <td class="px-6 py-4 text-gray-600">{{ item.createdDate }}</td>
+            <td class="px-6 py-4 font-semibold text-gray-900">{{ item.productNames }}</td>
+            <td class="px-6 py-4 text-gray-600">{{ item.totalCount }}개</td>
+            <td class="px-6 py-4 font-bold text-gray-900">₩ {{ item.price?.toLocaleString() }}</td>
             <td class="px-6 py-4">
-                <span class="px-2.5 py-1 rounded-full text-xs font-bold bg-green-50 text-green-600 border border-green-100">
-                  납부완료
-                </span>
+              <span class="px-2.5 py-1 rounded-full text-xs font-bold bg-green-50 text-green-600 border border-green-100">
+                납부완료
+              </span>
             </td>
+          </tr>
+          <tr v-if="orderData.length === 0">
+            <td colspan="5" class="px-6 py-10 text-center text-gray-400">해당 기간의 발주 내역이 없습니다.</td>
           </tr>
           </tbody>
         </table>
+
+        <div v-if="orderTotalPages > 1" class="flex justify-center items-center gap-2 py-4 border-t border-gray-100">
+          <button
+            @click="changeOrderPage(orderCurrentPage - 1)"
+            :disabled="orderCurrentPage === 0"
+            class="p-2 border rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M15 19l-7-7 7-7" stroke-width="2"/></svg>
+          </button>
+          <div class="flex gap-1">
+            <button
+              v-for="p in orderTotalPages"
+              :key="p"
+              @click="changeOrderPage(p - 1)"
+              class="w-9 h-9 text-sm font-semibold rounded-lg transition-colors"
+              :class="orderCurrentPage === p - 1 ? 'bg-blue-600 text-white' : 'bg-white border border-gray-200 text-gray-600 hover:bg-gray-50'">
+              {{ p }}
+            </button>
+          </div>
+          <button
+            @click="changeOrderPage(orderCurrentPage + 1)"
+            :disabled="orderCurrentPage === orderTotalPages - 1"
+            class="p-2 border rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7" stroke-width="2"/></svg>
+          </button>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
-import { getSettlement } from '@/api/store' // api/index.js 경로에 맞게 수정 필요
+import { ref, onMounted, watch } from 'vue'
+import { getSettlement, getOrderSettlement } from '@/api/store'
 
 const activeTab = ref('sales')
 
@@ -171,11 +199,10 @@ const salesCurrentPage = ref(0)
 const salesTotalPages = ref(1)
 const salesPageSize = 10
 
-// 매출 API 호출
 const fetchSalesData = async () => {
   try {
     const response = await getSettlement(salesYear.value, salesMonth.value, salesCurrentPage.value, salesPageSize)
-    const result = response.data.result // BaseResponse의 result 매핑
+    const result = response.data.result
 
     if (result) {
       totalSalesAmount.value = result.monthlyTotalAmount || 0
@@ -194,35 +221,55 @@ const changeSalesPage = (page) => {
   fetchSalesData()
 }
 
-// 필터 변경 시 1페이지부터 다시 불러오기
 watch([salesYear, salesMonth], () => {
   salesCurrentPage.value = 0
 })
 
-
-// --- 발주 데이터 (Mock 유지) ---
+// --- 발주 상태 관리 ---
 const orderYear = ref('2026')
 const orderMonth = ref('04')
+const orderData = ref([])
+const totalOrderAmount = ref(0)
+const expectedPayAmount = ref(0)
+const orderCurrentPage = ref(0)
+const orderTotalPages = ref(1)
+const orderPageSize = 10
 
-const orderData = ref([
-  { id: 10, year: '2026', month: '04', day: '10', item: '한우 등심', count: 25, period: '04-10', amount: 2125000 },
-  { id: 11, year: '2026', month: '04', day: '11', item: '한우 안심', count: 10, period: '04-11', amount: 950000 },
-  { id: 12, year: '2026', month: '04', day: '12', item: '올리브오일', count: 10, period: '04-12', amount: 120000 },
-  { id: 13, year: '2026', month: '03', day: '15', item: '생크림', count: 22, period: '03-15', amount: 154000 },
-])
+const fetchOrderData = async () => {
+  try {
+    const response = await getOrderSettlement(orderYear.value, Number(orderMonth.value), orderCurrentPage.value, orderPageSize)
+    const result = response.data.result
 
-const filteredOrders = computed(() => {
-  return orderData.value.filter(d => d.year === orderYear.value && d.month === orderMonth.value)
-})
+    if (result) {
+      totalOrderAmount.value = result.totalAmount || 0
+      expectedPayAmount.value = result.expectedPayAmount || 0
+      if (result.orderHistory) {
+        orderData.value = result.orderHistory.content || []
+        orderTotalPages.value = result.orderHistory.totalPages || 1
+      }
+    }
+  } catch (error) {
+    console.error('발주 데이터를 불러오는데 실패했습니다:', error)
+  }
+}
 
-const totalOrderAmount = computed(() => {
-  return filteredOrders.value.reduce((acc, cur) => acc + cur.amount, 0)
+const changeOrderPage = (page) => {
+  orderCurrentPage.value = page
+  fetchOrderData()
+}
+
+watch([orderYear, orderMonth], () => {
+  orderCurrentPage.value = 0
+  fetchOrderData()
 })
 
 // --- 탭 전환 시 조회 ---
 watch(activeTab, (newTab) => {
   if (newTab === 'sales' && salesData.value.length === 0) {
     fetchSalesData()
+  }
+  if (newTab === 'order' && orderData.value.length === 0) {
+    fetchOrderData()
   }
 })
 


### PR DESCRIPTION
## 📋 Summary
-  로그인한 가맹점 발주 정산 목록 조회 백엔드 연동

## 📂 변경 파일
- `frontend/src/views/store/StoreSettlementView.vue`
- `frontend/src/api/store/index.js`

## ✨ 주요 변경 사항
- [ ] store/index.js '/store/order/settlement' api 호출
- [ ] StoreSettlementView.vue '/store/order/settlement' api 연동
- [ ] 카드 색상, 글꼴 색상 변경

Closes #149 