### PR TITLE
[Feat] #711 - AI 보고서 조회 기능 및 챗봇 연동 UX 개선

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/report/ReportService.java
+++ b/backend/src/main/java/com/example/nexus/domain/report/ReportService.java
@@ -11,36 +11,29 @@ import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
-import org.springframework.core.io.ClassPathResource;
-
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 
-import static com.example.nexus.common.model.BaseResponseStatus.*;
+import static com.example.nexus.common.model.BaseResponseStatus.NOT_FOUND_USER;
 
 @Service
 public class ReportService {
@@ -58,125 +51,90 @@ public class ReportService {
     @Value("${spring.cloud.aws.s3.report-bucket}")
     private String reportBucket;
 
-    /**
-     * 메인 로직: 데이터 준비 → AI 분석 → PDF 생성 → S3 업로드 → DB 저장
-     *
-     * 1. createAndSaveReport (메인 공정 시작)
-     * 2. handleChatbotRequest (AI에게 질문 던지기)
-     * 3. getRecentSummary (DB에서 분석용 수치 데이터 추출)
-     * 4. generatePdfFromAiResponse (AI 답변을 PDF 파일로 굽기)
-     * 5. convertMarkdownToHtml (텍스트 형식을 웹 형식으로 변환)
-     * S3 업로드 및 DB 저장 (최종 보관)
-     */
-
-    // 0. AI에게 성격(프롬포트)를 고정해 두기 위해서 생성자를 직접 생성
+    // 0. 생성자 주입
     public ReportService(ReportRepository reportRepository,
                          PosPayRepository posPayRepository,
                          PosOrdersItemRepository posOrdersItemRepository,
                          UserRepository userRepository,
                          ChatClient.Builder chatClientBuilder,
-                         S3Client s3Client
-    ) {
+                         S3Client s3Client) {
         this.reportRepository = reportRepository;
         this.posPayRepository = posPayRepository;
         this.posOrdersItemRepository = posOrdersItemRepository;
         this.userRepository = userRepository;
-
         this.s3Client = s3Client;
         this.chatClient = chatClientBuilder.build();
     }
 
-    // 1, 회원 메세지와 우저 정보를 받아와 S3와 DB에 저장
-    @Transactional
+    // 1. 메인 로직 (트랜잭션 분리 및 안전한 예외 처리)
     public String createAndSaveReport(Long userIdx, String userMessage) {
-        // 회원 존재 여부 확인
         User loginUser = userRepository.findById(userIdx)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
 
         // AI 답변 받기
         String aiResponse = handleChatbotRequest(userMessage);
 
-        // 상황 A: 일상 대화 ([CHAT]) 이름표를 달고 왔을 때
         if (aiResponse.contains("[CHAT]")) {
-            // 기존의 PDF 생성, S3 업로드 로직을 전부 건너뛰고 텍스트만 바로 반환!
             return aiResponse.replace("[CHAT]", "").trim();
         }
 
-        // [제목 추출 로직 추가]
-        String title = "AI 분석 보고서"; // 기본값
+        // 제목 추출 로직
+        String title = "AI 분석 보고서";
         if (aiResponse.contains("[TITLE:")) {
             int start = aiResponse.indexOf("[TITLE:") + 7;
             int end = aiResponse.indexOf("]", start);
             if (end != -1) {
-                title = aiResponse.substring(start, end);
+                title = aiResponse.substring(start, end).trim();
             }
         }
 
-        // AI 분석 및 임시 PDF 생성 (기존 로직)
         String aiMarkdown = aiResponse.replaceAll("\\[REPORT\\]|\\[TITLE:.*?\\]", "").trim();
-        String localFilePath = generatePdfFromAiResponse(aiMarkdown);
-        File tempFile = new File(localFilePath);
 
-        // S3 업로드 경로(Key) 생성
-        String s3Key = "reports/" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"))
-                + "/" + UUID.randomUUID() + ".pdf";
+        // 임시 PDF 파일 생성
+        File tempFile = generatePdfFromAiResponse(aiMarkdown);
 
         try {
-            // S3로 파일 업로드
-            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(reportBucket)
-                    .key(s3Key)
-                    .contentType("application/pdf")
-                    .build();
-
-            s3Client.putObject(putObjectRequest, RequestBody.fromFile(tempFile));
-
-            // 트랜잭션 동기화 매니저에 롤백 시 작업을 예약함
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCompletion(int status) {
-                    // 트랜잭션이 STATUS_ROLLED_BACK(롤백) 상태로 끝났다면 S3 파일 삭제
-                    if (status == TransactionSynchronization.STATUS_ROLLED_BACK) {
-                        s3Client.deleteObject(DeleteObjectRequest.builder()
-                                .bucket(reportBucket)
-                                .key(s3Key)
-                                .build());
-                    }
-                }
-            });
-
-            // 6. DB 저장
-            Report report = Report.builder()
-                    .title(title)
-                    .filePath(s3Key)
-                    .user(loginUser) // 연관관계 매핑
-                    .build();
-
-            reportRepository.save(report);
-
-            return title + "보고서 생성이 완료되었습니다! 보고서 목록에서 확인해주세요.";
-
+            // S3 업로드 및 DB 저장을 수동 롤백 로직으로 안전하게 처리
+            return saveReportResult(loginUser, title, tempFile);
         } catch (Exception e) {
-            throw new RuntimeException("보고서 생성 실패: " + e.getMessage(), e);
+            throw new RuntimeException("보고서 생성 및 저장 실패: " + e.getMessage(), e);
         } finally {
-            // 서버에 남은 임시 PDF 삭제
-            if (tempFile.exists()) {
+            // 디스크 용량 확보를 위해 임시 파일은 무조건 삭제
+            if (tempFile != null && tempFile.exists()) {
                 tempFile.delete();
             }
         }
     }
 
-    //   2. AI에게 질문 던지기
+    // 2. DB 저장 및 S3 업로드 (수동 롤백 방식 - 트랜잭션 에러 완벽 해결)
+    public String saveReportResult(User user, String title, File tempFile) {
+        String s3Key = "reports/" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"))
+                + "/" + UUID.randomUUID() + ".pdf";
+
+        // 1. S3에 PDF 파일 먼저 업로드
+        s3Client.putObject(PutObjectRequest.builder()
+                        .bucket(reportBucket).key(s3Key).contentType("application/pdf").build(),
+                RequestBody.fromFile(tempFile));
+
+        // 2. DB 저장 시도 및 수동 롤백
+        try {
+            reportRepository.save(Report.builder().title(title).filePath(s3Key).user(user).build());
+            return title + " 보고서 생성이 완료되었습니다!";
+        } catch (Exception e) {
+            // DB 저장 실패 시: S3에 방금 올린 파일 즉시 삭제 (롤백)
+            s3Client.deleteObject(DeleteObjectRequest.builder().bucket(reportBucket).key(s3Key).build());
+            throw new RuntimeException("DB 저장 중 오류가 발생하여 S3 업로드 파일을 삭제(롤백)했습니다.", e);
+        }
+    }
+
+    // 3. AI에게 프롬프트 전송
     public String handleChatbotRequest(String userMessage) {
-        // 최신 데이터 집계 가져오기
         ReportDto.ReportDataSummaryDto summary = getRecentSummary();
 
         try {
-            // 🌟 1. 외부 마크다운 파일(report-template.md) 읽어오기
             String template = reportTemplate.getContentAsString(java.nio.charset.StandardCharsets.UTF_8);
-
-            // 🌟 2. 템플릿의 변수들({{...}})을 실제 데이터로 치환
             List<String> top5 = summary.topProducts();
+
             String finalInstruction = template
                     .replace("{{totalSales}}", String.format("%,d", summary.totalSales()))
                     .replace("{{product1}}", top5.size() > 0 ? top5.get(0) : "데이터 없음")
@@ -185,10 +143,8 @@ public class ReportService {
                     .replace("{{product4}}", top5.size() > 3 ? top5.get(3) : "데이터 없음")
                     .replace("{{product5}}", top5.size() > 4 ? top5.get(4) : "데이터 없음");
 
-            // 4. AI에게 보낼 최종 프롬프트 구성
             String finalPrompt = finalInstruction + "\n\n사용자의 질문: " + userMessage;
 
-            // 5. 프롬프트 전송 및 답변 반환
             return chatClient.prompt()
                     .user(finalPrompt)
                     .call()
@@ -199,19 +155,14 @@ public class ReportService {
         }
     }
 
-    // 3. DB에서 데이터 가지고 오기
+    // 4. DB 수치 집계 (최근 30일)
     public ReportDto.ReportDataSummaryDto getRecentSummary() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime startDate  = now.minusDays(30); // 최근 30일 기준
+        LocalDateTime startDate  = now.minusDays(30);
 
         Long totalSales = posPayRepository.sumSalesByDateBetween(startDate, now);
+        if (totalSales == null) totalSales = 0L;
 
-        // 매출이 아예 없는 경우 null이 반환될 수 있으므로 0으로 안전하게 처리
-        if (totalSales == null) {
-            totalSales = 0L;
-        }
-
-        // PageRequest.of(0, 5)을 통해 LIMIT 5과 동일하게 5개만 가져옴
         List<String> topProducts = posOrdersItemRepository.findTopSellingMenus(startDate, now, PageRequest.of(0, 5));
 
         return ReportDto.ReportDataSummaryDto.builder()
@@ -220,12 +171,12 @@ public class ReportService {
                 .build();
     }
 
-    // 4. HTML을 PDF로 만들고 서버에 저장하는 메서드
-    private String generatePdfFromAiResponse(String aiMarkdown) {
+    // 5. 마크다운 -> HTML -> PDF 변환 (JAR 폰트 호환성 및 나눔고딕 적용)
+    private File generatePdfFromAiResponse(String aiMarkdown) {
         try {
             String htmlContent = convertMarkdownToHtml(aiMarkdown);
 
-            // 🌟 마법의 CSS (폰트 크기 축소, 여백 정렬, 테이블/인용구 디자인)
+            // 보고서 전용 나눔고딕 CSS 적용
             String fullHtml = "<html><head><style>" +
                     "body { font-family: 'NanumGothic', sans-serif; font-size: 12px; line-height: 1.6; padding: 30px; color: #333; }" +
                     "h1 { font-size: 18px; color: #F37321; border-bottom: 2px solid #F37321; padding-bottom: 8px; margin-bottom: 20px; }" +
@@ -238,38 +189,42 @@ public class ReportService {
                     "th { background-color: #F37321; color: white; font-weight: bold; }" +
                     "ul { margin-top: 5px; padding-left: 20px; }" +
                     "</style></head><body>" +
-                    // 기존에 강제로 넣던 <h2> 제목과 <hr/>은 마크다운과 겹치므로 삭제했습니다!
                     htmlContent +
                     "</body></html>";
 
-            String directoryPath = "uploads/temp_reports/";
-            Path path = Paths.get(directoryPath);
-            if (!Files.exists(path)) {
-                Files.createDirectories(path);
-            }
+            // 시스템 임시 폴더 사용 (서버 배포 시 권한 문제 방지)
+            String tempDir = System.getProperty("java.io.tmpdir");
+            File tempFile = new File(tempDir, "temp_report_" + UUID.randomUUID() + ".pdf");
 
-            String fileName = "temp_report_" + UUID.randomUUID().toString() + ".pdf";
-            String fullFilePath = directoryPath + fileName;
+            // 리소스 폰트 로드 (나눔고딕 경로 유지)
+            Resource fontResource = new ClassPathResource("aiReport/fonts/NanumGothic.ttf");
 
-            File fontFile = new ClassPathResource("aiReport/fonts/NanumGothic.ttf").getFile();
-
-            try (OutputStream os = new FileOutputStream(fullFilePath)) {
+            try (OutputStream os = new FileOutputStream(tempFile)) {
                 PdfRendererBuilder builder = new PdfRendererBuilder();
                 builder.useFastMode();
                 builder.withHtmlContent(fullHtml, null);
-                builder.useFont(fontFile, "NanumGothic");
+
+                // JAR 패키징 대응: File 객체 대신 Stream 방식으로 폰트 주입
+                builder.useFont(() -> {
+                    try {
+                        return fontResource.getInputStream();
+                    } catch (Exception ex) {
+                        throw new RuntimeException("폰트 파일을 읽을 수 없습니다.", ex);
+                    }
+                }, "NanumGothic"); // 🌟 나눔고딕으로 변경
+
                 builder.toStream(os);
                 builder.run();
             }
 
-            return fullFilePath;
+            return tempFile;
 
         } catch (Exception e) {
-            throw new RuntimeException("임시 PDF 파일 생성 중 오류 발생", e);
+            throw new RuntimeException("임시 PDF 파일 생성 중 오류 발생: " + e.getMessage(), e);
         }
     }
 
-    // 5. 마크다운 텍스트를 HTML로 변환하는 메서드
+    // 6. 마크다운 변환기
     private String convertMarkdownToHtml(String markdown) {
         Parser parser = Parser.builder().build();
         Node document = parser.parse(markdown);
@@ -277,13 +232,11 @@ public class ReportService {
         return renderer.render(document);
     }
 
-
-    // 보고서 조회
+    // 7. 사용자별 보고서 리스트 조회
     @Transactional(readOnly = true)
     public ReportDto.ReportPageRes reportList(Long userIdx, int page, int size) {
-        // 사용자 존재 및 삭제 여부 확인 (보안 검증)
         User user = userRepository.findById(userIdx)
-                .filter(u -> !u.isDeleted()) // 삭제되지 않은 사용자인지 확인
+                .filter(u -> !u.isDeleted())
                 .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
 
         PageRequest pageRequest = PageRequest.of(page, size);

--- a/frontend/src/api/report/index.js
+++ b/frontend/src/api/report/index.js
@@ -2,3 +2,6 @@ import api from '@/plugins/axiosinterceptor.js'
 
 export const postReportGenerate = (chatRequest) =>
   api.post('/report/generate', chatRequest)
+
+export const getReportList = (page, size) =>
+  api.get(`/report/list?page=${page}&size=${size}`)

--- a/frontend/src/components/AiChatbot.vue
+++ b/frontend/src/components/AiChatbot.vue
@@ -2,7 +2,9 @@
 import { ref, nextTick } from 'vue'
 import { Bot, X, Send } from 'lucide-vue-next'
 import { postReportGenerate } from '@/api/report/index.js'
+import { useRouter } from 'vue-router'
 
+const router = useRouter()
 const isOpen = ref(false)
 const isLoading = ref(false)
 const input = ref('')
@@ -26,6 +28,14 @@ const messages = ref([
 
 let nextId = 2
 
+// 스크롤 하단 이동 함수
+async function scrollToBottom() {
+  await nextTick()
+  if (messageContainer.value) {
+    messageContainer.value.scrollTop = messageContainer.value.scrollHeight
+  }
+}
+
 // 메세지 보내기
 async function sendMessage() {
   const text = input.value.trim()
@@ -39,16 +49,33 @@ async function sendMessage() {
   await scrollToBottom()
 
   try {
-    const chatRequest  = {
-      message: text
-    }
-    const res = await postReportGenerate(chatRequest )
+    const chatRequest  = { message: text }
+    const res = await postReportGenerate(chatRequest)
 
     messages.value.push({
       id: nextId++,
       role: 'ai',
-      text: res.data.result // 서버에서 내려준 응답 메시지 출력
+      text: res.data.result
     })
+
+    if (res.data.result.includes("보고서 생성이 완료되었습니다")) {
+      // 사용자에게 의사를 물어봅니다.
+      const goToReportPage = confirm(
+        "📊 보고서 생성이 완료되었습니다!\n보고서 목록 페이지로 이동하여 확인하시겠습니까?"
+      )
+
+      if (goToReportPage) {
+        // 현재 경로 확인
+        if (window.location.pathname === '/report') {
+          // 이미 보고서 페이지라면 새로고침해서 리스트 갱신
+          location.reload()
+        } else {
+          // 다른 페이지라면 보고서 페이지로 이동
+          router.push({ name: 'report' });
+        }
+      }
+    }
+
   } catch (error) {
     messages.value.push({
       id: nextId++,
@@ -61,12 +88,6 @@ async function sendMessage() {
   }
 }
 
-async function scrollToBottom() {
-  await nextTick()
-  if (messageContainer.value) {
-    messageContainer.value.scrollTop = messageContainer.value.scrollHeight
-  }
-}
 </script>
 
 <template>

--- a/frontend/src/components/AiChatbot.vue
+++ b/frontend/src/components/AiChatbot.vue
@@ -22,7 +22,15 @@ const messages = ref([
   {
     id: 1,
     role: 'ai',
-    text: '안녕하세요! Nexus AI 어시스턴트입니다. 보고서 생성을 요청해보세요. 예) "저번달 총 매출과 이번달 비교 보고서 만들어줘"',
+    text: `반갑습니다!
+    Nexus AI 어시스턴트입니다. 🤖
+
+    매장의 실시간 데이터를 바탕으로
+    똑똑한 분석을 도와드릴게요.
+
+    궁금한 점은 채팅으로 편하게 물어보시고, 상세 분석이 필요하면 "보고서 만들어줘"라고 요청해 보세요!
+
+    예) "이번 달 매출 요약 보고서 써줘"`,
   },
 ])
 
@@ -61,7 +69,7 @@ async function sendMessage() {
     if (res.data.result.includes("보고서 생성이 완료되었습니다")) {
       // 사용자에게 의사를 물어봅니다.
       const goToReportPage = confirm(
-        "📊 보고서 생성이 완료되었습니다!\n보고서 목록 페이지로 이동하여 확인하시겠습니까?"
+        "보고서 생성이 완료되었습니다!\n보고서 목록 페이지로 이동하여 확인하시겠습니까?"
       )
 
       if (goToReportPage) {
@@ -74,6 +82,7 @@ async function sendMessage() {
           router.push({ name: 'report' });
         }
       }
+
     }
 
   } catch (error) {
@@ -131,7 +140,7 @@ async function sendMessage() {
               <div class="w-7 h-7 rounded-full bg-[#F37321] flex items-center justify-center shrink-0">
                 <Bot class="w-4 h-4 text-white" />
               </div>
-              <div class="max-w-[240px] px-3 py-2 rounded-2xl rounded-bl-sm bg-gray-100 text-sm text-gray-800 leading-relaxed">
+              <div class="max-w-[240px] px-3 py-2 rounded-2xl rounded-bl-sm bg-gray-100 text-sm text-gray-800 leading-relaxed whitespace-pre-line">
                 {{ msg.text }}
               </div>
             </div>
@@ -165,7 +174,7 @@ async function sendMessage() {
               v-model="input"
               @keydown.enter.exact.prevent="sendMessage"
               @input="autoResize"
-              placeholder="보고서 생성을 요청해보세요..."
+              placeholder="'보고서 만들어줘'라고 요청해 보세요!"
               rows="1"
               class="flex-1 resize-none text-sm px-3 py-2 rounded-xl border border-gray-200 focus:outline-none focus:border-[#F37321] transition-colors leading-relaxed max-h-28 overflow-y-auto"
               :disabled="isLoading"

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { reactive, ref, watch, onMounted } from 'vue'
-import { FileText, Download } from 'lucide-vue-next'
+import { reactive, ref, watch, onMounted, computed } from 'vue'
+import { FileText, Download, ChevronRight, ChevronLeft } from 'lucide-vue-next'
 import Toast from '@/components/common/Toast.vue'
 import { useToast } from '@/composables/useToast'
 import { useNews } from '@/composables/useNews'
@@ -42,6 +42,7 @@ async function fetchHqNews() {
   }
 }
 
+// 보고서 조회
 async function fetchReports(page = 0){
   isReportLoading.value = true;
 
@@ -56,7 +57,6 @@ async function fetchReports(page = 0){
     pagination.currentPage = res.data.result.currentPage
 
   } catch (error) {
-    console.error('[ReportView] 보고서 조회 실패:', error);
     showToast(`${error} '[ReportView] 보고서 조회 실패:'`)
   } finally {
     isReportLoading.value = false;
@@ -77,6 +77,26 @@ watch(activeTab, (val) => {
   if (val === 'news' && newsSummaries.value.length === 0) fetchHqNews()
   if (val === 'report' && reports.value.length === 0) fetchReports(0);
 })
+
+// 페이지 변경
+const changePage = (page) => {
+  // 0보다 작거나 마지막 페이지(totalPage - 1)보다 크면 무시[cite: 1]
+  if (page < 0 || page >= pagination.totalPage) return
+  fetchReports(page)
+}
+
+// 버튼 클릭
+const visiblePages = computed(() => {
+  const range = 10; // 한 번에 보여줄 페이지 개수
+  const currentGroup = Math.floor(pagination.currentPage / range);
+  const start = currentGroup * range;
+  const end = Math.min(start + range, pagination.totalPage);
+  const pages = [];
+  for (let i = start; i < end; i++) {
+    pages.push(i);
+  }
+  return pages;
+});
 
 onMounted(() => {
   fetchReports(0);
@@ -183,6 +203,30 @@ onMounted(() => {
       @close="selectedNews = null"
     />
     <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
+  </div>
+  <div v-if="pagination.totalPage > 1" class="flex justify-center items-center gap-2 py-4 border-t border-gray-100">
+    <button
+      class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+      :disabled="pagination.currentPage === 0"
+      @click="changePage(pagination.currentPage - 1)">
+      <ChevronLeft class="w-4 h-4" />
+    </button>
+
+    <button v-for="pageIdx in visiblePages" :key="pageIdx"
+            class="w-8 h-8 rounded text-sm font-semibold cursor-pointer transition-colors"
+            :class="pagination.currentPage === pageIdx
+            ? 'bg-[#F37321] text-white'
+            : 'text-gray-500 hover:bg-gray-50'"
+            @click="changePage(pageIdx)">
+      {{ pageIdx + 1 }}
+    </button>
+
+    <button
+      class="p-2 rounded border border-gray-200 text-gray-400 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+      :disabled="pagination.currentPage >= pagination.totalPage - 1"
+      @click="changePage(pagination.currentPage + 1)">
+      <ChevronRight class="w-4 h-4" />
+    </button>
   </div>
 </template>
 

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -1,3 +1,83 @@
+<script setup>
+import { reactive, ref, watch, onMounted } from 'vue'
+import { FileText, Download } from 'lucide-vue-next'
+import Toast from '@/components/common/Toast.vue'
+import { useToast } from '@/composables/useToast'
+import { useNews } from '@/composables/useNews'
+import { getHqNews } from '@/api/news'
+import NewsListItem from '@/components/news/NewsListItem.vue'
+import NewsDetailModal from '@/components/news/NewsDetailModal.vue'
+import { getReportList } from '@/api/report/index.js'
+
+const { toast, showToast } = useToast()
+const { selectedNews, detailContents, detailLoading, openDetail } = useNews()
+const reports = ref([])  // 보고서 리스트
+const newsSummaries = ref([])
+const tabs = [
+  { label: '보고서', value: 'report' },
+  { label: '뉴스 요약', value: 'news' },
+]
+const activeTab = ref('report')
+const newsLoading = ref(false)
+const isReportLoading = ref(false)
+// 보고서 페이징
+const pagination = reactive({
+  totalPage: 0,
+  totalCount: 0,
+  currentPage: 0,
+  currentSize: 10
+})
+
+//  뉴스 조회
+async function fetchHqNews() {
+  newsLoading.value = true
+  try {
+    const today = new Date().toISOString().slice(0, 10)
+    const { data } = await getHqNews(today)
+    newsSummaries.value = data.result ?? []
+  } catch (e) {
+    console.error('[ReportView] 뉴스 조회 실패:', e)
+  } finally {
+    newsLoading.value = false
+  }
+}
+
+async function fetchReports(page = 0){
+  isReportLoading.value = true;
+
+  try {
+    const res = await getReportList(page, pagination.currentSize);
+    console.log(res.data.result)
+    reports.value.splice(0, reports.value.length, ...res.data.result.reportList)
+    console.log(reports.value)
+
+    pagination.totalPage = res.data.result.totalPage
+    pagination.totalCount = res.data.result.totalCount
+    pagination.currentPage = res.data.result.currentPage
+
+  } catch (error) {
+    console.error('[ReportView] 보고서 조회 실패:', error);
+  } finally {
+    isReportLoading.value = false;
+  }
+}
+
+// 레포트 다운로드
+function handleDownload(report) {
+  showToast(`${report.report_title} 다운로드 준비 중입니다.`)
+}
+
+watch(activeTab, (val) => {
+  if (val === 'news' && newsSummaries.value.length === 0) fetchHqNews()
+  if (val === 'report' && reports.value.length === 0) fetchReports(0);
+})
+
+onMounted(() => {
+  fetchReports(0);
+})
+
+</script>
+
 <template>
   <div class="p-6">
     <!-- Header -->
@@ -26,42 +106,42 @@
     <div v-if="activeTab === 'report'" class="bg-white rounded-lg border border-gray-200 overflow-hidden">
       <table class="w-full text-sm">
         <thead>
-          <tr class="border-b border-gray-100 bg-gray-50/70">
-            <th class="text-left px-5 py-3 font-semibold text-gray-600 w-20">번호</th>
-            <th class="text-left px-5 py-3 font-semibold text-gray-600">보고서 제목</th>
-            <th class="text-left px-5 py-3 font-semibold text-gray-600 w-40">생성일시</th>
-            <th class="text-center px-5 py-3 font-semibold text-gray-600 w-28">다운로드</th>
-          </tr>
+        <tr class="border-b border-gray-100 bg-gray-50/70">
+          <th class="text-left px-5 py-3 font-semibold text-gray-600 w-20">번호</th>
+          <th class="text-left px-5 py-3 font-semibold text-gray-600">보고서 제목</th>
+          <th class="text-left px-5 py-3 font-semibold text-gray-600 w-40">생성일시</th>
+          <th class="text-center px-5 py-3 font-semibold text-gray-600 w-28">다운로드</th>
+        </tr>
         </thead>
         <tbody class="divide-y divide-gray-50">
-          <tr v-if="reports.length === 0">
-            <td colspan="4" class="px-5 py-16 text-center text-gray-400 text-sm">
-              생성된 보고서가 없습니다.
-            </td>
-          </tr>
-          <tr
-            v-for="report in reports"
-            :key="report.idx"
-            class="hover:bg-gray-50/50 transition-colors"
-          >
-            <td class="px-5 py-3.5 text-gray-400">{{ report.idx }}</td>
-            <td class="px-5 py-3.5">
-              <div class="flex items-center gap-2">
-                <FileText class="w-4 h-4 text-[#F37321] shrink-0" />
-                <span class="font-medium text-gray-800">{{ report.report_title }}</span>
-              </div>
-            </td>
-            <td class="px-5 py-3.5 text-gray-500">{{ report.created_at }}</td>
-            <td class="px-5 py-3.5 text-center">
-              <button
-                @click="handleDownload(report)"
-                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer"
-              >
-                <Download class="w-3.5 h-3.5" />
-                PDF
-              </button>
-            </td>
-          </tr>
+        <tr v-if="reports.length === 0">
+          <td colspan="4" class="px-5 py-16 text-center text-gray-400 text-sm">
+            생성된 보고서가 없습니다.
+          </td>
+        </tr>
+        <tr
+          v-for="report in reports"
+          :key="report.idx"
+          class="hover:bg-gray-50/50 transition-colors"
+        >
+          <td class="px-5 py-3.5 text-gray-400">{{ report.idx }}</td>
+          <td class="px-5 py-3.5">
+            <div class="flex items-center gap-2">
+              <FileText class="w-4 h-4 text-[#F37321] shrink-0" />
+              <span class="font-medium text-gray-800">{{ report.reportTitle }}</span>
+            </div>
+          </td>
+          <td class="px-5 py-3.5 text-gray-500">{{ report.createdAt }}</td>
+          <td class="px-5 py-3.5 text-center">
+            <button
+              @click="handleDownload(report.reportFilePath)"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-[#F37321] border border-[#F37321] rounded hover:bg-orange-50 transition-colors cursor-pointer"
+            >
+              <Download class="w-3.5 h-3.5" />
+              PDF
+            </button>
+          </td>
+        </tr>
         </tbody>
       </table>
     </div>
@@ -100,80 +180,3 @@
   </div>
 </template>
 
-<script setup>
-import { ref, watch } from 'vue'
-import { FileText, Download } from 'lucide-vue-next'
-import Toast from '@/components/common/Toast.vue'
-import { useToast } from '@/composables/useToast'
-import { useNews } from '@/composables/useNews'
-import { getHqNews } from '@/api/news'
-import NewsListItem from '@/components/news/NewsListItem.vue'
-import NewsDetailModal from '@/components/news/NewsDetailModal.vue'
-
-const { toast, showToast } = useToast()
-const { selectedNews, detailContents, detailLoading, openDetail } = useNews()
-
-const tabs = [
-  { label: '보고서', value: 'report' },
-  { label: '뉴스 요약', value: 'news' },
-]
-
-const activeTab = ref('report')
-const newsLoading = ref(false)
-
-async function fetchHqNews() {
-  newsLoading.value = true
-  try {
-    const today = new Date().toISOString().slice(0, 10)
-    const { data } = await getHqNews(today)
-    newsSummaries.value = data.result ?? []
-  } catch (e) {
-    console.error('[ReportView] 뉴스 조회 실패:', e)
-  } finally {
-    newsLoading.value = false
-  }
-}
-
-watch(activeTab, (val) => {
-  if (val === 'news' && newsSummaries.value.length === 0) fetchHqNews()
-})
-
-const reports = ref([
-  {
-    idx: 5,
-    report_title: '2026년 4월 입점 매장별 매출 비교 보고서',
-    created_at: '2026-04-20 14:32',
-    file_path: '/reports/report_5.pdf',
-  },
-  {
-    idx: 4,
-    report_title: '3월 vs 4월 총 매출 비교 보고서',
-    created_at: '2026-04-18 09:15',
-    file_path: '/reports/report_4.pdf',
-  },
-  {
-    idx: 3,
-    report_title: '2026년 1분기 발주 품목 통계 보고서',
-    created_at: '2026-04-10 16:48',
-    file_path: '/reports/report_3.pdf',
-  },
-  {
-    idx: 2,
-    report_title: '일식 스시바 월별 정산 분석 보고서',
-    created_at: '2026-04-05 11:20',
-    file_path: '/reports/report_2.pdf',
-  },
-  {
-    idx: 1,
-    report_title: '2026년 3월 전체 입점 매장 재고 현황 보고서',
-    created_at: '2026-04-01 10:00',
-    file_path: '/reports/report_1.pdf',
-  },
-])
-
-const newsSummaries = ref([])
-
-function handleDownload(report) {
-  showToast(`${report.report_title} 다운로드 준비 중입니다.`)
-}
-</script>

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -48,16 +48,14 @@ async function fetchReports(page = 0){
 
   try {
     const res = await getReportList(page, pagination.currentSize);
-    console.log(res.data.result)
     reports.value.splice(0, reports.value.length, ...res.data.result.reportList)
-    console.log(reports.value)
 
     pagination.totalPage = res.data.result.totalPage
     pagination.totalCount = res.data.result.totalCount
     pagination.currentPage = res.data.result.currentPage
 
   } catch (error) {
-    showToast(`${error} '[ReportView] 보고서 조회 실패:'`)
+    showToast(`[ReportView] 보고서 조회 실패: ${error.message || error}`)
   } finally {
     isReportLoading.value = false;
   }

--- a/frontend/src/views/hq/ReportView.vue
+++ b/frontend/src/views/hq/ReportView.vue
@@ -57,6 +57,7 @@ async function fetchReports(page = 0){
 
   } catch (error) {
     console.error('[ReportView] 보고서 조회 실패:', error);
+    showToast(`${error} '[ReportView] 보고서 조회 실패:'`)
   } finally {
     isReportLoading.value = false;
   }
@@ -64,7 +65,12 @@ async function fetchReports(page = 0){
 
 // 레포트 다운로드
 function handleDownload(report) {
-  showToast(`${report.report_title} 다운로드 준비 중입니다.`)
+  const filePath = report;
+  if (!filePath) return showToast('파일이 없습니다.', 'error');
+
+  const s3BaseUrl = 'https://nexus-reports-archive.s3.ap-northeast-2.amazonaws.com/';
+  window.open(s3BaseUrl + filePath, '_blank'); // 새 탭에서 열기
+  showToast(`${report.reportTitle} 미리보기 준비 중입니다.`)
 }
 
 watch(activeTab, (val) => {


### PR DESCRIPTION
## Summary
- AI 챗봇을 통해 생성된 보고서를 목록 형태로 조회하고 미리볼 수 있는 페이지를 구현했으며, 챗봇을 통한 보고서 생성 완료 시 자연스럽게 해당 페이지로 이어지도록 프론트엔드 사용자 경험(UX)을 개선했습니다.

## 변경 파일
- `frontend/src/components/AiChatbot.vue`
- `frontend/src/views/ReportView.vue`
- `frontend/src/api/report/index.js`

## 주요 변경 사항
- [x] **보고서 목록 조회 기능 구현:** `ReportView.vue` 내에 AI 보고서 탭 추가 및 페이징(Pagination) 처리 연동
- [x] **보고서 미리보기(다운로드) 추가:** S3 URL을 활용하여 생성된 PDF 보고서를 새 창에서 미리보기/다운로드할 수 있는 기능 구현
- [x] **챗봇 - 보고서 페이지 연동 (UX 개선):** 챗봇에서 보고서 생성이 완료되면 `confirm` 알림을 띄워 보고서 목록 페이지로 즉시 이동할 수 있도록 흐름 개선
- [x] **페이지 확인 및 라우팅 처리:** 알림 수락 시 현재 경로를 확인하여 이미 보고서 페이지(`/report`)인 경우 리스트를 새로고침하고, 다른 페이지인 경우 라우터 이동 처리
- [x] **챗봇 초기 멘트 수정:** 사용자가 보고서 생성 기능을 직관적으로 알 수 있도록 AI 어시스턴트의 초기 안내 멘트(예시 문구 포함) 업데이트

## DB & Infrastructure (해당 시)
- [x] 프론트엔드 뷰단 개선으로 별도의 DB 스키마 변경 없음
- [x] 기존에 구축된 AWS S3(`nexus-reports-archive`) URL 경로를 활용하여 PDF 뷰어 연동

## Test Plan
- [x] AI 챗봇 창 오픈 시 수정된 초기 안내 멘트가 정상적으로 노출되는지 확인
- [x] "보고서 만들어줘" 요청 후 생성이 완료되었을 때 알림창(confirm)이 정상적으로 뜨는지 확인
- [x] 알림창에서 '확인' 클릭 시 `ReportView` 페이지로 이동(또는 새로고침)하여 방금 생성된 보고서가 리스트 최상단에 뜨는지 확인
- [x] 리스트 하단의 페이지네이션(이전/다음, 번호 클릭)이 정상적으로 동작하는지 확인
- [x] 리스트에서 'PDF 다운로드' 버튼 클릭 시 S3 URL을 통해 새 탭에서 보고서가 정상적으로 열리는지 확인

## Issue
- Closes #711