### PR TITLE
[Feat] #792 - Prometheus + Grafana 모니터링 환경 구성 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -70,10 +70,15 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, prometheus, metrics
   endpoint:
     health:
       show-details: always
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
 
 portone:
   portone_secret: ${PORTONE_SECRET}

--- a/k8s/backend/deployment-blue.yaml
+++ b/k8s/backend/deployment-blue.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app: nexus-backend
         slot: blue
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "8080"
     spec:
       containers:
         - name: nexus-backend

--- a/k8s/backend/deployment-green.yaml
+++ b/k8s/backend/deployment-green.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app: nexus-backend
         slot: green
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "8080"
     spec:
       containers:
         - name: nexus-backend


### PR DESCRIPTION
## Summary                                                
- Spring Boot 백엔드에 Prometheus 메트릭 엔드포인트를 추가하고, K8s Deployment에 스크래핑 어노테이션을 설정하여 Istio addon Prometheus와 연동

## 변경 파일
- backend/build.gradle
- backend/src/main/resources/application-prod.yaml
- k8s/backend/deployment-blue.yaml
- k8s/backend/deployment-green.yaml

## 주요 변경 사항
- micrometer-registry-prometheus 의존성 추가
- application-prod.yaml에 prometheus, metrics 엔드포인트 노출 및 메트릭 태그 설정
- deployment-blue/green에 prometheus.io 스크래핑 어노테이션 추가

## DB & Infrastructure
- DB 변경 없음
- Istio + addon(Prometheus, Grafana, Kiali, Jaeger) 클러스터에 설치 완료

## Test Plan
- [ ] /actuator/prometheus 엔드포인트 응답 확인
- [ ] Prometheus Targets에서 백엔드 Pod 수집 확인
- [ ] Grafana에서 JVM/HTTP 메트릭 대시보드 확인

## Issue
- Closes #792