### PR TITLE
[Chore] #801 #802 - Backend JVM 설정 및 부하 테스트 환경 구성

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -10,4 +10,4 @@ RUN cd /app/mcp && npm install --omit=dev
 COPY backend/build/libs/*.jar app.jar
 
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xms512m", "-Xmx1024m", "-jar", "app.jar"]

--- a/k8s/load-test/README.md
+++ b/k8s/load-test/README.md
@@ -1,0 +1,69 @@
+# 부하 테스트 환경
+
+운영 서버에 영향 없이 부하 테스트를 수행하기 위한 별도 환경.
+
+## 구조
+
+```
+운영 환경 (건드리지 않음)                테스트 환경 (부하 테스트용)
+┌──────────────────────┐              ┌──────────────────────┐
+│ nexus-backend-green  │              │ test-backend         │
+│   → db-service       │              │   → test-db-service  │
+│   (Istio sidecar O)  │              │   (Istio sidecar X)  │
+│   (리소스 제한 없음)   │              │   (CPU 1core / 1Gi)  │
+└──────────────────────┘              │   (JVM -Xms512m)     │
+                                      └──────────────────────┘
+```
+
+## 배포 순서
+
+```bash
+# 1. 테스트용 DB 생성
+kubectl apply -f test-db-statefulset.yaml
+
+# 2. 테스트용 ConfigMap 생성 (테스트 DB를 바라봄)
+kubectl apply -f test-backend-configmap.yaml
+
+# 3. 테스트용 Backend 배포
+kubectl apply -f test-backend-deployment.yaml
+
+# 4. pod 상태 확인
+kubectl get pods -l app=test-backend
+kubectl get pods -l type=test-db
+
+# 5. 테스트 DB에 데이터 세팅 필요
+#    운영 DB에서 스키마 + 테스트 데이터를 dump해서 테스트 DB에 넣기
+#    (아래 '데이터 준비' 섹션 참고)
+```
+
+## 데이터 준비
+
+```bash
+# 운영 DB에서 스키마 + 기본 데이터 dump
+kubectl exec db-statefulset-0 -- mysqldump -uroot -pqwer1234 nexus > dump.sql
+
+# 테스트 DB에 import
+kubectl cp dump.sql test-db-statefulset-0:/tmp/dump.sql
+kubectl exec test-db-statefulset-0 -- mysql -uroot -pqwer1234 nexus < /tmp/dump.sql
+```
+
+## k6 부하 테스트
+
+```bash
+# 테스트 Backend 접속 주소
+# <아무 노드 IP>:30088 로 접근 가능
+
+# 예시
+k6 run --vus 10 --duration 1m test.js
+```
+
+## 정리 (테스트 끝나면)
+
+```bash
+kubectl delete -f test-backend-deployment.yaml
+kubectl delete -f test-backend-configmap.yaml
+kubectl delete -f test-db-statefulset.yaml
+
+# 테스트 DB PVC도 삭제
+kubectl delete pvc volume-test-db-statefulset-0
+```

--- a/k8s/load-test/test-backend-configmap.yaml
+++ b/k8s/load-test/test-backend-configmap.yaml
@@ -1,0 +1,13 @@
+## 부하 테스트 전용 Backend ConfigMap
+## 테스트용 DB(test-db-service)를 바라봄
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-backend-config
+data:
+  SPRING_PROFILES_ACTIVE: prod
+  DB_URL: jdbc:mariadb://test-db-service:3306/nexus
+  DB_DRIVER: org.mariadb.jdbc.Driver
+  AWS_S3_STORE_BUCKET: nexus-store-archive
+  AWS_S3_MENU_BUCKET: nexus-menu-assets
+  AWS_S3_STATIC: ap-northeast-2

--- a/k8s/load-test/test-backend-deployment.yaml
+++ b/k8s/load-test/test-backend-deployment.yaml
@@ -1,0 +1,75 @@
+## 부하 테스트 전용 Backend Deployment
+## 운영 pod와 완전히 분리 (별도 이름, 별도 DB)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-backend
+  labels:
+    app: test-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-backend
+  template:
+    metadata:
+      labels:
+        app: test-backend
+      annotations:
+        sidecar.istio.io/inject: "false"   # 테스트용이라 Istio sidecar 불필요
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "8080"
+    spec:
+      containers:
+        - name: nexus-backend
+          image: deatytim/nexusback:latest
+          ports:
+            - containerPort: 8080
+          env:
+            ## JVM 메모리 설정
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms512m -Xmx1024m"
+          envFrom:
+            - configMapRef:
+                name: test-backend-config
+            - secretRef:
+                name: nexus-backend-secret   # Secret은 운영과 공유 (API 키 등)
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 1000m          # 1 core
+              memory: 1536Mi      # Xmx 1024m + JVM 오버헤드 ~256m + 여유
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5
+---
+## 테스트 Backend에 접근하기 위한 Service
+## NodePort로 외부에서 직접 k6 부하를 쏠 수 있게 함
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-backend-service
+spec:
+  type: NodePort
+  selector:
+    app: test-backend
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30088        # 외부에서 <노드IP>:30088 으로 접근

--- a/k8s/load-test/test-db-statefulset.yaml
+++ b/k8s/load-test/test-db-statefulset.yaml
@@ -1,0 +1,64 @@
+## 부하 테스트 전용 MariaDB
+## 운영 DB(db-statefulset)와 완전히 분리된 별도 인스턴스
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-db-statefulset
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      type: test-db
+  serviceName: test-db-service
+  template:
+    metadata:
+      labels:
+        type: test-db
+    spec:
+      containers:
+        - name: mariadb
+          image: mariadb:latest
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MARIADB_ROOT_PASSWORD
+              value: qwer1234
+            - name: MARIADB_ROOT_HOST
+              value: '%'
+            - name: MARIADB_DATABASE
+              value: nexus
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+            - name: volume
+              mountPath: /var/lib/mysql
+      securityContext:
+        fsGroup: 999
+      terminationGracePeriodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: volume
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1G
+        storageClassName: longhorn
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-db-service
+spec:
+  clusterIP: None
+  selector:
+    type: test-db
+  ports:
+    - port: 3306
+      targetPort: 3306

--- a/k8s/monitoring/grafana-dashboard-nexus.json
+++ b/k8s/monitoring/grafana-dashboard-nexus.json
@@ -1,0 +1,245 @@
+{
+  "title": "Nexus Backend Overview",
+  "tags": ["nexus", "spring-boot"],
+  "timezone": "browser",
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "application",
+        "label": "Service",
+        "type": "query",
+        "datasource": { "type": "prometheus" },
+        "query": "label_values(http_server_requests_seconds_count{job=\"spring-boot\"}, application)",
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": { "type": "prometheus" },
+        "query": "label_values(up{job=\"spring-boot\", application=~\"$application\"}, instance)",
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "현재 TPS",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "targets": [{ "expr": "sum(rate(http_server_requests_seconds_count{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[5m]))", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "reqps", "thresholds": { "steps": [{ "color": "blue", "value": null }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "title": "에러율 (%)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "targets": [{ "expr": "sum(rate(http_server_requests_seconds_count{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\", status=~\"5..\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[5m])) * 100 or vector(0)", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 2, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 5 }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "title": "CPU 사용률",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "targets": [{ "expr": "avg(process_cpu_usage{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"})", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.5 }, { "color": "red", "value": 0.8 }] } } }
+    },
+    {
+      "title": "힙 메모리 사용률",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "targets": [{ "expr": "sum(jvm_memory_used_bytes{area=\"heap\", job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}) / sum(jvm_memory_max_bytes{area=\"heap\", job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"} > 0) * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 85 }] } } }
+    },
+    {
+      "title": "DB 활성 커넥션",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "targets": [{ "expr": "sum(hikaricp_connections_active{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"})", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "min": 0, "max": 20, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 15 }, { "color": "red", "value": 18 }] } } }
+    },
+    {
+      "title": "서버 가동률",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "targets": [{ "expr": "avg(avg_over_time(up{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[$__range])) * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 2, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 95 }, { "color": "yellow", "value": 99 }, { "color": "green", "value": 99.9 }] } } },
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "auto" }
+    },
+
+    {
+      "title": "HTTP 트래픽",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "HTTP 요청 수 (TPS)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [{ "expr": "sum by (method, uri) (rate(http_server_requests_seconds_count{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{method}} {{uri}}" }],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2 } } }
+    },
+    {
+      "title": "응답 시간 (AVG / P95 / P99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        { "expr": "sum by (application) (rate(http_server_requests_seconds_sum{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[5m])) / sum by (application) (rate(http_server_requests_seconds_count{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[5m]))", "legendFormat": "AVG" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[5m])))", "legendFormat": "P95" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[5m])))", "legendFormat": "P99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "5xx 에러",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 14 },
+      "targets": [{ "expr": "sum by (status, uri) (rate(http_server_requests_seconds_count{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\", status=~\"5..\"}[5m]))", "legendFormat": "{{status}} {{uri}}" }],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20, "lineWidth": 2 }, "color": { "mode": "fixed", "fixedColor": "red" } } }
+    },
+    {
+      "title": "4xx 클라이언트 에러",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 14 },
+      "targets": [{ "expr": "sum by (status, uri) (rate(http_server_requests_seconds_count{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\", status=~\"4..\"}[5m]))", "legendFormat": "{{status}} {{uri}}" }],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20, "lineWidth": 2 }, "color": { "mode": "fixed", "fixedColor": "orange" } } }
+    },
+    {
+      "title": "HTTP 상태코드 분포",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 14 },
+      "targets": [{ "expr": "sum by (status) (increase(http_server_requests_seconds_count{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[1h]))", "legendFormat": "{{status}}" }],
+      "fieldConfig": { "defaults": {} },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] }, "pieType": "donut" }
+    },
+
+    {
+      "title": "JVM & 시스템",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "CPU 사용량 추이",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+      "targets": [
+        { "expr": "process_cpu_usage{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}", "legendFormat": "Process CPU" },
+        { "expr": "system_cpu_usage{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}", "legendFormat": "System CPU" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2 } } }
+    },
+    {
+      "title": "힙 메모리 사용량 추이",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "targets": [
+        { "expr": "sum by (id) (jvm_memory_used_bytes{area=\"heap\", job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"})", "legendFormat": "Used - {{id}}" },
+        { "expr": "sum(jvm_memory_max_bytes{area=\"heap\", job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"} > 0)", "legendFormat": "Max" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "GC 일시정지 시간",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "targets": [{ "expr": "sum by (action, cause) (rate(jvm_gc_pause_seconds_sum{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{action}} - {{cause}}" }],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "bars", "fillOpacity": 40, "lineWidth": 1 } } }
+    },
+    {
+      "title": "스레드 수",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "targets": [
+        { "expr": "jvm_threads_live_threads{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}", "legendFormat": "Live" },
+        { "expr": "jvm_threads_daemon_threads{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}", "legendFormat": "Daemon" },
+        { "expr": "jvm_threads_peak_threads{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}", "legendFormat": "Peak" }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+
+    {
+      "title": "DB 커넥션",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "DB 커넥션 풀",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "targets": [
+        { "expr": "hikaricp_connections_active{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}", "legendFormat": "Active" },
+        { "expr": "hikaricp_connections_idle{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}", "legendFormat": "Idle" },
+        { "expr": "hikaricp_connections_pending{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}", "legendFormat": "Pending" },
+        { "expr": "hikaricp_connections_max{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}", "legendFormat": "Max" }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "DB 커넥션 획득 시간",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "targets": [
+        { "expr": "hikaricp_connections_acquire_seconds_max{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}", "legendFormat": "Max 획득 시간" },
+        { "expr": "rate(hikaricp_connections_acquire_seconds_sum{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[5m]) / rate(hikaricp_connections_acquire_seconds_count{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[5m])", "legendFormat": "Avg 획득 시간" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "DB 대기 스레드",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 48 },
+      "targets": [{ "expr": "sum(hikaricp_connections_pending{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"})", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "min": 0, "max": 10, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 5 }] } } }
+    },
+    {
+      "title": "DB 커넥션 타임아웃",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 48 },
+      "targets": [{ "expr": "sum(increase(hikaricp_connections_timeout_total{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}[1h]))", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "title": "Non-Heap 메모리 사용률",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 48 },
+      "targets": [{ "expr": "sum(jvm_memory_used_bytes{area=\"nonheap\", job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"}) / sum(jvm_memory_max_bytes{area=\"nonheap\", job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"} > 0) * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 85 }] } } }
+    },
+    {
+      "title": "디스크 여유 공간",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 48 },
+      "targets": [{ "expr": "disk_free_bytes{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"} / disk_total_bytes{job=\"spring-boot\", application=~\"$application\", instance=~\"$instance\"} * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 10 }, { "color": "yellow", "value": 20 }, { "color": "green", "value": 30 }] } } }
+    }
+  ],
+  "schemaVersion": 39
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- Backend JVM 메모리 설정 추가 및 부하 테스트 전용 K8s 환경 구성                                                                                                                                                                  
                                                          
## 변경 파일
- docker/backend/Dockerfile
- k8s/monitoring/grafana-dashboard-nexus.json
- k8s/load-test/test-db-statefulset.yaml
- k8s/load-test/test-backend-configmap.yaml
- k8s/load-test/test-backend-deployment.yaml
- k8s/load-test/README.md

## 주요 변경 사항
- Dockerfile에 -Xms512m -Xmx1024m JVM 힙 메모리 설정 추가
- Grafana 대시보드 JSON 설정 파일 추가
- 부하 테스트 전용 MariaDB StatefulSet 및 Service 추가
- 부하 테스트 전용 Backend Deployment 추가 (CPU 1core, Memory 1536Mi 제한)
- 테스트 DB를 바라보는 별도 ConfigMap 분리
- NodePort 30088로 k6 직접 접근 가능

## DB & Infrastructure
- 운영 DB 변경 없음
- 테스트 전용 DB를 별도 StatefulSet으로 분리

## Test Plan
- [ ] 테스트 환경 배포 후 pod 정상 기동 확인
- [ ] NodePort 30088 접근 확인
- [ ] k6 부하 테스트 실행 및 Grafana 메트릭 확인

## Issue
- Closes #801
- Closes #802