### PR TITLE
[Refactor] #780 - Orders 도메인 동시성 제어 (비관적 잠금 적용) 

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -3,10 +3,12 @@ package com.example.nexus.domain.orders;
 import com.example.nexus.common.enums.OrdersStatus;
 import com.example.nexus.common.enums.OrdersType;
 import com.example.nexus.domain.orders.model.Orders;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -50,7 +52,23 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
             "ORDER BY FUNCTION('DATE_FORMAT', o.createdAt, '%Y-%m')")
     List<Object[]> findDangerStatsByMonth(@Param("since") LocalDateTime since);
 
-    // 본사 발주 관리 - 일괄 승인 시 Store, OrdersItemList, Product 한 번에 로딩 (N+1 방지)
+    // 동시성 제어 - 단건 비관적 잠금 (상태 변경 전용)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM Orders o WHERE o.idx = :idx")
+    Optional<Orders> findByIdForUpdate(@Param("idx") Long idx);
+
+    // 동시성 제어 - 단건 비관적 잠금 + 연관 엔티티 로딩 (승인 시 출고 처리 필요)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT DISTINCT o FROM Orders o " +
+            "JOIN FETCH o.store " +
+            "LEFT JOIN FETCH o.ordersItemList i " +
+            "LEFT JOIN FETCH i.product " +
+            "LEFT JOIN FETCH o.delivery " +
+            "WHERE o.idx = :idx")
+    Optional<Orders> findByIdWithDetailsForUpdate(@Param("idx") Long idx);
+
+    // 본사 발주 관리 - 일괄 승인 시 Store, OrdersItemList, Product 한 번에 로딩 + 비관적 잠금
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT DISTINCT o FROM Orders o " +
             "JOIN FETCH o.store " +
             "JOIN FETCH o.ordersItemList i " +

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -422,7 +422,7 @@ public class OrdersService {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
-        Orders orders = ordersRepository.findById(ordersIdx)
+        Orders orders = ordersRepository.findByIdForUpdate(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
         if (!orders.getStore().getIdx().equals(store.getIdx())) {
@@ -454,7 +454,8 @@ public class OrdersService {
             throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
         }
 
-        Orders orders = item.getOrders();
+        Orders orders = ordersRepository.findByIdForUpdate(item.getOrders().getIdx())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
         long priceDiff = (long) item.getProduct().getUnitPrice() * (count - item.getCount());
         item.updateCount(count);
         orders.updatePrice(orders.getPrice() + priceDiff);
@@ -473,7 +474,8 @@ public class OrdersService {
             throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
         }
 
-        Orders orders = item.getOrders();
+        Orders orders = ordersRepository.findByIdForUpdate(item.getOrders().getIdx())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
         orders.updatePrice(orders.getPrice() - (long) item.getProduct().getUnitPrice() * item.getCount());
         ordersItemRepository.delete(item);
     }

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -380,7 +380,7 @@ public class OrdersService {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
-        Orders orders = ordersRepository.findById(ordersIdx)
+        Orders orders = ordersRepository.findByIdWithDetailsForUpdate(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
         if (!orders.getStore().getIdx().equals(store.getIdx())) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -191,7 +191,7 @@ public class OrdersService {
     // 본사 - 이상 발주 개별 승인 (출고 처리 포함)
     @Transactional
     public void approve(Long ordersIdx) {
-        Orders orders = ordersRepository.findByIdWithDetails(ordersIdx)
+        Orders orders = ordersRepository.findByIdWithDetailsForUpdate(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
         if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
@@ -207,7 +207,7 @@ public class OrdersService {
     // 본사 - 이상 발주 개별 반려
     @Transactional
     public void reject(Long ordersIdx) {
-        Orders orders = ordersRepository.findById(ordersIdx)
+        Orders orders = ordersRepository.findByIdForUpdate(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
         if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
@@ -516,7 +516,7 @@ public class OrdersService {
         Store store = storeRepository.findByUserIdx(userIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
-        Orders orders = ordersRepository.findById(ordersIdx)
+        Orders orders = ordersRepository.findByIdForUpdate(ordersIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
 
         if (!orders.getStore().getIdx().equals(store.getIdx())) {

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItem.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/OrdersItem.java
@@ -3,7 +3,6 @@ package com.example.nexus.domain.orders.model;
 import com.example.nexus.domain.product.model.Product;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Table(name = "orders_item")
@@ -25,7 +24,6 @@ public class OrdersItem {
     @JoinColumn(name = "orders_idx", nullable = false)
     private Orders orders;
 
-    @BatchSize(size = 100)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_idx", nullable = false)
     private Product product;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 발주 상태 변경, 점주 확정, 아이템 수정 시 동시성 경쟁 조건을 비관적 잠금(PESSIMISTIC_WRITE)으로 해결                                                                                                                            
                                                                                                                                                                                                                            
## 변경 파일                                                                                                                                                                                                                      
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java`
- `backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java`

## 주요 변경 사항
- OrdersRepository에 `findByIdForUpdate`, `findByIdWithDetailsForUpdate` 비관적 잠금 쿼리 추가
- `findAllByOrdersStatusWithDetails`에 `@Lock(PESSIMISTIC_WRITE)` 추가 (일괄 승인 동시성 제어)
- `approve`, `reject`, `cancelOrder`에 비관적 잠금 적용 → 이중 승인/출고/매출채권 방지
- `confirmStoreOrder`에 비관적 잠금 적용 → 배송 중복 생성 방지
- `addStoreItem`, `updateStoreItemCount`, `deleteStoreItem`에 비관적 잠금 적용 → price Lost Update 방지

## Test Plan
- [ ] 발주 승인/반려 동시 호출 시 한쪽만 성공하는지 확인
- [ ] 점주 발주 확정 더블 클릭 시 배송이 1건만 생성되는지 확인
- [ ] 품목 추가/수량 변경 동시 요청 시 가격이 정확히 반영되는지 확인
- [ ] 스케줄러 일괄 승인 중 개별 반려/취소 시 충돌 없이 처리되는지 확인

## Issue
- Closes #780