### PR TITLE
[Feat] #91 - 본사 정산 목록 조회 기능 프론트, 백 연동

### DIFF
--- a/frontend/src/api/headincome/index.js
+++ b/frontend/src/api/headincome/index.js
@@ -1,0 +1,9 @@
+import api from '@/plugins/axiosinterceptor'
+
+// 본사 정산 관리 - 상단 카드 요약 조회
+export const getHeadSettlementSummary = (year, month) =>
+  api.get('/head/settlement/summary', { params: { year, month } })
+
+// 본사 정산 관리 - 가맹점별 정산 리스트 페이징 조회
+export const getHeadSettlementList = (year, month, storeName = '', page = 0, size = 10) =>
+  api.get('/head/settlement/list', { params: { year, month, storeName, page, size } })

--- a/frontend/src/views/hq/SettlementView.vue
+++ b/frontend/src/views/hq/SettlementView.vue
@@ -2,7 +2,6 @@
   <div class="p-5 space-y-4">
 
     <div class="flex flex-col gap-3">
-
       <div class="flex justify-between items-start flex-wrap gap-4">
         <div class="min-w-0">
           <h1 class="text-xl font-bold text-gray-900 tracking-tight">정산 관리</h1>
@@ -10,22 +9,9 @@
       </div>
 
       <div class="flex flex-wrap gap-2 items-center">
-
-        <div class="flex rounded-lg border border-gray-200 bg-gray-50/90 p-0.5">
-          <button
-            v-for="p in periodGranularityOptions"
-            :key="p"
-            type="button"
-            class="text-xs px-2.5 py-1.5 rounded-md font-semibold transition-colors cursor-pointer"
-            :class="periodGranularity === p ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
-            @click="periodGranularity = p"
-          >
-            {{ p }}
-          </button>
-        </div>
-
         <select
           v-model="selectedMonth"
+          @change="onMonthChange"
           class="px-3 py-2 rounded-lg border border-gray-200 text-sm bg-white shadow-sm
                  focus:border-[#F37321] focus:ring-1 focus:ring-[#F37321] outline-none"
         >
@@ -45,48 +31,28 @@
 
     <div class="flex flex-wrap gap-3 items-center">
       <div class="relative flex-1 min-w-[12rem] max-w-md">
-
         <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-          <svg
-            class="w-4 h-4 text-gray-400"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            />
+          <svg class="w-4 h-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </div>
-
         <input
           v-model="settlementSearch"
+          @input="onSearchInput"
           type="search"
           placeholder="매장명 검색…"
           class="w-full pl-10 px-3 py-2 rounded-lg border border-gray-200 text-sm
-                 bg-white shadow-sm
-                 focus:border-[#F37321] focus:ring-1 focus:ring-[#F37321]
-                 outline-none"
+                 bg-white shadow-sm focus:border-[#F37321] focus:ring-1 focus:ring-[#F37321] outline-none"
         />
       </div>
     </div>
 
-    <div class="grid grid-cols-2 gap-4">
+    <!-- 매장 청구 합계 카드 -->
+    <div class="grid grid-cols-1 gap-4">
       <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
         <div class="p-5">
           <p class="text-xs font-bold text-gray-400 uppercase tracking-wider">매장 청구 합계</p>
-          <p class="text-2xl font-black text-gray-900 mt-2">₩ {{ totalStore.toLocaleString() }}</p>
-          <p class="text-xs text-gray-400 mt-2 pt-2 border-t border-gray-100">{{ selectedMonth }}</p>
-        </div>
-      </div>
-      <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
-        <div class="p-5">
-          <p class="text-xs font-bold text-gray-400 uppercase tracking-wider">순이익 (차액)</p>
-          <p class="text-2xl font-black text-green-600 mt-2">₩ {{ (totalStore - totalSupplier).toLocaleString() }}</p>
+          <p class="text-2xl font-black text-green-600">₩ {{ totalBillingAmount.toLocaleString() }}</p>
           <p class="text-xs text-gray-400 mt-2 pt-2 border-t border-gray-100">{{ selectedMonth }}</p>
         </div>
       </div>
@@ -115,44 +81,62 @@
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주/납품 건수</th>
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">정산금액</th>
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">명세서</th>
         </tr>
         </thead>
 
         <tbody class="divide-y divide-gray-100">
-        <tr v-for="s in filteredSettlements" :key="s.name" class="hover:bg-gray-50/50 transition-colors">
-          <td class="px-5 py-3.5 font-semibold text-gray-900">{{ s.name }}</td>
-          <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ s.period }}</td>
-          <td class="px-5 py-3.5 text-gray-600">{{ s.count }}건</td>
-          <td class="px-5 py-3.5 font-bold text-gray-900">₩ {{ s.amount.toLocaleString() }}</td>
+        <tr v-for="s in settlementList" :key="s.storeIdx" class="hover:bg-gray-50/50 transition-colors">
+          <td class="px-5 py-3.5 font-semibold text-gray-900">{{ s.storeName }}</td>
+          <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ s.periodStart }} ~ {{ s.periodEnd }}</td>
+          <td class="px-5 py-3.5 text-gray-600">{{ s.orderCount }}건</td>
+          <td class="px-5 py-3.5 font-bold text-gray-900">₩ {{ s.totalPrice?.toLocaleString() }}</td>
           <td class="px-5 py-3.5">
-              <span
-                class="text-xs font-bold px-2 py-0.5 rounded"
-                :class="s.status === '정산완료'
-                  ? 'bg-green-50 text-green-700 border border-green-200'
-                  : 'bg-amber-50 text-amber-600 border border-amber-200'"
-              >
-                {{ s.status }}
-              </span>
+            <span
+              class="text-xs font-bold px-2 py-0.5 rounded"
+              :class="s.status
+                ? 'bg-green-50 text-green-700 border border-green-200'
+                : 'bg-amber-50 text-amber-600 border border-amber-200'"
+            >
+              {{ s.status ? '정산완료' : '대기' }}
+            </span>
           </td>
           <td class="px-5 py-3.5 text-center">
-            <button
-              type="button"
-              class="text-gray-300 hover:text-[#F37321] transition-colors cursor-pointer"
-              @click="downloadStatement(s)"
-            >
-              <Download class="w-4 h-4 mx-auto" />
-            </button>
           </td>
         </tr>
 
-        <tr v-if="filteredSettlements.length === 0">
+        <tr v-if="settlementList.length === 0">
           <td colspan="6" class="px-5 py-10 text-center text-sm text-gray-400">
             검색 결과가 없습니다.
           </td>
         </tr>
         </tbody>
       </table>
+
+      <!-- 페이징 -->
+      <div v-if="totalPages > 1" class="flex justify-center items-center gap-2 py-4 border-t border-gray-100">
+        <button
+          @click="changePage(currentPage - 1)"
+          :disabled="currentPage === 0"
+          class="p-2 border rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M15 19l-7-7 7-7" stroke-width="2"/></svg>
+        </button>
+        <div class="flex gap-1">
+          <button
+            v-for="p in totalPages"
+            :key="p"
+            @click="changePage(p - 1)"
+            class="w-9 h-9 text-sm font-semibold rounded-lg transition-colors"
+            :class="currentPage === p - 1 ? 'bg-[#F37321] text-white' : 'bg-white border border-gray-200 text-gray-600 hover:bg-gray-50'">
+            {{ p }}
+          </button>
+        </div>
+        <button
+          @click="changePage(currentPage + 1)"
+          :disabled="currentPage === totalPages - 1"
+          class="p-2 border rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7" stroke-width="2"/></svg>
+        </button>
+      </div>
     </div>
 
     <ConfirmModal
@@ -170,57 +154,88 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
-import { Download } from 'lucide-vue-next'
+import { ref, onMounted } from 'vue'
 import Toast from '@/components/common/Toast.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import { useToast } from '@/composables/useToast'
+import { getHeadSettlementSummary, getHeadSettlementList } from '@/api/headincome'
 
 const { toast, showToast } = useToast()
 
 const selectedMonth = ref('2026-04')
 const activeTab = ref('입점 매장 정산')
 const settlementSearch = ref('')
-const periodGranularity = ref('월간')
-const periodGranularityOptions = ['주간', '월간', '년간']
-
-// 모달 상태 관리
 const isModalOpen = ref(false)
 
-const storeSettlements = ref([
-  { name: '한우 오마카세',  period: '2026-04-01 ~ 04-30', count: 28, amount: 12500000, status: '정산완료' },
-  { name: '이탈리안 키친',  period: '2026-04-01 ~ 04-30', count: 31, amount: 15800000, status: '정산완료' },
-  { name: '일식 스시바',    period: '2026-04-01 ~ 04-30', count: 19, amount: 9200000,  status: '대기' },
-  { name: '차이나 가든',    period: '2026-04-01 ~ 04-30', count: 22, amount: 11300000, status: '대기' },
-])
+// 상단 카드
+const totalBillingAmount = ref(0)
 
-const supplierSettlements = ref([
-  { name: '서울우유', period: '2026-04-01 ~ 04-30', count: 14, amount: 4500000, status: '정산완료' },
-  { name: '동서식품', period: '2026-04-01 ~ 04-30', count: 8, amount: 7200000, status: '대기' },
-  { name: '한국포장', period: '2026-04-01 ~ 04-30', count: 5, amount: 1800000, status: '대기' },
-  { name: '청정원F&B', period: '2026-04-01 ~ 04-30', count: 6, amount: 2100000, status: '정산완료' },
-])
+// 리스트 + 페이징
+const settlementList = ref([])
+const currentPage = ref(0)
+const totalPages = ref(1)
+const pageSize = 10
 
-const currentSettlements = computed(() =>
-  activeTab.value === '입점 매장 정산' ? storeSettlements.value : supplierSettlements.value,
-)
-
-const filteredSettlements = computed(() => {
-  const q = settlementSearch.value.trim()
-  if (!q) return currentSettlements.value
-  return currentSettlements.value.filter(s => s.name.includes(q))
-})
-
-function downloadStatement(row) {
-  showToast(`${row.name} 거래 명세서(PDF) 다운로드`)
+// selectedMonth "2026-04" → year: 2026, month: 4 파싱
+const parsedDate = () => {
+  const [year, month] = selectedMonth.value.split('-').map(Number)
+  return { year, month }
 }
 
-// 모달 '예' 클릭 시 실행 함수
+const fetchSummary = async () => {
+  try {
+    const { year, month } = parsedDate()
+    const res = await getHeadSettlementSummary(year, month)
+    totalBillingAmount.value = res.data.result?.totalBillingAmount ?? 0
+  } catch (error) {
+    console.error('청구 합계 조회 실패:', error)
+  }
+}
+
+const fetchList = async (page = 0) => {
+  try {
+    const { year, month } = parsedDate()
+    const res = await getHeadSettlementList(year, month, settlementSearch.value, page, pageSize)
+    const result = res.data.result
+
+    if (result) {
+      settlementList.value = result.content || []
+      totalPages.value = result.totalPages || 1
+      currentPage.value = result.number || 0
+    }
+  } catch (error) {
+    console.error('정산 리스트 조회 실패:', error)
+  }
+}
+
+const onMonthChange = () => {
+  currentPage.value = 0
+  fetchSummary()
+  fetchList(0)
+}
+
+// 검색어 입력 시 0페이지부터 다시 조회
+let searchTimer = null
+const onSearchInput = () => {
+  clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => {
+    currentPage.value = 0
+    fetchList(0)
+  }, 300) // 타이핑 멈추고 300ms 후 조회 (debounce)
+}
+
+const changePage = (page) => {
+  currentPage.value = page
+  fetchList(page)
+}
+
 function confirmClosing() {
   showToast(`${selectedMonth.value} 재고 마감이 완료되었습니다.`)
   isModalOpen.value = false
 }
 
-const totalStore = computed(() => storeSettlements.value.reduce((s, v) => s + v.amount, 0))
-const totalSupplier = computed(() => supplierSettlements.value.reduce((s, v) => s + v.amount, 0))
+onMounted(() => {
+  fetchSummary()
+  fetchList(0)
+})
 </script>


### PR DESCRIPTION
## 📋 Summary
-  본사 정산 목록 조회 기능 프론트, 백 연동

## 📂 변경 파일
- `frontend/src/api/headincome/index.js`
- `frontend/src/views/hq/SettlementView.vue`

## ✨ 주요 변경 사항
- [ ] headincome/index.js 본사 정산 관리 api 호출
- [ ] SettlementView.vue 순이익 카드 제거, 더미데이터 삭제 후 백엔드 연동

Closes #91