### PR TITLE
[Fix] #775 - 가맹점 배송 현황 조회 데이터 불러오지 못함 수정

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
@@ -60,11 +60,11 @@ public class DeliveryController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
         }
 
-        Long storeIdx = authUserDetails.getIdx();
+        Long userIdx = authUserDetails.getIdx();
 
         return ResponseEntity.ok(BaseResponse.success(
                 deliveryService.getDeliveriesForStore(
-                        storeIdx,
+                        userIdx,
                         orderIdx,
                         status,
                         year,

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java
@@ -2,11 +2,15 @@ package com.example.nexus.domain.delivery;
 
 import com.example.nexus.common.enums.DeliveryStatus;
 import com.example.nexus.common.enums.NotificationType;
+import com.example.nexus.common.exception.BaseException;
+import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.delivery.model.DeliveryDto;
 import com.example.nexus.domain.notification.HeadNotificationService;
 import com.example.nexus.domain.notification.StoreNotificationService;
 import com.example.nexus.domain.orders.model.Orders;
+import com.example.nexus.domain.store.StoreRepository;
+import com.example.nexus.domain.store.model.Store;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -25,6 +29,7 @@ public class DeliveryService {
     private final DeliveryRepository deliveryRepository;
     private final HeadNotificationService headNotificationService;
     private final StoreNotificationService storeNotificationService;
+    private final StoreRepository storeRepository;
 
     // 점주 발주 확정 시 배송 생성
     @Transactional
@@ -94,7 +99,7 @@ public class DeliveryService {
 
     // 가맹점 배송 조회
     public DeliveryDto.DeliveryPageRes getDeliveriesForStore(
-            Long storeIdx,
+            Long userIdx,
             Long orderIdx,
             DeliveryStatus status,
             Integer year,
@@ -104,6 +109,9 @@ public class DeliveryService {
             int size
     ) {
 
+        Store store = storeRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
+
         Pageable pageable = PageRequest.of(
                 page,
                 size,
@@ -112,7 +120,7 @@ public class DeliveryService {
 
         Page<Delivery> deliveryPage =
                 deliveryRepository.findAllByStoreFilters(
-                        storeIdx,
+                        store.getIdx(),
                         orderIdx,
                         status,
                         year,


### PR DESCRIPTION
## 📋 Summary
-  가맹점 배송 현황 조회 데이터 불러오지 못함 수정

## 📂 변경 파일
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java`
- `backend/src/main/java/com/example/nexus/domain/delivery/DeliveryService.java`

## ✨ 주요 변경 사항
- [ ] DeliveryController 'storeIdx' 말고 'userIdx' 로 전달하게 변수명 수정
- [ ] DeliveryService 에 StoreRepository 주입 추가
- [ ] DeliveryService 매개변수 storeIdx -> userIdx 로 수정
- [ ] storeRepository 에서 userIdx 찾아오게 추가


Closes #775