### PR TITLE
[Feat] #90 - 본사 정산 목록 조회

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/head/HeadController.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadController.java
@@ -51,4 +51,38 @@ public class HeadController {
         List<HeadIncomeDto.ListRes> result = headIncomeService.getIncomeList(storeName, status, startDate, endDate);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
+
+    // 본사 정산 관리 - 상단 요약 카드 조회
+    @GetMapping("/settlement/summary")
+    public ResponseEntity<BaseResponse<HeadIncomeDto.HeadSettlementSummaryRes>> getSettlementSummary(
+            @AuthenticationPrincipal AuthUserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month) {
+        if (userDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        HeadIncomeDto.HeadSettlementSummaryRes result = headIncomeService.getSettlementSummary(year, month);
+
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    // 본사 정산 관리 - 가맹점별 정산 리스트 페이징 조회
+    @GetMapping("/settlement/list")
+    public ResponseEntity<BaseResponse<PageResponse<HeadIncomeDto.StoreSettlementRes>>> getStoreSettlementList(
+            @AuthenticationPrincipal AuthUserDetails userDetails,
+            @RequestParam(required = false, defaultValue = "") String storeName,
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        if (userDetails == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        PageResponse<HeadIncomeDto.StoreSettlementRes> result =
+                headIncomeService.getStoreSettlementList(storeName, year, month, page, size);
+
+        return ResponseEntity.ok(BaseResponse.success(result));
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java
@@ -1,13 +1,18 @@
 package com.example.nexus.domain.head;
 
 import com.example.nexus.domain.head.model.HeadIncome;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface HeadIncomeRepository extends JpaRepository<HeadIncome, Long> {
+
     List<HeadIncome> findAllByStoreIdx(Long storeIdx);
 
     List<HeadIncome> findBySettlementIdx(Long idx);
@@ -21,4 +26,37 @@ public interface HeadIncomeRepository extends JpaRepository<HeadIncome, Long> {
             "AND (:startDate IS NULL OR FUNCTION('DATE', o.createdAt) >= :startDate) " +
             "AND (:endDate IS NULL OR FUNCTION('DATE', o.createdAt) <= :endDate)")
     List<HeadIncome> findByFilters(String storeName, Boolean status, LocalDate startDate, LocalDate endDate);
+
+    // 본사 정산 관리 - 가맹점별 그루핑 페이징 조회
+    // 가맹점별로 묶어서 발주 건수, 총 정산 금액, 정산 상태를 집계
+    @Query("""
+            SELECT hi.store.idx, hi.store.storeName, COUNT(hi), SUM(hi.price),
+                   CASE WHEN SUM(CASE WHEN hi.status = false THEN 1 ELSE 0 END) > 0 THEN false ELSE true END
+            FROM HeadIncome hi
+            JOIN hi.orders o
+            WHERE (:storeName IS NULL OR :storeName = '' OR hi.store.storeName LIKE %:storeName%)
+              AND o.createdAt >= :start
+              AND o.createdAt < :end
+            GROUP BY hi.store.idx, hi.store.storeName
+            ORDER BY hi.store.storeName ASC
+            """)
+    Page<Object[]> findStoreSettlementByMonth(
+            @Param("storeName") String storeName,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable
+    );
+
+    // 본사 정산 관리 - 상단 카드용 전체 청구 합계
+    @Query("""
+            SELECT COALESCE(SUM(hi.price), 0)
+            FROM HeadIncome hi
+            JOIN hi.orders o
+            WHERE o.createdAt >= :start
+              AND o.createdAt < :end
+            """)
+    Long sumTotalBillingByMonth(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java
@@ -1,12 +1,18 @@
 package com.example.nexus.domain.head;
 
+import com.example.nexus.common.model.PageResponse;
 import com.example.nexus.domain.head.model.HeadIncome;
 import com.example.nexus.domain.head.model.HeadIncomeDto;
 import com.example.nexus.domain.orders.model.Orders;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -86,5 +92,55 @@ public class HeadIncomeService {
 
     public HeadIncome findById(Long idx) {
         return headIncomeRepository.findById(idx).orElse(null);
+    }
+
+    // 본사 정산 관리 - 가맹점별 월 정산 요약 페이징 조회
+    @Transactional(readOnly = true)
+    public PageResponse<HeadIncomeDto.StoreSettlementRes> getStoreSettlementList(
+            String storeName, int year, int month, int page, int size) {
+
+        LocalDateTime start = LocalDateTime.of(LocalDate.of(year, month, 1), LocalTime.MIN);
+        LocalDateTime end = start.plusMonths(1);
+
+        Page<Object[]> resultPage = headIncomeRepository.findStoreSettlementByMonth(
+                storeName, start, end, PageRequest.of(page, size)
+        );
+
+        LocalDate periodStart = start.toLocalDate();
+        LocalDate periodEnd = end.toLocalDate().minusDays(1);
+
+        List<HeadIncomeDto.StoreSettlementRes> content = resultPage.getContent().stream()
+                .map(row -> HeadIncomeDto.StoreSettlementRes.builder()
+                        .storeIdx(((Number) row[0]).longValue())
+                        .storeName((String) row[1])
+                        .periodStart(periodStart)
+                        .periodEnd(periodEnd)
+                        .orderCount(((Number) row[2]).intValue())
+                        .totalPrice(((Number) row[3]).longValue())
+                        .status((Boolean) row[4])
+                        .build())
+                .toList();
+
+        return PageResponse.<HeadIncomeDto.StoreSettlementRes>builder()
+                .content(content)
+                .number(resultPage.getNumber())
+                .size(resultPage.getSize())
+                .totalPages(resultPage.getTotalPages())
+                .totalElements(resultPage.getTotalElements())
+                .build();
+    }
+
+    // 본사 정산 관리 - 상단 카드 요약 조회
+    @Transactional(readOnly = true)
+    public HeadIncomeDto.HeadSettlementSummaryRes getSettlementSummary(int year, int month) {
+        LocalDateTime start = LocalDateTime.of(LocalDate.of(year, month, 1), LocalTime.MIN);
+        LocalDateTime end = start.plusMonths(1);
+
+        Long totalBillingAmount = headIncomeRepository.sumTotalBillingByMonth(start, end);
+
+        return HeadIncomeDto.HeadSettlementSummaryRes.builder()
+                .totalBillingAmount(totalBillingAmount != null ? totalBillingAmount : 0L)
+                .totalStoreCount(0)
+                .build();
     }
 }

--- a/backend/src/main/java/com/example/nexus/domain/head/model/HeadIncomeDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/model/HeadIncomeDto.java
@@ -44,4 +44,25 @@ public class HeadIncomeDto {
         private Boolean status;
         private Long settlementIdx;
     }
+
+    // 본사 정산 관리 - 가맹점별 정산 요약 단건
+    @Getter
+    @Builder
+    public static class StoreSettlementRes {
+        private Long storeIdx;
+        private String storeName;
+        private LocalDate periodStart;
+        private LocalDate periodEnd;
+        private int orderCount;
+        private Long totalPrice;
+        private Boolean status;
+    }
+
+    // 본사 정산 관리 - 전체 응답 (상단 요약 카드 + 페이징 리스트)
+    @Getter
+    @Builder
+    public static class HeadSettlementSummaryRes {
+        private Long totalBillingAmount;
+        private int totalStoreCount;
+    }
 }


### PR DESCRIPTION
## 📋 Summary
-  본사 정산 목록 조회 기능 구현 페이징 처리

## 📂 변경 파일
- `backend/src/main/java/com/example/nexus/domain/head/HeadController.java`
- `backend/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java`
- `backend/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java`
- `backend/src/main/java/com/example/nexus/domain/head/model/HeadIncomeDto.java`

## ✨ 주요 변경 사항
- [ ] controller 전체 가맹점들에 대한 발주 금액 총합 구하는 service 실행
- [ ] controller 가맹점별 정산 리스트 페이지로 조회
- [ ] service 연,월 별로 조회 (페이징 처리)
- [ ] 해당 월에 전체 가맹점에서 발생한 정산 금액 총합 계산
- [ ] repository 가맹점 idx, 가맹점명, 발주건수, 정산상태 가져와서 집계
- [ ] 정산 관리 정보 담아줄 Dto 생성


Closes #90 