### PR TITLE
[Refactor] #751 - 메뉴 업로드 파일 용량 제한 및 개발, 배포 설정

### DIFF
--- a/backend/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
+++ b/backend/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
@@ -28,7 +28,7 @@ public enum BaseResponseStatus {
     STORE_ALREADY_CLOSED(false, 3106, "폐업 처리되어 수정할 수 없는 가맹점입니다."),
     DUPLICATE_EMAIL(false, 3107, "이미 다른 계정에서 사용중인 이메일입니다."),
     S3_DELETE_FAILED(false, 3108, "S3 삭제 실패했습니다."),
-    EXCEED_PDF_FILE_SIZE(false, 3207, "파일 크기는 10MB를 초과할 수 없습니다."),
+    EXCEED_PDF_FILE_SIZE(false, 3109, "파일 크기는 10MB를 초과할 수 없습니다."),
 
     // 3200번대 ~ 메뉴 클라이언트 오류
     NOT_FOUND_CATEGORY(false, 3201, "존재하지 않는 카테고리입니다."),

--- a/backend/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
+++ b/backend/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
@@ -28,6 +28,7 @@ public enum BaseResponseStatus {
     STORE_ALREADY_CLOSED(false, 3106, "폐업 처리되어 수정할 수 없는 가맹점입니다."),
     DUPLICATE_EMAIL(false, 3107, "이미 다른 계정에서 사용중인 이메일입니다."),
     S3_DELETE_FAILED(false, 3108, "S3 삭제 실패했습니다."),
+    EXCEED_PDF_FILE_SIZE(false, 3207, "파일 크기는 10MB를 초과할 수 없습니다."),
 
     // 3200번대 ~ 메뉴 클라이언트 오류
     NOT_FOUND_CATEGORY(false, 3201, "존재하지 않는 카테고리입니다."),
@@ -36,7 +37,7 @@ public enum BaseResponseStatus {
     NOT_FOUND_MENU(false, 3204, "존재하지 않는 메뉴입니다."),
     DUPLICATE_CATEGORY_NAME(false, 3205, "이미 존재하는 카테고리입니다."),
     CATEGORY_IN_USE(false, 3206, "해당 카테고리를 사용하는 메뉴가 존재하여 삭제할 수 없습니다."),
-    EXCEED_MENU_FILE_SIZE(false, 3207, "파일 크기는 5MB를 초과할 수 없습니다."),
+    EXCEED_IMG_FILE_SIZE(false, 3207, "파일 크기는 5MB를 초과할 수 없습니다."),
 
 
     // 4000번대 실패

--- a/backend/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
+++ b/backend/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
@@ -36,6 +36,7 @@ public enum BaseResponseStatus {
     NOT_FOUND_MENU(false, 3204, "존재하지 않는 메뉴입니다."),
     DUPLICATE_CATEGORY_NAME(false, 3205, "이미 존재하는 카테고리입니다."),
     CATEGORY_IN_USE(false, 3206, "해당 카테고리를 사용하는 메뉴가 존재하여 삭제할 수 없습니다."),
+    EXCEED_MENU_FILE_SIZE(false, 3207, "파일 크기는 5MB를 초과할 수 없습니다."),
 
 
     // 4000번대 실패

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuController.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuController.java
@@ -38,9 +38,11 @@ public class MenuController {
 
     // S3 Pre-signed URL 요청
     @GetMapping("/presignedUrl/{fileName}")
-    public ResponseEntity presignedUrl(@PathVariable(name = "fileName") String fileName){
+    public ResponseEntity presignedUrl(
+            @PathVariable(name = "fileName") String fileName,
+            @RequestParam(name = "fileSize") long fileSize){
         // 1. 서비스를 호출하여 URL과 고유 파일명을 받아옵니다.
-        Map<String, String> result = menuService.getPresignedUrl(fileName);
+        Map<String, String> result = menuService.getPresignedUrl(fileName, fileSize);
 
         // 2. BaseResponse.success에 결과 Map을 담아 반환합니다.
         return ResponseEntity.ok(BaseResponse.success(result));

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -40,7 +40,6 @@ public class MenuService {
     @Value("${spring.cloud.aws.s3.menu-bucket}")
     private String menuBucket;
 
-    // 🌟 운영 서버에서는 true, 개발 컴퓨터(yml)에서는 false로 관리하세요!
     @Value("${spring.cloud.aws.s3.enabled:true}")
     private boolean isS3Enabled;
 
@@ -75,7 +74,7 @@ public class MenuService {
         // 🌟 1. 파일 크기 검사 (예: 5MB 제한)
         long maxSize = 5 * 1024 * 1024;
         if (fileSize > maxSize) {
-            throw new BaseException(EXCEED_MENU_FILE_SIZE);
+            throw new BaseException(EXCEED_IMG_FILE_SIZE);
         }
 
         // 2. 환경별 스위치 검사 (개발 편의성)
@@ -238,7 +237,7 @@ public class MenuService {
 
         // 🌟 3. 스위치가 꺼져있으면 삭제 로직 건너뛰기
         if (!isS3Enabled) {
-            System.out.println("🚧 [연습 모드] S3 파일 삭제를 건너뜁니다. (Key: " + key + ")");
+            System.out.println("[연습 모드] S3 파일 삭제를 건너뜁니다. (Key: " + key + ")");
             return;
         }
 

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -56,8 +56,7 @@ public class MenuService {
     public MenuDto.MenuItemListRes menuItemList(Long menuIdx) {
         Optional<Menu> res = menuRepository.findById(menuIdx);
 
-        menuRepository.findById(menuIdx)
-                .orElseThrow(() -> new BaseException(NOT_FOUND_MENU)); // null 방지
+        res.orElseThrow(() -> new BaseException(NOT_FOUND_MENU));
 
         if(res.isPresent()){
             Menu menu = res.get();

--- a/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -40,6 +40,10 @@ public class MenuService {
     @Value("${spring.cloud.aws.s3.menu-bucket}")
     private String menuBucket;
 
+    // 🌟 운영 서버에서는 true, 개발 컴퓨터(yml)에서는 false로 관리하세요!
+    @Value("${spring.cloud.aws.s3.enabled:true}")
+    private boolean isS3Enabled;
+
     @Transactional(readOnly = true)
     public MenuDto.MenuPageRes list(MenuDto.MenuSearchPagingReq searchReq, int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
@@ -49,8 +53,12 @@ public class MenuService {
         return MenuDto.MenuPageRes.from(result);
     }
 
+    @Transactional(readOnly = true)
     public MenuDto.MenuItemListRes menuItemList(Long menuIdx) {
         Optional<Menu> res = menuRepository.findById(menuIdx);
+
+        menuRepository.findById(menuIdx)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_MENU)); // null 방지
 
         if(res.isPresent()){
             Menu menu = res.get();
@@ -59,14 +67,31 @@ public class MenuService {
         return null;
     }
 
-    public Map<String, String> getPresignedUrl(String fileName) {
+    public Map<String, String> getPresignedUrl(String fileName, long fileSize) {
         // 1. 경로 및 고유 파일명 생성 (기존 로직 유지)
         String path = createPath(fileName);
+
+
+        // 🌟 1. 파일 크기 검사 (예: 5MB 제한)
+        long maxSize = 5 * 1024 * 1024;
+        if (fileSize > maxSize) {
+            throw new BaseException(EXCEED_MENU_FILE_SIZE);
+        }
+
+        // 2. 환경별 스위치 검사 (개발 편의성)
+        if (!isS3Enabled) {
+            System.out.println("[DEV MODE] S3 통신을 건너뛰고 가짜 URL을 반환합니다.");
+            return Map.of(
+                    "url", "http://local-test-dummy.com/" + path,
+                    "fileName", path
+            );
+        }
 
         // 2. S3 업로드 요청 생성
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(menuBucket)
                 .key(path)
+                .contentLength(fileSize)
                 .build();
 
         // 3. Pre-signed 요청 설정 (유효시간 분)
@@ -210,6 +235,13 @@ public class MenuService {
         if (key == null || key.isBlank()) {
             return;
         }
+
+        // 🌟 3. 스위치가 꺼져있으면 삭제 로직 건너뛰기
+        if (!isS3Enabled) {
+            System.out.println("🚧 [연습 모드] S3 파일 삭제를 건너뜁니다. (Key: " + key + ")");
+            return;
+        }
+
         try {
             s3Client.deleteObject(DeleteObjectRequest.builder()
                     .bucket(menuBucket)

--- a/backend/src/main/java/com/example/nexus/domain/report/ReportService.java
+++ b/backend/src/main/java/com/example/nexus/domain/report/ReportService.java
@@ -31,6 +31,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.example.nexus.common.model.BaseResponseStatus.NOT_FOUND_USER;
@@ -50,6 +51,10 @@ public class ReportService {
 
     @Value("${spring.cloud.aws.s3.report-bucket}")
     private String reportBucket;
+
+    @Value("${spring.cloud.aws.s3.enabled:true}")
+    private boolean isS3Enabled;
+
 
     // 0. 생성자 주입
     public ReportService(ReportRepository reportRepository,
@@ -111,9 +116,24 @@ public class ReportService {
         String s3Key = "reports/" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"))
                 + "/" + UUID.randomUUID() + ".pdf";
 
+        // 2. 환경별 스위치 검사 (개발 편의성)
+        if (!isS3Enabled) {
+            System.out.println("[DEV MODE] S3 업로드를 건너뛰고 가짜 경로로 DB에 저장합니다.");
+            // S3 업로드 없이 바로 DB 저장 로직으로 넘어감
+            reportRepository.save(Report.builder()
+                    .title(title)
+                    .filePath("dev-mode-dummy/" + s3Key) // 가짜 경로 저장
+                    .user(user)
+                    .build());
+            return title + " 보고서 생성이 완료되었습니다! (DEV MODE)";
+        }
+
         // 1. S3에 PDF 파일 먼저 업로드
         s3Client.putObject(PutObjectRequest.builder()
-                        .bucket(reportBucket).key(s3Key).contentType("application/pdf").build(),
+                        .bucket(reportBucket)
+                        .key(s3Key)
+                        .contentType("application/pdf")
+                        .build(),
                 RequestBody.fromFile(tempFile));
 
         // 2. DB 저장 시도 및 수동 롤백

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreController.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreController.java
@@ -86,9 +86,11 @@ public class StoreController {
 
     // S3 Pre-signed URL 요청
     @GetMapping("/presignedUrl/{fileName}")
-    public ResponseEntity presignedUrl(@PathVariable(name = "fileName") String fileName){
+    public ResponseEntity presignedUrl(
+            @PathVariable(name = "fileName") String fileName,
+            @RequestParam(name = "fileSize") long fileSize){
         // 1. 서비스를 호출하여 URL과 고유 파일명을 받아옵니다.
-        Map<String, String> result = storeService.getPresignedUrl(fileName);
+        Map<String, String> result = storeService.getPresignedUrl(fileName, fileSize);
 
         // 2. BaseResponse.success에 결과 Map을 담아 반환합니다.
         return ResponseEntity.ok(BaseResponse.success(result));

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreService.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreService.java
@@ -46,6 +46,9 @@ public class StoreService {
     @Value("${spring.cloud.aws.s3.store-bucket}")
     private String storeBucket;
 
+    @Value("${spring.cloud.aws.s3.enabled:true}")
+    private boolean isS3Enabled;
+
     @Transactional
     public PageResponse<StoreInventoryDto.ListRes> listByStoreIdxPaged(Long storeIdx, int page, int size) {
         storeRepository.findById(storeIdx)
@@ -194,15 +197,31 @@ public class StoreService {
     }
 
     // Presigned URL을 발급 받는 로직
-    public Map<String, String> getPresignedUrl(String fileName) {
+    public Map<String, String> getPresignedUrl(String fileName, long fileSize) {
 
         // 1. 경로 및 고유 파일명 생성 (기존 로직 유지)
         String path = createPath(fileName);
+
+        // 🌟 1. 파일 크기 검사 (예: 10MB 제한)
+        long maxSize = 10 * 1024 * 1024;
+        if (fileSize > maxSize) {
+            throw new BaseException(EXCEED_PDF_FILE_SIZE);
+        }
+
+        // 2. 환경별 스위치 검사 (개발 편의성)
+        if (!isS3Enabled) {
+            System.out.println("[DEV MODE] S3 통신을 건너뛰고 가짜 URL을 반환합니다.");
+            return Map.of(
+                    "url", "http://local-test-dummy.com/" + path,
+                    "fileName", path
+            );
+        }
 
         // 2. S3 업로드 요청 생성
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(storeBucket)
                 .key(path)
+                .contentLength(fileSize)
                 .build();
 
         // 3. Pre-signed 요청 설정 (유효시간 분)
@@ -276,6 +295,12 @@ public class StoreService {
         if (key == null || key.isBlank()) {
             return;
         }
+        // 🌟 3. 스위치가 꺼져있으면 삭제 로직 건너뛰기
+        if (!isS3Enabled) {
+            System.out.println("[연습 모드] S3 파일 삭제를 건너뜁니다. (Key: " + key + ")");
+            return;
+        }
+
         try {
             s3Client.deleteObject(DeleteObjectRequest.builder()
                     .bucket(storeBucket)

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -60,6 +60,12 @@ spring:
           auth: true
           timeout: 5000
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB      # 파일 하나당 최대 크기 (PDF 기준)
+      max-request-size: 15MB   # 전체 요청의 최대 크기
+
 server:
   port: 8080
 

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -37,6 +37,7 @@ spring:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
       s3:
+        enabled: true # false = S3 작동 X
         store-bucket: ${AWS_S3_STORE_BUCKET}
         menu-bucket: ${AWS_S3_MENU_BUCKET}
         report-bucket: ${AWS_S3_REPORT_BUCKET}


### PR DESCRIPTION
## Summary
- 가맹점, 메뉴 에 S3부분에 등록 파일 용량 제안 설정
- 가맹점, 메뉴, 레시피 에 S3 개발, 배포 설정하기

## 변경 파일
- `backend/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java`
- `backend/src/main/java/com/example/nexus/domain/menu/MenuController.java`
- `backend/src/main/java/com/example/nexus/domain/menu/MenuService.java`
- `backend/src/main/java/com/example/nexus/domain/report/ReportService.java`
- `backend/src/main/java/com/example/nexus/domain/store/StoreController.java`
- `backend/src/main/java/com/example/nexus/domain/store/StoreService.java`
- `backend/src/main/resources/application-dev.yaml`


## 주요 변경 사항
- [x] StoreService S3 파일 용량 제안 설정 및 S3 개발, 배포 설정하기
- [x] MenuService S3 파일 용량 제안 설정 및 S3 개발, 배포 설정하기
- [x] ReportService S3 개발, 배포 설정하기


## Issue
- Closes #751 