### PR TITLE
[Fix] MCP 서버 경로 및 환경변수 수정으로 백엔드 기동 오류 해결

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -11,3 +11,4 @@ COPY backend/build/libs/*.jar app.jar
 
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]
+


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- Docker 빌드 컨텍스트를 프로젝트 루트로 변경하여 mcp 복사 오류 해결
- Secret에 누락된 환경변수 추가 (NAVER, S3 Report 등)
- NAVER_CLIENTID → NAVER_CLIENT_ID 키 이름 수정
- 미구현 발주 통계/판매·매출 분석 페이지 제거