### PR TITLE
[Refactor] #777 - Orders 도메인 N+1 쿼리 최적화

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -64,6 +64,13 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     // 본사 발주 관리 - 이상 발주 목록 조회 (위험 플래그 기준)
     List<Orders> findAllByIsDangerTrue();
 
+    // 본사 발주 관리 - 이상 발주 재평가 시 Store, OrdersItemList 한 번에 로딩 (N+1 방지)
+    @Query("SELECT DISTINCT o FROM Orders o " +
+            "JOIN FETCH o.store " +
+            "LEFT JOIN FETCH o.ordersItemList " +
+            "WHERE o.isDanger = true")
+    List<Orders> findAllDangerWithDetails();
+
     // 본사 발주 관리 - 이상 발주 판별을 위한 매장별 평균 발주 수량 계산 (단건)
     @Query("SELECT COALESCE(SUM(i.count), 0) / GREATEST(COUNT(DISTINCT o.idx), 1) " +
             "FROM Orders o JOIN o.ordersItemList i " +

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -3,6 +3,8 @@ package com.example.nexus.domain.orders;
 import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.orders.model.Orders;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +17,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecificationExecutor<Orders> {
+
+    // Specification 기반 목록 조회 시 Store를 한 번에 JOIN FETCH (N+1 방지)
+    @Override
+    @EntityGraph(attributePaths = {"store"})
+    Page<Orders> findAll(Specification<Orders> spec, Pageable pageable);
 
     // 정산용 - 매장별 전체 주문 목록 조회
     List<Orders> findAllByStoreIdx(Long storeIdx);

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -50,9 +50,6 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m')")
     List<Object[]> findDangerStatsByMonth(@Param("since") LocalDateTime since);
 
-    // 본사 발주 관리 - 본사 확정 발주 일괄 승인을 위한 대상 조회
-    List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
-
     // 본사 발주 관리 - 일괄 승인 시 Store, OrdersItemList, Product 한 번에 로딩 (N+1 방지)
     @Query("SELECT DISTINCT o FROM Orders o " +
             "JOIN FETCH o.store " +
@@ -60,9 +57,6 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "JOIN FETCH i.product " +
             "WHERE o.ordersStatus = :status")
     List<Orders> findAllByOrdersStatusWithDetails(@Param("status") OrdersStatus status);
-
-    // 본사 발주 관리 - 이상 발주 목록 조회 (위험 플래그 기준)
-    List<Orders> findAllByIsDangerTrue();
 
     // 본사 발주 관리 - 이상 발주 재평가 시 Store, OrdersItemList 한 번에 로딩 (N+1 방지)
     @Query("SELECT DISTINCT o FROM Orders o " +

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecificationExecutor<Orders> {
 
@@ -87,6 +88,25 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     // 점주 제안 발주서 & 점주 대시보드  - 미확정 제안 발주서 목록
     List<Orders> findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
 
+    // 점주 제안 발주서 - Store, OrdersItemList, Product 한 번에 로딩 (N+1 방지)
+    @Query("SELECT DISTINCT o FROM Orders o " +
+            "JOIN FETCH o.store " +
+            "JOIN FETCH o.ordersItemList i " +
+            "JOIN FETCH i.product " +
+            "WHERE o.store.idx = :storeIdx AND o.ordersStatus = :status AND o.ordersType = :type " +
+            "ORDER BY o.createdAt DESC")
+    List<Orders> findPendingWithDetails(@Param("storeIdx") Long storeIdx, @Param("status") OrdersStatus status, @Param("type") OrdersType type);
+
+    // 발주 상세 조회 - Store, OrdersItemList, Product 한 번에 로딩 (N+1 방지)
+    @Query("SELECT DISTINCT o FROM Orders o " +
+            "JOIN FETCH o.store " +
+            "LEFT JOIN FETCH o.ordersItemList i " +
+            "LEFT JOIN FETCH i.product " +
+            "LEFT JOIN FETCH o.delivery " +
+            "WHERE o.idx = :idx")
+    Optional<Orders> findByIdWithDetails(@Param("idx") Long idx);
+
     // 점주 발주 관리 - 점주 이력 페이징 조회
+    @EntityGraph(attributePaths = {"store", "ordersItemList", "ordersItemList.product", "delivery"})
     Page<Orders> findAllByStore_IdxAndOrdersStatusIn(Long storeIdx, List<OrdersStatus> ordersStatuses, Pageable pageable);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -116,6 +116,6 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     Optional<Orders> findByIdWithDetails(@Param("idx") Long idx);
 
     // 점주 발주 관리 - 점주 이력 페이징 조회
-    @EntityGraph(attributePaths = {"store", "ordersItemList", "ordersItemList.product", "delivery"})
+    @EntityGraph(attributePaths = {"store", "delivery"})
     Page<Orders> findAllByStore_IdxAndOrdersStatusIn(Long storeIdx, List<OrdersStatus> ordersStatuses, Pageable pageable);
 }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -55,11 +55,27 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     // 본사 발주 관리 - 이상 발주 목록 조회 (위험 플래그 기준)
     List<Orders> findAllByIsDangerTrue();
 
-    // 본사 발주 관리 - 이상 발주 판별을 위한 매장별 평균 발주 수량 계산
+    // 본사 발주 관리 - 이상 발주 판별을 위한 매장별 평균 발주 수량 계산 (단건)
     @Query("SELECT COALESCE(SUM(i.count), 0) / GREATEST(COUNT(DISTINCT o.idx), 1) " +
             "FROM Orders o JOIN o.ordersItemList i " +
             "WHERE o.store.idx = :storeIdx AND o.createdAt >= :since AND (:excludeIdx IS NULL OR o.idx <> :excludeIdx)")
     Integer findAvgQtyByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("since") LocalDateTime since, @Param("excludeIdx") Long excludeIdx);
+
+    // 본사 발주 관리 - 이상 발주 목록 조회 시 매장별 평균 수량 + 주문 총수량 일괄 계산 (N+1 방지)
+    // 반환: [orders_idx, avgQty, totalQty]
+    @Query(value = "SELECT o1.orders_idx, " +
+            "COALESCE(SUM(oi_hist.count), 0) / GREATEST(COUNT(DISTINCT o2.orders_idx), 1), " +
+            "COALESCE(cur.total_qty, 0) " +
+            "FROM orders o1 " +
+            "LEFT JOIN orders o2 ON o2.store_idx = o1.store_idx " +
+            "  AND o2.created_at >= DATE_SUB(o1.created_at, INTERVAL :period MONTH) " +
+            "  AND o2.orders_idx != o1.orders_idx " +
+            "LEFT JOIN orders_item oi_hist ON oi_hist.orders_idx = o2.orders_idx " +
+            "LEFT JOIN (SELECT orders_idx, SUM(count) AS total_qty FROM orders_item GROUP BY orders_idx) cur " +
+            "  ON cur.orders_idx = o1.orders_idx " +
+            "WHERE o1.orders_idx IN :orderIds " +
+            "GROUP BY o1.orders_idx, cur.total_qty", nativeQuery = true)
+    List<Object[]> findAvgQtyBatch(@Param("orderIds") List<Long> orderIds, @Param("period") int period);
 
     // 점주 대시보드 - 미확정 제안 발주서 개수 KPI
     long countByStore_IdxAndOrdersStatusAndOrdersType(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -53,6 +53,14 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     // 본사 발주 관리 - 본사 확정 발주 일괄 승인을 위한 대상 조회
     List<Orders> findAllByOrdersStatus(OrdersStatus ordersStatus);
 
+    // 본사 발주 관리 - 일괄 승인 시 Store, OrdersItemList, Product 한 번에 로딩 (N+1 방지)
+    @Query("SELECT DISTINCT o FROM Orders o " +
+            "JOIN FETCH o.store " +
+            "JOIN FETCH o.ordersItemList i " +
+            "JOIN FETCH i.product " +
+            "WHERE o.ordersStatus = :status")
+    List<Orders> findAllByOrdersStatusWithDetails(@Param("status") OrdersStatus status);
+
     // 본사 발주 관리 - 이상 발주 목록 조회 (위험 플래그 기준)
     List<Orders> findAllByIsDangerTrue();
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -74,8 +74,8 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     // 본사 발주 관리 - 이상 발주 목록 조회 시 매장별 평균 수량 + 주문 총수량 일괄 계산 (N+1 방지)
     // 반환: [orders_idx, avgQty, totalQty]
     @Query(value = "SELECT o1.orders_idx, " +
-            "COALESCE(SUM(oi_hist.count), 0) / GREATEST(COUNT(DISTINCT o2.orders_idx), 1), " +
-            "COALESCE(cur.total_qty, 0) " +
+            "CAST(COALESCE(SUM(oi_hist.count), 0) / GREATEST(COUNT(DISTINCT o2.orders_idx), 1) AS SIGNED), " +
+            "CAST(COALESCE(cur.total_qty, 0) AS SIGNED) " +
             "FROM orders o1 " +
             "LEFT JOIN orders o2 ON o2.store_idx = o1.store_idx " +
             "  AND o2.created_at >= DATE_SUB(o1.created_at, INTERVAL :period MONTH) " +

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -166,22 +166,26 @@ public class OrdersService {
         dangerRepository.save(danger);
 
         // 기존 이상 발주 재평가: 새 기준 미달 시 isDanger 해제
-        List<Orders> dangerOrders = ordersRepository.findAllByIsDangerTrue();
+        List<Orders> dangerOrders = ordersRepository.findAllDangerWithDetails();
 
-        for (Orders orders : dangerOrders) {
-            List<OrdersItem> items = orders.getOrdersItemList() != null ? orders.getOrdersItemList() : Collections.emptyList();
-            int totalQty = items.stream().mapToInt(OrdersItem::getCount).sum();
-
-            LocalDateTime since = orders.getCreatedAt().minusMonths(req.getPeriod());
-
-            Integer avgQty = ordersRepository.findAvgQtyByStoreAndPeriod(orders.getStore().getIdx(), since, orders.getIdx());
-
-            int ratio = avgQty > 0 ? (totalQty - avgQty) * 100 / avgQty : 0;
-
-            if (ratio < req.getRatio()) {
-                orders.markDanger(false);
+        if (!dangerOrders.isEmpty()) {
+            List<Long> orderIds = dangerOrders.stream().map(Orders::getIdx).toList();
+            List<Object[]> rows = ordersRepository.findAvgQtyBatch(orderIds, req.getPeriod());
+            Map<Long, Integer> avgQtyMap = new HashMap<>();
+            for (Object[] row : rows) {
+                avgQtyMap.put(((Number) row[0]).longValue(), ((Number) row[1]).intValue());
             }
 
+            for (Orders orders : dangerOrders) {
+                List<OrdersItem> items = orders.getOrdersItemList() != null ? orders.getOrdersItemList() : Collections.emptyList();
+                int totalQty = items.stream().mapToInt(OrdersItem::getCount).sum();
+                int avgQty = avgQtyMap.getOrDefault(orders.getIdx(), 0);
+                int ratio = avgQty > 0 ? (totalQty - avgQty) * 100 / avgQty : 0;
+
+                if (ratio < req.getRatio()) {
+                    orders.markDanger(false);
+                }
+            }
         }
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -118,11 +118,23 @@ public class OrdersService {
         int period = dangerRepository.findById(1L)
                 .map(Danger::getPeriod).orElse(3);
 
-        return ordersRepository.findAll(spec, pageable).map(orders -> {
-            LocalDateTime since = orders.getCreatedAt().minusMonths(period);
-            Integer avgQty = ordersRepository.findAvgQtyByStoreAndPeriod(
-                    orders.getStore().getIdx(), since, orders.getIdx());
-            return DangerDto.DangerListRes.from(orders, avgQty);
+        Page<Orders> page = ordersRepository.findAll(spec, pageable);
+        List<Long> orderIds = page.getContent().stream().map(Orders::getIdx).toList();
+
+        Map<Long, int[]> dangerStatsMap = new HashMap<>();
+        if (!orderIds.isEmpty()) {
+            List<Object[]> rows = ordersRepository.findAvgQtyBatch(orderIds, period);
+            for (Object[] row : rows) {
+                Long ordersIdx = ((Number) row[0]).longValue();
+                int avgQty = ((Number) row[1]).intValue();
+                int totalQty = ((Number) row[2]).intValue();
+                dangerStatsMap.put(ordersIdx, new int[]{avgQty, totalQty});
+            }
+        }
+
+        return page.map(orders -> {
+            int[] stats = dangerStatsMap.getOrDefault(orders.getIdx(), new int[]{0, 0});
+            return DangerDto.DangerListRes.from(orders, stats[0], stats[1]);
         });
     }
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -140,7 +140,7 @@ public class OrdersService {
 
     // 발주 상세 조회 (단건)
     public OrdersDto.OrdersRes findById(Long ordersIdx) {
-        Orders orders = ordersRepository.findById(ordersIdx).orElseThrow(
+        Orders orders = ordersRepository.findByIdWithDetails(ordersIdx).orElseThrow(
                 () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
         return OrdersDto.OrdersRes.from(orders);
     }
@@ -366,7 +366,7 @@ public class OrdersService {
             }
         }
 
-        return ordersRepository.findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(store.getIdx(), OrdersStatus.WAITING, OrdersType.AUTO).stream()
+        return ordersRepository.findPendingWithDetails(store.getIdx(), OrdersStatus.WAITING, OrdersType.AUTO).stream()
                 .map(order -> OrdersDto.OrdersRes.fromWithStock(order, stockMap))
                 .toList();
     }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -188,7 +188,7 @@ public class OrdersService {
     // 본사 - 이상 발주 개별 승인 (출고 처리 포함)
     @Transactional
     public void approve(Long ordersIdx) {
-        Orders orders = ordersRepository.findById(ordersIdx)
+        Orders orders = ordersRepository.findByIdWithDetails(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
         if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
@@ -217,7 +217,7 @@ public class OrdersService {
     // 본사 - 확정 발주 일괄 승인 (출고 처리 포함)
     @Transactional
     public void approveAllConfirmed() {
-        List<Orders> confirmedOrders = ordersRepository.findAllByOrdersStatus(OrdersStatus.CONFIRMED);
+        List<Orders> confirmedOrders = ordersRepository.findAllByOrdersStatusWithDetails(OrdersStatus.CONFIRMED);
 
         for (Orders orders : confirmedOrders) {
             try {
@@ -248,8 +248,8 @@ public class OrdersService {
     // 발주 승인 시 품목별 출고 처리 (재고 차감)
     private void applyOutboundForOrder(Orders orders, String memoPrefix) {
         Long storeIdx = orders.getStore().getIdx();
-        List<OrdersItem> items = ordersItemRepository.findByOrdersIdx(orders.getIdx());
-        if (items.isEmpty()) {
+        List<OrdersItem> items = orders.getOrdersItemList();
+        if (items == null || items.isEmpty()) {
             throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
         }
         String memo = memoPrefix + orders.getIdx();

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
 
 public class DangerDto {
 
@@ -43,9 +41,7 @@ public class DangerDto {
         private Integer avgQty;
         private Integer ratio;
 
-        public static DangerListRes from(Orders entity, Integer avgQty) {
-            List<OrdersItem> items = entity.getOrdersItemList() != null ? entity.getOrdersItemList() : Collections.emptyList();
-            int totalQty = items.stream().mapToInt(OrdersItem::getCount).sum();
+        public static DangerListRes from(Orders entity, int avgQty, int totalQty) {
             int ratioValue = avgQty > 0 ? (totalQty - avgQty) * 100 / avgQty : 0;
 
             return DangerListRes.builder()

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
@@ -6,6 +6,7 @@ import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.store.model.Store;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -47,6 +48,7 @@ public class Orders {
     @JoinColumn(name = "store_idx", nullable = false)
     private Store store;
 
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "orders", fetch = FetchType.LAZY)
     private List<OrdersItem> ordersItemList;
 

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItem.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItem.java
@@ -3,6 +3,7 @@ package com.example.nexus.domain.orders.model;
 import com.example.nexus.domain.product.model.Product;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Table(name = "orders_item")
@@ -24,6 +25,7 @@ public class OrdersItem {
     @JoinColumn(name = "orders_idx", nullable = false)
     private Orders orders;
 
+    @BatchSize(size = 100)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_idx", nullable = false)
     private Product product;


### PR DESCRIPTION
## Summary
- Orders 도메인 전반의 N+1 쿼리 문제를 @EntityGraph 및 JPQL JOIN FETCH로 해결                                                                                                                                                     
                                                                                                                                                                                                                              
## 변경 파일
- backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
- backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
- backend/src/main/java/com/example/nexus/domain/orders/model/DangerDto.java
- docs/Orders_N+1_개선_기록.md

## 주요 변경 사항
- Specification 기반 findAll에 @EntityGraph 오버라이드 적용 (Store N+1 해결, 목록 조회 4개 대상)
- 이상 발주 목록 조회 시 건별 avgQty 쿼리를 Native 벌크 쿼리로 통합
- 발주 상세 조회에 findByIdWithDetails JPQL JOIN FETCH 추가
- 점주 제안 발주서 조회에 findPendingWithDetails JPQL JOIN FETCH 추가
- 점주 발주 이력 페이징에 @EntityGraph 적용
- 일괄 승인에 findAllByOrdersStatusWithDetails JPQL JOIN FETCH 추가
- applyOutboundForOrder에서 별도 아이템 조회 제거, 이미 로딩된 ordersItemList 사용
- 이상 발주 재평가에 findAllDangerWithDetails JOIN FETCH + findAvgQtyBatch 벌크 쿼리 적용
- 미사용 Repository 메서드 및 import 정리

## 개선 결과

| 대상 | 개선 전 | 개선 후 |
|------|--------|--------|
| 목록 조회 4개 | 11쿼리/10건 | 1쿼리 |
| 이상 발주 목록 | 21쿼리/10건 | 2쿼리 |
| 상세/이력 조회 | 4+N~31+N쿼리 | 1쿼리 |
| 일괄/개별 승인 | 1+2N+아이템수 | 1쿼리 |
| 이상 발주 재평가 | 1+3N | 2쿼리 |

## Test Plan
- [ ] 자동 발주 제안 / 확정 발주 / 발주 이력 / 이상 발주 목록 조회 정상 동작 확인
- [ ] 발주 상세 모달 정상 표시 확인
- [ ] 점주 제안 발주서 목록 및 발주 이력 정상 조회 확인
- [ ] 확정 발주 전체 승인 / 이상 발주 개별 승인·반려 정상 동작 확인
- [ ] 이상 발주 기준 변경 시 재평가 정상 동작 확인
- [ ] Hibernate SQL 로그로 N+1 쿼리 제거 확인

## Issue
- Closes #777