### PR TITLE
[Test] #752 - Blue/Green 무중단 배포 검증용 프론트엔드 슬롯 표시 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,13 @@ k8s/db-service.yaml
 frontend/.env.development
 
 docs/
+
+# 배포
+personal/*
+personal
+frontend/personal/
+backend/src/main/resources/application-aws.yaml
+backend/deploy.sh
+backend/init-db.sh
+frontend/deploy.sh
+frontend/bash

--- a/backend/src/main/java/com/example/nexus/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/nexus/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("http://localhost:5173"));
+        configuration.setAllowedOriginPatterns(List.of("http://localhost:5173", "https://www.nexussystem.kro.kr"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -8,6 +8,11 @@
           <div class="w-9 h-9 bg-[#F37321] flex items-center justify-center text-white font-black text-base">H</div>
           <span class="text-2xl font-bold tracking-tight text-gray-900">HANWHA <span class="font-light">Nexus</span></span>
         </div>
+        <!-- Blue/Green 배포 테스트용 (검증 후 제거) -->
+        <div class="text-center py-4">
+          <span class="text-7xl font-black text-green-500 tracking-widest drop-shadow-lg">GREEN</span>
+        </div>
+
         <div>
           <h1 class="text-4xl font-black text-gray-900 leading-tight tracking-tight">
             유통 관리<br/>통합 플랫폼


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
  - Blue/Green 무중단 배포 시 프론트엔드 전환을 시각적으로 검증하기 위한 테스트 코드 추가                                                                                                                                           
                                                                                                                                                                                                                                    
  ## 변경 파일                                                                                                                                                                                                                      
  - `frontend/src/views/LoginView.vue`
  - `backend/src/main/java/com/example/nexus/config/SecurityConfig.java`
  - `.gitignore`

  ## 주요 변경 사항
  - 로그인 페이지에 현재 슬롯명(GREEN) 대형 텍스트 표시 추가
  - CORS 허용 origin에 프로덕션 도메인(nexussystem.kro.kr) 추가
  - .gitignore에 배포 스크립트 및 개인 설정 파일 제외 규칙 추가

  ## Test Plan
  - [ ] Green 슬롯 배포 후 로그인 화면에서 "GREEN" 텍스트 확인
  - [ ] Blue 전환 배포 후 새로고침하며 텍스트 전환 녹화