### PR TITLE
[Fix] prod 환경 MCP 비활성화 및 ConfigMap에 프로파일 설정 추가

### DIFF
--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -20,15 +20,16 @@ spring:
           temperature: 0.3
     mcp:
       client:
-        stdio:
-          connections:
-            naver-news:
-              command: node
-              args:
-                - /app/mcp/server.mjs
-              env:
-                NAVER_CLIENT_ID: ${NAVER_CLIENT_ID:}
-                NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET:}
+        enabled: false
+#        stdio:
+#          connections:
+#            naver-news:
+#              command: node
+#              args:
+#                - /app/mcp/server.mjs
+#              env:
+#                NAVER_CLIENT_ID: ${NAVER_CLIENT_ID:}
+#                NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET:}
 
   cloud:
     aws:


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- Docker 빌드 컨텍스트를 프로젝트 루트로 변경하여 mcp 복사 오류 해결                                                                                                                                                              
- prod 환경 MCP 클라이언트 비활성화로 기동 타임아웃 해결                                                                                                                                                                          
- ConfigMap에 SPRING_PROFILES_ACTIVE=prod 추가                                                                                                                                                                                    
- Secret에 누락 환경변수 추가 (NAVER, S3 Report)                                                                                                                                                                                  
- 미구현 발주 통계/판매·매출 분석 페이지 제거                                                                                                                                                                                     
- 보고서 PDF/챗봇 기능, 비밀번호 마스킹 등 기존 dev 작업 포함