### PR TITLE
[Feat] #805 - 실시간 대시보드 조회 API 구현 (DB 직접 쿼리 방식)  

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -15,6 +15,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class DashboardController {
     private final DashboardService dashboardService;
 
+    // === 실시간 대시보드 API (부하 테스트용 DB 직접 쿼리 방식) ===
+
+    @GetMapping("/realtime/sales/today")
+    public ResponseEntity<BaseResponse> getTodaySales() {
+        return ResponseEntity.ok(BaseResponse.success(dashboardService.getTodaySales()));
+    }
+
+    @GetMapping("/realtime/store/top")
+    public ResponseEntity<BaseResponse> getTopStores() {
+        return ResponseEntity.ok(BaseResponse.success(dashboardService.getTopStores()));
+    }
+
+    @GetMapping("/realtime/menu/top")
+    public ResponseEntity<BaseResponse> getTopMenus() {
+        return ResponseEntity.ok(BaseResponse.success(dashboardService.getTopMenus()));
+    }
+
     /**
      * 가맹점 현황 KPI 조회
      *

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -17,16 +17,31 @@ public class DashboardController {
 
     // === 실시간 대시보드 API (부하 테스트용 DB 직접 쿼리 방식) ===
 
+    /**
+     * 오늘 전체 매장 실시간 매출 합계 조회
+     *
+     * @return ResponseEntity 오늘 전체 매출 금액
+     */
     @GetMapping("/realtime/sales/today")
     public ResponseEntity<BaseResponse> getTodaySales() {
         return ResponseEntity.ok(BaseResponse.success(dashboardService.getTodaySales()));
     }
 
+    /**
+     * 매장별 매출 랭킹 TOP 3 조회
+     *
+     * @return ResponseEntity 매출 상위 매장 3개 (매장명, 매출액)
+     */
     @GetMapping("/realtime/store/top")
     public ResponseEntity<BaseResponse> getTopStores() {
         return ResponseEntity.ok(BaseResponse.success(dashboardService.getTopStores()));
     }
 
+    /**
+     * 메뉴별 판매 수량 랭킹 TOP 3 조회
+     *
+     * @return ResponseEntity 판매 수량 상위 메뉴 3개 (메뉴명, 판매 수량)
+     */
     @GetMapping("/realtime/menu/top")
     public ResponseEntity<BaseResponse> getTopMenus() {
         return ResponseEntity.ok(BaseResponse.success(dashboardService.getTopMenus()));

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -15,8 +15,11 @@ import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.head.HeadInventoryRepository;
 import com.example.nexus.domain.head.model.HeadInventory;
 import com.example.nexus.domain.orders.OrdersRepository;
+import com.example.nexus.domain.pos.PosOrdersItemRepository;
+import com.example.nexus.domain.pos.PosPayRepository;
 import com.example.nexus.domain.store.StoreRepository;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,6 +35,46 @@ public class DashboardService {
     private final OrdersRepository ordersRepository;
     private final HeadInventoryRepository headInventoryRepository;
     private final DeliveryRepository deliveryRepository;
+    private final PosPayRepository posPayRepository;
+    private final PosOrdersItemRepository posOrdersItemRepository;
+
+    // 실시간 대시보드: 오늘 전체 매출 합계
+    public DashboardDto.RealtimeSalesRes getTodaySales() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+        long total = posPayRepository.sumTodaySales(start, end);
+        return DashboardDto.RealtimeSalesRes.builder().todaySales(total).build();
+    }
+
+    // 실시간 대시보드: 매장별 매출 랭킹 TOP 3
+    public DashboardDto.RankingRes getTopStores() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+        List<Object[]> rows = posPayRepository.findTopStoresByPeriod(start, end, PageRequest.of(0, 3));
+        List<DashboardDto.RankingItem> items = rows.stream()
+                .map(r -> DashboardDto.RankingItem.builder()
+                        .idx((Long) r[0])
+                        .name((String) r[1])
+                        .score((Long) r[2])
+                        .build())
+                .toList();
+        return DashboardDto.RankingRes.builder().rankings(items).build();
+    }
+
+    // 실시간 대시보드: 메뉴별 판매 수량 랭킹 TOP 3
+    public DashboardDto.RankingRes getTopMenus() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+        List<Object[]> rows = posOrdersItemRepository.findTopMenusByPeriod(start, end, PageRequest.of(0, 3));
+        List<DashboardDto.RankingItem> items = rows.stream()
+                .map(r -> DashboardDto.RankingItem.builder()
+                        .idx((Long) r[0])
+                        .name((String) r[1])
+                        .score((Long) r[2])
+                        .build())
+                .toList();
+        return DashboardDto.RankingRes.builder().rankings(items).build();
+    }
 
     // 본사 대시보드 입점 매장 카드 데이터 조회 메서드
     public DashboardDto.StoreKpiRes getStoreKpi() {

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -121,4 +121,25 @@ public class DashboardDto {
         private List<DeliveryItem> items;
         private boolean hasNext;
     }
+
+    // 실시간 대시보드 DTO
+    @Getter
+    @Builder
+    public static class RealtimeSalesRes {
+        private long todaySales;
+    }
+
+    @Getter
+    @Builder
+    public static class RankingItem {
+        private Long idx;
+        private String name;
+        private long score;
+    }
+
+    @Getter
+    @Builder
+    public static class RankingRes {
+        private List<RankingItem> rankings;
+    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/pos/PosOrdersItemRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/PosOrdersItemRepository.java
@@ -21,4 +21,14 @@ public interface PosOrdersItemRepository extends JpaRepository<PosOrdersItem, Lo
             "GROUP BY m.menuName " +
             "ORDER BY SUM(poi.quantity) DESC")
     List<String> findTopSellingMenus(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, Pageable pageable);
+
+    // 실시간 대시보드: 메뉴별 판매 수량 랭킹 TOP N
+    @Query("SELECT m.idx, m.menuName, SUM(poi.quantity) " +
+            "FROM PosOrdersItem poi " +
+            "JOIN poi.menu m " +
+            "JOIN poi.posPay p " +
+            "WHERE p.paidAt >= :start AND p.paidAt < :end " +
+            "GROUP BY m.idx, m.menuName " +
+            "ORDER BY SUM(poi.quantity) DESC")
+    List<Object[]> findTopMenusByPeriod(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end, Pageable pageable);
 }

--- a/backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/pos/PosPayRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import org.springframework.data.domain.Pageable;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -25,4 +27,16 @@ public interface PosPayRepository extends JpaRepository<PosPay, Long> {
     // AI 보고서: 특정 기간 총 매출 합계
     @Query("SELECT COALESCE(SUM(p.payAmount), 0) FROM PosPay p WHERE p.paidAt BETWEEN :startDate AND :endDate")
     Long sumSalesByDateBetween(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    // 실시간 대시보드: 오늘 전체 매출 합계
+    @Query("SELECT COALESCE(SUM(p.payAmount), 0) FROM PosPay p WHERE p.paidAt >= :start AND p.paidAt < :end")
+    Long sumTodaySales(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    // 실시간 대시보드: 매장별 매출 랭킹 TOP N
+    @Query("SELECT p.store.idx, p.store.storeName, SUM(p.payAmount) " +
+            "FROM PosPay p " +
+            "WHERE p.paidAt >= :start AND p.paidAt < :end " +
+            "GROUP BY p.store.idx, p.store.storeName " +
+            "ORDER BY SUM(p.payAmount) DESC")
+    List<Object[]> findTopStoresByPeriod(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end, Pageable pageable);
 }

--- a/k8s/load-test/test-db-statefulset.yaml
+++ b/k8s/load-test/test-db-statefulset.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         type: test-db
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: mariadb


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 부하 테스트를 위한 실시간 대시보드 조회 API 3종 구현 (DB 직접 쿼리 방식)

## 변경 파일
- PosPayRepository.java
- PosOrdersItemRepository.java
- DashboardDto.java
- DashboardService.java
- DashboardController.java

## 주요 변경 사항
- 오늘 전체 매출 합계 API 추가 (GET /dashboard/realtime/sales/today)
- 매장별 매출 랭킹 TOP 3 API 추가 (GET /dashboard/realtime/store/top)
- 메뉴별 판매 수량 랭킹 TOP 3 API 추가 (GET /dashboard/realtime/menu/top)
- Redis 도입 전 DB 직접 쿼리 방식으로 구현하여 부하 테스트 시 한계점 확인 목적

## Test Plan
- [ ] 테스트 환경 배포 후 API 정상 응답 확인
- [ ] k6 부하 테스트로 DB 경합 상황 재현 및 Grafana 녹화

## Issue
- Closes #805