### PR TITLE
[Fix] #792 Istio 사이드카 환경 Probe 타임아웃 조정

### DIFF
--- a/k8s/backend/deployment-blue.yaml
+++ b/k8s/backend/deployment-blue.yaml
@@ -37,15 +37,15 @@ spec:
             httpGet:
               path: /actuator/health
               port: 8080
-            initialDelaySeconds: 40
+            initialDelaySeconds: 60
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 10
             failureThreshold: 5
           livenessProbe:
             httpGet:
               path: /actuator/health
               port: 8080
-            initialDelaySeconds: 80
+            initialDelaySeconds: 120
             periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
+            timeoutSeconds: 10
+            failureThreshold: 5

--- a/k8s/backend/deployment-green.yaml
+++ b/k8s/backend/deployment-green.yaml
@@ -37,15 +37,15 @@ spec:
             httpGet:
               path: /actuator/health
               port: 8080
-            initialDelaySeconds: 40
+            initialDelaySeconds: 60
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 10
             failureThreshold: 5
           livenessProbe:
             httpGet:
               path: /actuator/health
               port: 8080
-            initialDelaySeconds: 80
+            initialDelaySeconds: 120
             periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
+            timeoutSeconds: 10
+            failureThreshold: 5


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- Istio 사이드카가 probe를 리라이트하면서 timeout이 1초로 줄어드는 문제 대응

## 변경 파일
- k8s/backend/deployment-blue.yaml
- k8s/backend/deployment-green.yaml

## 주요 변경 사항
- readiness probe: initialDelaySeconds 40→60, timeoutSeconds 5→10
- liveness probe: initialDelaySeconds 80→120, timeoutSeconds 5→10, failureThreshold 3→5

## Test Plan
- [ ] Pod이 2/2 Running 상태로 정상 기동 확인
- [ ] Jenkins Blue/Green 배포 시 rollout status 타임아웃 없이 통과 확인

## Issue
- Closes #792