### PR TITLE
[Fix] #807 - 발주 가격 계산 버그 수정 및 안정성 개선

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -273,12 +273,13 @@ public class OrdersService {
      * 주문 수량의 초과 비율이 기준 이상이면 이상 발주로 판정
      * 예: 평균 10개, 이번 30개, 기준 200% → (30-10)*100/10 = 200% → 이상 발주
      */
-    private void recalculatePrice(Orders orders) {
+    private List<OrdersItem> recalculatePrice(Orders orders) {
         List<OrdersItem> items = ordersItemRepository.findByOrdersIdx(orders.getIdx());
         long total = items.stream()
                 .mapToLong(item -> (long) item.getProduct().getUnitPrice() * item.getCount())
                 .sum();
         orders.updatePrice(total);
+        return items;
     }
 
     private boolean evaluateDanger(Long storeIdx, int totalQty, LocalDateTime baseTime, Long excludeIdx) {
@@ -400,10 +401,9 @@ public class OrdersService {
         }
 
         // 점주가 아이템을 수정했을 수 있으므로 확정 시점에 가격 재계산
-        recalculatePrice(orders);
+        List<OrdersItem> items = recalculatePrice(orders);
 
         // 이상 발주 재판정
-        List<OrdersItem> items = orders.getOrdersItemList() != null ? orders.getOrdersItemList() : Collections.emptyList();
         int totalQty = items.stream().mapToInt(OrdersItem::getCount).sum();
         boolean isDanger = evaluateDanger(store.getIdx(), totalQty, orders.getCreatedAt(), orders.getIdx());
         orders.markDanger(isDanger);

--- a/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -273,6 +273,14 @@ public class OrdersService {
      * 주문 수량의 초과 비율이 기준 이상이면 이상 발주로 판정
      * 예: 평균 10개, 이번 30개, 기준 200% → (30-10)*100/10 = 200% → 이상 발주
      */
+    private void recalculatePrice(Orders orders) {
+        List<OrdersItem> items = ordersItemRepository.findByOrdersIdx(orders.getIdx());
+        long total = items.stream()
+                .mapToLong(item -> (long) item.getProduct().getUnitPrice() * item.getCount())
+                .sum();
+        orders.updatePrice(total);
+    }
+
     private boolean evaluateDanger(Long storeIdx, int totalQty, LocalDateTime baseTime, Long excludeIdx) {
         Danger danger = dangerRepository.findById(1L)
                 .orElse(Danger.builder().ratio(200).period(3).build());
@@ -391,7 +399,10 @@ public class OrdersService {
             throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
         }
 
-        // 이상 발주 재판정: 점주가 아이템을 수정했을 수 있으므로 확정 시점에 재평가
+        // 점주가 아이템을 수정했을 수 있으므로 확정 시점에 가격 재계산
+        recalculatePrice(orders);
+
+        // 이상 발주 재판정
         List<OrdersItem> items = orders.getOrdersItemList() != null ? orders.getOrdersItemList() : Collections.emptyList();
         int totalQty = items.stream().mapToInt(OrdersItem::getCount).sum();
         boolean isDanger = evaluateDanger(store.getIdx(), totalQty, orders.getCreatedAt(), orders.getIdx());
@@ -438,7 +449,7 @@ public class OrdersService {
                 .orders(orders)
                 .build());
 
-        orders.updatePrice(orders.getPrice() + (long) product.getUnitPrice() * req.getCount());
+        recalculatePrice(orders);
     }
 
     // 점주 - 제안 발주서 품목 수량 변경 (가격 차액 자동 반영)
@@ -456,9 +467,8 @@ public class OrdersService {
 
         Orders orders = ordersRepository.findByIdForUpdate(item.getOrders().getIdx())
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-        long priceDiff = (long) item.getProduct().getUnitPrice() * (count - item.getCount());
         item.updateCount(count);
-        orders.updatePrice(orders.getPrice() + priceDiff);
+        recalculatePrice(orders);
     }
 
     // 점주 - 제안 발주서 품목 삭제 (가격 자동 차감)
@@ -476,8 +486,9 @@ public class OrdersService {
 
         Orders orders = ordersRepository.findByIdForUpdate(item.getOrders().getIdx())
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
-        orders.updatePrice(orders.getPrice() - (long) item.getProduct().getUnitPrice() * item.getCount());
         ordersItemRepository.delete(item);
+        ordersItemRepository.flush();
+        recalculatePrice(orders);
     }
 
     // 점주 - 제안 발주서 거절

--- a/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
+++ b/backend/src/main/java/com/example/nexus/domain/orders/model/Orders.java
@@ -57,6 +57,7 @@ public class Orders {
 
     public void confirm() {
         this.ordersStatus = OrdersStatus.CONFIRMED;
+        this.createdAt = LocalDateTime.now();
     }
 
     public void cancel() {

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -77,6 +77,9 @@ management:
   endpoint:
     health:
       show-details: always
+  health:
+    mail:
+      enabled: false
 
 portone:
   portone_secret: ${PORTONE_SECRET}

--- a/frontend/src/components/orders/store/StoreOrderConfirmModal.vue
+++ b/frontend/src/components/orders/store/StoreOrderConfirmModal.vue
@@ -27,7 +27,7 @@ const emit = defineEmits(['close', 'confirm'])
           </div>
           <div class="flex justify-between items-center pt-3">
             <span class="text-sm font-bold text-gray-900">합계</span>
-            <span class="text-lg font-black text-blue-600">₩ {{ (order?.price ?? 0).toLocaleString() }}</span>
+            <span class="text-lg font-black text-blue-600">₩ {{ (order?.ordersItemList || []).reduce((sum, item) => sum + (item.count || 0) * (item.unitPrice ?? 0), 0).toLocaleString() }}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/orders/store/StorePendingOrderList.vue
+++ b/frontend/src/components/orders/store/StorePendingOrderList.vue
@@ -19,6 +19,10 @@ function sortedItems(order) {
   return [...(order.ordersItemList || [])].sort((a, b) => b.idx - a.idx)
 }
 
+function calcTotal(order) {
+  return (order.ordersItemList || []).reduce((sum, item) => sum + (item.count || 0) * (item.unitPrice ?? 0), 0)
+}
+
 const debounceTimers = new Map()
 
 function onCountChange(item) {
@@ -181,7 +185,7 @@ function onCountChange(item) {
             <td class="px-5 py-3 text-left text-xs font-bold text-gray-500">합계</td>
             <td colspan="3"></td>
             <td class="px-5 py-3 text-right font-black text-blue-600">
-              ₩ {{ (order.price ?? 0).toLocaleString() }}
+              ₩ {{ calcTotal(order).toLocaleString() }}
             </td>
             <td></td>
           </tr>

--- a/k8s/monitoring/grafana-dashboard-test-backend.json
+++ b/k8s/monitoring/grafana-dashboard-test-backend.json
@@ -1,0 +1,232 @@
+{
+  "title": "Test Backend Overview",
+  "tags": ["test", "spring-boot", "load-test"],
+  "timezone": "browser",
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": { "type": "prometheus" },
+        "query": "label_values(up{job=\"kubernetes-pods\", pod=~\"test-backend.*\"}, instance)",
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "현재 TPS",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "targets": [{ "expr": "sum(rate(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "reqps", "thresholds": { "steps": [{ "color": "blue", "value": null }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "title": "에러율 (%)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "targets": [{ "expr": "sum(rate(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\", status=~\"5..\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[5m])) * 100 or vector(0)", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 2, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 5 }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "title": "CPU 사용률",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "targets": [{ "expr": "avg(process_cpu_usage{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"})", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.5 }, { "color": "red", "value": 0.8 }] } } }
+    },
+    {
+      "title": "힙 메모리 사용률",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "targets": [{ "expr": "sum(jvm_memory_used_bytes{area=\"heap\", job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}) / sum(jvm_memory_max_bytes{area=\"heap\", job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"} > 0) * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 85 }] } } }
+    },
+    {
+      "title": "DB 활성 커넥션",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "targets": [{ "expr": "sum(hikaricp_connections_active{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"})", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "min": 0, "max": 20, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 15 }, { "color": "red", "value": 18 }] } } }
+    },
+    {
+      "title": "서버 가동률",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "targets": [{ "expr": "avg(avg_over_time(up{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[$__range])) * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 2, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 95 }, { "color": "yellow", "value": 99 }, { "color": "green", "value": 99.9 }] } } },
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "auto" }
+    },
+
+    {
+      "title": "HTTP 트래픽",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "HTTP 요청 수 (TPS)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [{ "expr": "sum by (method, uri) (rate(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{method}} {{uri}}" }],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2 } } }
+    },
+    {
+      "title": "응답 시간 (AVG / P95 / P99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        { "expr": "sum by (pod) (rate(http_server_requests_seconds_sum{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[5m])) / sum by (pod) (rate(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "AVG" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[5m])))", "legendFormat": "P95" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[5m])))", "legendFormat": "P99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "5xx 에러",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 14 },
+      "targets": [{ "expr": "sum by (status, uri) (rate(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\", status=~\"5..\"}[5m]))", "legendFormat": "{{status}} {{uri}}" }],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20, "lineWidth": 2 }, "color": { "mode": "fixed", "fixedColor": "red" } } }
+    },
+    {
+      "title": "4xx 클라이언트 에러",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 14 },
+      "targets": [{ "expr": "sum by (status, uri) (rate(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\", status=~\"4..\"}[5m]))", "legendFormat": "{{status}} {{uri}}" }],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20, "lineWidth": 2 }, "color": { "mode": "fixed", "fixedColor": "orange" } } }
+    },
+    {
+      "title": "HTTP 상태코드 분포",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 14 },
+      "targets": [{ "expr": "sum by (status) (increase(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[1h]))", "legendFormat": "{{status}}" }],
+      "fieldConfig": { "defaults": {} },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] }, "pieType": "donut" }
+    },
+
+    {
+      "title": "JVM & 시스템",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "CPU 사용량 추이",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+      "targets": [
+        { "expr": "process_cpu_usage{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}", "legendFormat": "Process CPU" },
+        { "expr": "system_cpu_usage{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}", "legendFormat": "System CPU" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2 } } }
+    },
+    {
+      "title": "힙 메모리 사용량 추이",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "targets": [
+        { "expr": "sum by (id) (jvm_memory_used_bytes{area=\"heap\", job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"})", "legendFormat": "Used - {{id}}" },
+        { "expr": "sum(jvm_memory_max_bytes{area=\"heap\", job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"} > 0)", "legendFormat": "Max" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "GC 일시정지 시간",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "targets": [{ "expr": "sum by (action, cause) (rate(jvm_gc_pause_seconds_sum{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{action}} - {{cause}}" }],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "bars", "fillOpacity": 40, "lineWidth": 1 } } }
+    },
+    {
+      "title": "스레드 수",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "targets": [
+        { "expr": "jvm_threads_live_threads{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}", "legendFormat": "Live" },
+        { "expr": "jvm_threads_daemon_threads{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}", "legendFormat": "Daemon" },
+        { "expr": "jvm_threads_peak_threads{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}", "legendFormat": "Peak" }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+
+    {
+      "title": "DB 커넥션",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "DB 커넥션 풀",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "targets": [
+        { "expr": "hikaricp_connections_active{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}", "legendFormat": "Active" },
+        { "expr": "hikaricp_connections_idle{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}", "legendFormat": "Idle" },
+        { "expr": "hikaricp_connections_pending{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}", "legendFormat": "Pending" },
+        { "expr": "hikaricp_connections_max{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}", "legendFormat": "Max" }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "DB 커넥션 획득 시간",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "targets": [
+        { "expr": "hikaricp_connections_acquire_seconds_max{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}", "legendFormat": "Max 획득 시간" },
+        { "expr": "rate(hikaricp_connections_acquire_seconds_sum{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[5m]) / rate(hikaricp_connections_acquire_seconds_count{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[5m])", "legendFormat": "Avg 획득 시간" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "DB 대기 스레드",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 48 },
+      "targets": [{ "expr": "sum(hikaricp_connections_pending{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"})", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "min": 0, "max": 10, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 5 }] } } }
+    },
+    {
+      "title": "DB 커넥션 타임아웃",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 48 },
+      "targets": [{ "expr": "sum(increase(hikaricp_connections_timeout_total{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}[1h]))", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "title": "Non-Heap 메모리 사용률",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 48 },
+      "targets": [{ "expr": "sum(jvm_memory_used_bytes{area=\"nonheap\", job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"}) / sum(jvm_memory_max_bytes{area=\"nonheap\", job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"} > 0) * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 85 }] } } }
+    },
+    {
+      "title": "디스크 여유 공간",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 48 },
+      "targets": [{ "expr": "disk_free_bytes{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"} / disk_total_bytes{job=\"kubernetes-pods\", pod=~\"test-backend.*\", instance=~\"$instance\"} * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 10 }, { "color": "yellow", "value": 20 }, { "color": "green", "value": 30 }] } } }
+    }
+  ],
+  "schemaVersion": 39
+}


### PR DESCRIPTION
## Summary
- 발주 아이템 수정 시 합계 금액이 음수로 표시되는 버그 수정 및 관련 안정성 개선

## 변경 파일
- `backend/.../orders/OrdersService.java`
- `backend/.../orders/model/Orders.java`
- `backend/src/main/resources/application-dev.yaml`
- `frontend/.../store/StorePendingOrderList.vue`
- `frontend/.../store/StoreOrderConfirmModal.vue`
- `k8s/monitoring/grafana-dashboard-test-backend.json`

## 주요 변경 사항
- 아이템 추가/수정/삭제 시 증분 계산을 아이템 기반 재계산(recalculatePrice)으로 변경
- 발주 확정 시 createdAt을 현재 시간으로 갱신하여 이력 정렬 문제 해결
- 프론트엔드 합계 표시를 아이템 기반 실시간 계산으로 변경 (제안 발주서, 확정 모달)
- Actuator mail health check 비활성화 (Gmail SMTP 반복 로그인 차단 방지)
- Grafana 부하 테스트 백엔드 대시보드 설정 추가

## Test Plan
- [ ] 제안 발주서에서 아이템 수량 변경 시 합계 즉시 반영 확인
- [ ] 아이템 삭제 후 합계가 정확한지 확인
- [ ] 발주 확정 후 이력에서 최신순으로 표시되는지 확인
- [ ] 확정 모달 합계 금액 정확성 확인

## Issue
- Closes #807