### PR TITLE
[Fix] #769 - 발주 관리 페이지 UI/기능 버그 수정 

### DIFF
--- a/backend/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
+++ b/backend/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
@@ -66,6 +66,9 @@ public enum BaseResponseStatus {
     PAYMENT_BILLING_REQUIRED(false, 4105, "최소 1개의 결제 수단이 필요합니다."),
     PAYMENT_DEFAULT_BILLING_REQUIRED(false, 4106, "기본 결제 수단이 존재하지 않습니다."),
 
+    // 4200번대 ~ 발주 관련
+    ORDERS_APPROVE_INSUFFICIENT_STOCK(false, 4201, "본사 재고가 부족하여 발주를 승인할 수 없습니다."),
+
     // 5000번대 실패
     FAIL(false, 5000, "요청 실패");
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -208,7 +208,14 @@ public class OrdersService {
         List<Orders> confirmedOrders = ordersRepository.findAllByOrdersStatus(OrdersStatus.CONFIRMED);
 
         for (Orders orders : confirmedOrders) {
-            applyOutboundForOrder(orders, "발주 일괄승인 ordersIdx=");
+            try {
+                applyOutboundForOrder(orders, "발주 일괄승인 ordersIdx=");
+            } catch (BaseException e) {
+                if (e.getStatus() == BaseResponseStatus.STORE_INVENTORY_INSUFFICIENT) {
+                    throw new BaseException(BaseResponseStatus.ORDERS_APPROVE_INSUFFICIENT_STOCK);
+                }
+                throw e;
+            }
             orders.approve();
             createHeadIncome(orders);
             deliveryService.startDeliveryByOrders(orders);

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersSpecification.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersSpecification.java
@@ -30,6 +30,7 @@ public class OrdersSpecification {
         return (root, query, cb) -> cb.isTrue(root.get("isDanger"));
     }
 
+
     public static Specification<Orders> keywordLike(String keyword) {
         return (root, query, cb) -> {
             String pattern = "%" + keyword + "%";

--- a/frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
@@ -77,12 +77,12 @@ function resetFilters() {
           <tr class="border-b border-gray-200 bg-gray-50">
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주번호</th>
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">입점 매장</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주수량</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">평균수량</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">초과율</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">발주수량</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">평균수량</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">초과율</th>
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">총 금액</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주일시</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">발주일시</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">상태</th>
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">처리</th>
           </tr>
         </thead>
@@ -93,16 +93,16 @@ function resetFilters() {
           >
             <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ o.id }}</td>
             <td class="px-5 py-3.5 font-semibold text-gray-900">{{ o.store }}</td>
-            <td class="px-5 py-3.5 font-bold text-red-600">{{ (o.qty ?? 0).toLocaleString() }}</td>
-            <td class="px-5 py-3.5 text-gray-500">{{ (o.avgQty ?? 0).toLocaleString() }}</td>
-            <td class="px-5 py-3.5">
+            <td class="px-5 py-3.5 font-bold text-red-600 text-center">{{ (o.qty ?? 0).toLocaleString() }}</td>
+            <td class="px-5 py-3.5 text-gray-500 text-center">{{ (o.avgQty ?? 0).toLocaleString() }}</td>
+            <td class="px-5 py-3.5 text-center">
               <span class="text-xs font-black px-2 py-0.5 rounded bg-red-50 text-red-600 border border-red-200">
                 +{{ o.ratio }}%
               </span>
             </td>
             <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice(o.price) }}</td>
-            <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ o.date }}</td>
-            <td class="px-5 py-3.5">
+            <td class="px-5 py-3.5 text-xs text-gray-400 font-mono text-center">{{ o.date }}</td>
+            <td class="px-5 py-3.5 text-center">
               <span class="text-xs font-bold px-2 py-0.5 rounded"
                 :class="o.status === 'APPROVE' || o.status === 'REJECT'
                   ? 'bg-gray-100 text-gray-400 border border-gray-200'

--- a/frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
@@ -110,7 +110,7 @@ function resetFilters() {
                 {{ o.status === 'APPROVE' || o.status === 'REJECT' ? '처리완료' : 'DANGER' }}
               </span>
             </td>
-            <td class="px-5 py-3.5">
+            <td class="px-5 py-3.5 h-[52px]">
               <div v-if="o.status !== 'APPROVE' && o.status !== 'REJECT'" class="flex justify-center gap-1.5">
                 <button @click.stop="$emit('approve', o)"
                   class="px-2.5 py-1 bg-[#F37321] text-white text-xs font-semibold hover:bg-[#e0661d] rounded cursor-pointer">승인</button>

--- a/frontend/src/components/orders/hq/HqAutoOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqAutoOrderTable.vue
@@ -63,9 +63,9 @@ function resetSearch() {
           <tr class="border-b border-gray-200 bg-gray-50">
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주번호</th>
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">대상 매장</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주일시</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center pr-10">발주일시</th>
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">총 금액</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">상태</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
@@ -74,9 +74,9 @@ function resetSearch() {
             @click="$emit('open-detail', o.id)">
             <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ o.id }}</td>
             <td class="px-5 py-3.5 font-semibold text-gray-900">{{ o.store }}</td>
-            <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ o.date ?? '-' }}</td>
+            <td class="px-5 py-3.5 text-xs text-gray-400 font-mono text-center pr-10">{{ o.date ?? '-' }}</td>
             <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice(o.price) }}</td>
-            <td class="px-5 py-3.5">
+            <td class="px-5 py-3.5 text-center">
               <span class="text-xs font-bold px-2 py-0.5 rounded" :class="statusClass(o.status)">{{ o.status }}</span>
             </td>
           </tr>

--- a/frontend/src/components/orders/hq/HqConfirmedOrderTable.vue
+++ b/frontend/src/components/orders/hq/HqConfirmedOrderTable.vue
@@ -63,9 +63,9 @@ function resetSearch() {
           <tr class="border-b border-gray-200 bg-gray-50">
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주번호</th>
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">가맹점</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주일시</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center pr-10">발주일시</th>
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">총 금액</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">상태</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
@@ -74,9 +74,9 @@ function resetSearch() {
             @click="$emit('open-detail', o.id)">
             <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ o.id }}</td>
             <td class="px-5 py-3.5 font-semibold text-gray-900">{{ o.store }}</td>
-            <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ o.date }}</td>
+            <td class="px-5 py-3.5 text-xs text-gray-400 font-mono text-center pr-10">{{ o.date }}</td>
             <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice(o.price) }}</td>
-            <td class="px-5 py-3.5">
+            <td class="px-5 py-3.5 text-center">
               <span class="text-xs font-bold px-2 py-0.5 rounded" :class="statusClass(o.status)">{{ o.status }}</span>
             </td>
           </tr>

--- a/frontend/src/components/orders/hq/HqDangerSettingsModal.vue
+++ b/frontend/src/components/orders/hq/HqDangerSettingsModal.vue
@@ -14,6 +14,7 @@ const months = ref(props.initMonths)
 
 watch(() => props.initThreshold, (v) => { threshold.value = v })
 watch(() => props.initMonths, (v) => { months.value = v })
+watch(threshold, (v) => { if (v < 100) threshold.value = 100 })
 </script>
 
 <template>

--- a/frontend/src/components/orders/hq/HqOrderHistoryTable.vue
+++ b/frontend/src/components/orders/hq/HqOrderHistoryTable.vue
@@ -88,27 +88,27 @@ function resetFilters() {
         <thead>
           <tr class="border-b border-gray-200 bg-gray-50">
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주번호</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">유형</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center pr-10">유형</th>
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">입점 매장</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주일시</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center pr-10">발주일시</th>
             <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">총 금액</th>
-            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
+            <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">상태</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
           <tr v-for="h in orders" :key="h.id" class="hover:bg-gray-50/50 transition-colors cursor-pointer"
             @click="$emit('open-detail', h.id)">
             <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ h.id }}</td>
-            <td class="px-5 py-3.5">
+            <td class="px-5 py-3.5 text-center pr-10">
               <span class="text-xs font-bold px-2 py-0.5 rounded"
                 :class="h.type === '자동' ? 'bg-blue-50 text-blue-600 border border-blue-200' : 'bg-purple-50 text-purple-600 border border-purple-200'">
                 {{ h.type }}
               </span>
             </td>
             <td class="px-5 py-3.5 font-semibold text-gray-900">{{ h.store }}</td>
-            <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ h.date }}</td>
+            <td class="px-5 py-3.5 text-xs text-gray-400 font-mono text-center pr-10">{{ h.date }}</td>
             <td class="px-5 py-3.5 font-semibold text-gray-700">{{ formatPrice(h.price) }}</td>
-            <td class="px-5 py-3.5">
+            <td class="px-5 py-3.5 text-center">
               <span class="text-xs font-bold px-2 py-0.5 rounded" :class="statusClass(h.status)">{{ h.status }}</span>
             </td>
           </tr>

--- a/frontend/src/components/orders/store/StoreOrderHistoryTable.vue
+++ b/frontend/src/components/orders/store/StoreOrderHistoryTable.vue
@@ -60,12 +60,13 @@ const visiblePages = computed(() => {
               {{ ORDER_STATUS_LABEL[h.ordersStatus] }}
             </span>
           </td>
-          <td class="px-5 py-3.5 h-[52px]">
+          <td class="px-5 py-3.5 h-[52px] align-middle">
             <button v-if="h.ordersStatus === 'CONFIRMED'"
               @click.stop="emit('cancel', h)"
               class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-red-200 text-red-500 bg-red-50 hover:bg-red-500 hover:text-white hover:cursor-pointer transition-colors">
               취소
             </button>
+            <span v-else class="text-xs text-gray-400 block text-center">—</span>
           </td>
         </tr>
         <tr v-if="orders.length === 0">

--- a/frontend/src/components/orders/store/StoreOrderHistoryTable.vue
+++ b/frontend/src/components/orders/store/StoreOrderHistoryTable.vue
@@ -28,12 +28,12 @@ const visiblePages = computed(() => {
       <thead>
         <tr class="border-b border-gray-200 bg-gray-50">
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주번호</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">유형</th>
+          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">유형</th>
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">품목</th>
           <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">총 금액</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">발주일시</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">상태</th>
-          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider">처리</th>
+          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">발주일시</th>
+          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center">상태</th>
+          <th class="px-5 py-3 text-[10px] font-bold text-gray-400 uppercase tracking-wider w-[100px] text-center">처리</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-100">
@@ -41,7 +41,7 @@ const visiblePages = computed(() => {
           class="hover:bg-gray-50/50 transition-colors cursor-pointer"
           @click="emit('open-detail', h)">
           <td class="px-5 py-3.5 font-mono text-xs text-gray-400">{{ h.idx }}</td>
-          <td class="px-5 py-3.5">
+          <td class="px-5 py-3.5 text-center">
             <span class="text-xs font-bold px-2 py-0.5 rounded"
               :class="h.ordersType === 'AUTO' ? 'bg-blue-50 text-blue-600 border border-blue-200' : 'bg-purple-50 text-purple-600 border border-purple-200'">
               {{ ORDER_TYPE_LABEL[h.ordersType] }}
@@ -54,19 +54,21 @@ const visiblePages = computed(() => {
           <td class="px-5 py-3.5 font-semibold text-gray-700">
             ₩ {{ h.price?.toLocaleString() }}
           </td>
-          <td class="px-5 py-3.5 text-xs text-gray-400 font-mono">{{ h.createdAt?.replace('T', ' ').slice(0, 16) }}</td>
-          <td class="px-5 py-3.5">
+          <td class="px-5 py-3.5 text-xs text-gray-400 font-mono text-center">{{ h.createdAt?.replace('T', ' ').slice(0, 16) }}</td>
+          <td class="px-5 py-3.5 text-center">
             <span class="text-xs font-bold px-2 py-0.5 rounded" :class="storeStatusClass(h.ordersStatus)">
               {{ ORDER_STATUS_LABEL[h.ordersStatus] }}
             </span>
           </td>
-          <td class="px-5 py-3.5 h-[52px] align-middle">
-            <button v-if="h.ordersStatus === 'CONFIRMED'"
-              @click.stop="emit('cancel', h)"
-              class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-red-200 text-red-500 bg-red-50 hover:bg-red-500 hover:text-white hover:cursor-pointer transition-colors">
-              취소
-            </button>
-            <span v-else class="text-xs text-gray-400 block text-center">—</span>
+          <td class="px-5 py-2 align-middle">
+            <div class="flex items-center justify-center h-[28px]">
+              <button v-if="h.ordersStatus === 'CONFIRMED'"
+                @click.stop="emit('cancel', h)"
+                class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-red-200 text-red-500 bg-red-50 hover:bg-red-500 hover:text-white hover:cursor-pointer transition-colors">
+                취소
+              </button>
+              <span v-else class="text-xs text-gray-400">—</span>
+            </div>
           </td>
         </tr>
         <tr v-if="orders.length === 0">

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -220,9 +220,21 @@ function fetchTabData(id) {
   if (id === 'abnormal') fetchAbnormalOrders()
 }
 
+function resetSearchParams() {
+  autoSearchParams.value = {}
+  autoPage.value = 0
+  confirmedSearchParams.value = {}
+  confirmedPage.value = 0
+  historySearchParams.value = {}
+  historyPage.value = 0
+  abnormalSearchParams.value = {}
+  abnormalPage.value = 0
+}
+
 function setOrderViewTab(id) {
   activeTab.value = id
   router.replace({ path: '/order', query: { tab: id } })
+  resetSearchParams()
   fetchTabData(id)
 }
 

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -142,6 +142,7 @@ function onAbnormalPageChange(page) {
 const confirmedOrders = ref([])
 const confirmedPage = ref(0)
 const confirmedTotalPages = ref(1)
+const confirmedTotalElements = ref(0)
 const confirmedSearchParams = ref({})
 
 async function fetchConfirmedOrders(params = confirmedSearchParams.value, page = confirmedPage.value) {
@@ -157,6 +158,7 @@ async function fetchConfirmedOrders(params = confirmedSearchParams.value, page =
     }))
     confirmedPage.value = data.number
     confirmedTotalPages.value = data.totalPages
+    confirmedTotalElements.value = data.totalElements
   } catch (e) {
     console.error('확정 발주 목록 조회 실패', e)
   }
@@ -172,13 +174,13 @@ function onConfirmedPageChange(page) {
 }
 
 function approveAllConfirmed() {
-  if (confirmedOrders.value.length === 0) {
+  if (confirmedTotalElements.value === 0) {
     showToast('승인할 확정 발주가 없습니다.', 'error')
     return
   }
   openConfirm({
     type: 'warning',
-    title: `확정 발주 ${confirmedOrders.value.length}건을 전체 승인하시겠습니까?`,
+    title: `확정 발주 ${confirmedTotalElements.value}건을 전체 승인하시겠습니까?`,
     confirmText: '전체 승인',
     action: async () => {
       try {

--- a/frontend/src/views/hq/HqOrderManageView.vue
+++ b/frontend/src/views/hq/HqOrderManageView.vue
@@ -189,7 +189,12 @@ function approveAllConfirmed() {
         await fetchConfirmedOrders()
       } catch (e) {
         console.error('전체 승인 실패', e)
-        showToast('전체 승인에 실패했습니다.', 'error')
+        const code = e.response?.data?.code
+        if (code === 4201) {
+          showToast('본사 재고가 부족하여 발주를 승인할 수 없습니다.', 'error')
+        } else {
+          showToast('전체 승인에 실패했습니다.', 'error')
+        }
       }
     },
   })

--- a/frontend/src/views/store/StoreOrderManageView.vue
+++ b/frontend/src/views/store/StoreOrderManageView.vue
@@ -67,12 +67,9 @@ onMounted(() => {
   fetchPendingOrders()
 })
 
-const historyLoaded = ref(false)
-
 watch(activeTab, (tab) => {
-  if (tab === 'history' && !historyLoaded.value) {
+  if (tab === 'history') {
     fetchOrderHistory()
-    historyLoaded.value = true
   }
 })
 


### PR DESCRIPTION
## Summary                                                
- 발주 관리 페이지의 UI 레이아웃 불일치 및 기능 버그 수정

## 변경 파일
- frontend/src/views/hq/HqOrderManageView.vue
- frontend/src/views/store/StoreOrderManageView.vue
- frontend/src/components/orders/hq/HqAutoOrderTable.vue
- frontend/src/components/orders/hq/HqConfirmedOrderTable.vue
- frontend/src/components/orders/hq/HqOrderHistoryTable.vue
- frontend/src/components/orders/hq/HqAbnormalOrderTable.vue
- frontend/src/components/orders/hq/HqDangerSettingsModal.vue
- frontend/src/components/orders/store/StoreOrderHistoryTable.vue
- backend/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
- backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java

## 주요 변경 사항
- 확정 발주 전체 승인 시 페이지 건수 대신 전체 건수 표시
- 확정 발주 전체 승인 시 재고 부족 에러코드(4201) 및 메시지 개선
- 이상 발주 처리 컬럼 행 높이 통일
- 이상 발주 기준 설정 100% 미만 입력 방지
- 점주 발주 이력 취소 버튼 레이아웃 및 정렬 통일
- 점주 발주 이력 탭 전환 시 매번 데이터 새로 로드
- 본사 발주 관리 탭 전환 시 검색 조건 초기화
- 각 발주 목록 테이블 컬럼 가운데 정렬 적용

## Test Plan
- [ ] 확정 발주 전체 승인 시 전체 건수 정상 표시 확인
- [ ] 재고 부족 시 에러 메시지 정상 표시 확인
- [ ] 이상 발주/발주 이력 처리 컬럼 레이아웃 일관성 확인
- [ ] 이상 발주 기준 설정 100% 미만 입력 불가 확인
- [ ] 점주 발주 이력 탭 전환 시 데이터 갱신 확인
- [ ] 탭 전환 시 검색 조건 초기화 확인

## Issue
- Closes #769
