### PR TITLE
[Refactor] #788 - 대시보드 N+1 쿼리 해결 (JOIN FETCH 추가)

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -103,8 +103,11 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     );
 
     // 점주 대시보드 - 배송완료 제외 최신순
+    @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o " +
+            "WHERE o.store.idx = :storeIdx AND d.deliveryStatus <> :excludeStatus " +
+            "ORDER BY d.departureDate DESC")
     List<Delivery> findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc(
-            Long storeIdx,
-            DeliveryStatus excludeStatus
+            @Param("storeIdx") Long storeIdx,
+            @Param("excludeStatus") DeliveryStatus excludeStatus
     );
 }

--- a/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -95,8 +95,10 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     );
 
     // 본사 대시보드 - 지연 배송 목록 무한스크롤 페이징
+    @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s " +
+            "WHERE d.deliveryStatus = :status")
     Slice<Delivery> findByDeliveryStatus(
-            DeliveryStatus status,
+            @Param("status") DeliveryStatus status,
             Pageable pageable
     );
 

--- a/backend/src/main/java/com/example/nexus/domain/head/HeadInventoryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/head/HeadInventoryRepository.java
@@ -33,7 +33,9 @@ public interface HeadInventoryRepository extends JpaRepository<HeadInventory, Lo
     long countByStatus(InventoryStatus status);
 
     // 대시보드용: 위험 재고 목록 조회 (Slice 페이징)
-    Slice<HeadInventory> findByStatusIn(List<InventoryStatus> statuses, Pageable pageable);
+    @Query("SELECT h FROM HeadInventory h JOIN FETCH h.product " +
+            "WHERE h.status IN :statuses")
+    Slice<HeadInventory> findByStatusIn(@Param("statuses") List<InventoryStatus> statuses, Pageable pageable);
 
     // 알림용: 재고가 있는 전체 목록 조회
     List<HeadInventory> findAllByCountGreaterThan(int count);

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersRepository.java
@@ -113,7 +113,15 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, JpaSpecif
     long sumApprovedPriceByStoreAndPeriod(@Param("storeIdx") Long storeIdx, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 
     // 점주 제안 발주서 & 점주 대시보드  - 미확정 제안 발주서 목록
-    List<Orders> findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(Long storeIdx, OrdersStatus ordersStatus, OrdersType ordersType);
+    @Query("SELECT DISTINCT o FROM Orders o " +
+            "LEFT JOIN FETCH o.ordersItemList i " +
+            "LEFT JOIN FETCH i.product " +
+            "WHERE o.store.idx = :storeIdx AND o.ordersStatus = :ordersStatus AND o.ordersType = :ordersType " +
+            "ORDER BY o.createdAt DESC")
+    List<Orders> findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc(
+            @Param("storeIdx") Long storeIdx,
+            @Param("ordersStatus") OrdersStatus ordersStatus,
+            @Param("ordersType") OrdersType ordersType);
 
     // 점주 제안 발주서 - Store, OrdersItemList, Product 한 번에 로딩 (N+1 방지)
     @Query("SELECT DISTINCT o FROM Orders o " +

--- a/backend/src/main/java/com/example/nexus/domain/store/StoreInventoryRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/store/StoreInventoryRepository.java
@@ -46,7 +46,12 @@ public interface StoreInventoryRepository extends JpaRepository<StoreInventory, 
     long countByStore_IdxAndStatus(Long storeIdx, InventoryStatus status);
 
     // 점주 대시보드용 - 재고 위험 품목 목록 (CRITICAL/LOW 상태 조회)
-    List<StoreInventory> findByStore_IdxAndStatusInOrderByStatusDesc(Long storeIdx, List<InventoryStatus> statuses);
+    @Query("SELECT s FROM StoreInventory s JOIN FETCH s.product " +
+            "WHERE s.store.idx = :storeIdx AND s.status IN :statuses " +
+            "ORDER BY s.status DESC")
+    List<StoreInventory> findByStore_IdxAndStatusInOrderByStatusDesc(
+            @Param("storeIdx") Long storeIdx,
+            @Param("statuses") List<InventoryStatus> statuses);
 
     Optional<StoreInventory> findByStore_IdxAndProduct_IdxAndManufacturedDate(Long storeIdx, Long productIdx, LocalDateTime manufacturedDate);
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 본사/가맹점 대시보드에서 발생하는 N+1 쿼리 5건을 JOIN FETCH로 해결                                                                                                                                                              
                                                                                                                                                                                                                              
## 변경 파일
- DeliveryRepository.java
- HeadInventoryRepository.java
- OrdersRepository.java
- StoreInventoryRepository.java

## 주요 변경 사항
- DeliveryRepository.findByDeliveryStatus()에 Delivery → Orders → Store JOIN FETCH 추가
- HeadInventoryRepository.findByStatusIn()에 HeadInventory → Product JOIN FETCH 추가
- OrdersRepository.findAllByStore_IdxAndOrdersStatusAndOrdersTypeOrderByCreatedAtDesc()에 Orders → OrdersItemList → Product JOIN FETCH 추가
- DeliveryRepository.findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc()에 Delivery → Orders JOIN FETCH 추가
- StoreInventoryRepository.findByStore_IdxAndStatusInOrderByStatusDesc()에 StoreInventory → Product JOIN FETCH 추가

## Test Plan
- [ ] 본사 대시보드 지연 배송 목록 조회 시 쿼리 수 확인
- [ ] 본사 대시보드 위험 재고 목록 조회 시 쿼리 수 확인
- [ ] 가맹점 대시보드 대기 주문 목록 조회 시 쿼리 수 확인
- [ ] 가맹점 대시보드 배송 목록 조회 시 쿼리 수 확인
- [ ] 가맹점 대시보드 재고 경고 목록 조회 시 쿼리 수 확인

## Issue
- Closes #788