### PR TITLE
[Feat] #811 - 통계 도메인 생성 및 실시간 통계 API 6개 구현

### DIFF
--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardController.java
@@ -15,38 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class DashboardController {
     private final DashboardService dashboardService;
 
-    // === 실시간 대시보드 API (부하 테스트용 DB 직접 쿼리 방식) ===
-
-    /**
-     * 오늘 전체 매장 실시간 매출 합계 조회
-     *
-     * @return ResponseEntity 오늘 전체 매출 금액
-     */
-    @GetMapping("/realtime/sales/today")
-    public ResponseEntity<BaseResponse> getTodaySales() {
-        return ResponseEntity.ok(BaseResponse.success(dashboardService.getTodaySales()));
-    }
-
-    /**
-     * 매장별 매출 랭킹 TOP 3 조회
-     *
-     * @return ResponseEntity 매출 상위 매장 3개 (매장명, 매출액)
-     */
-    @GetMapping("/realtime/store/top")
-    public ResponseEntity<BaseResponse> getTopStores() {
-        return ResponseEntity.ok(BaseResponse.success(dashboardService.getTopStores()));
-    }
-
-    /**
-     * 메뉴별 판매 수량 랭킹 TOP 3 조회
-     *
-     * @return ResponseEntity 판매 수량 상위 메뉴 3개 (메뉴명, 판매 수량)
-     */
-    @GetMapping("/realtime/menu/top")
-    public ResponseEntity<BaseResponse> getTopMenus() {
-        return ResponseEntity.ok(BaseResponse.success(dashboardService.getTopMenus()));
-    }
-
     /**
      * 가맹점 현황 KPI 조회
      *

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/DashboardService.java
@@ -15,8 +15,6 @@ import com.example.nexus.domain.delivery.model.Delivery;
 import com.example.nexus.domain.head.HeadInventoryRepository;
 import com.example.nexus.domain.head.model.HeadInventory;
 import com.example.nexus.domain.orders.OrdersRepository;
-import com.example.nexus.domain.pos.PosOrdersItemRepository;
-import com.example.nexus.domain.pos.PosPayRepository;
 import com.example.nexus.domain.store.StoreRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -35,47 +33,6 @@ public class DashboardService {
     private final OrdersRepository ordersRepository;
     private final HeadInventoryRepository headInventoryRepository;
     private final DeliveryRepository deliveryRepository;
-    private final PosPayRepository posPayRepository;
-    private final PosOrdersItemRepository posOrdersItemRepository;
-
-    // 실시간 대시보드: 오늘 전체 매출 합계
-    public DashboardDto.RealtimeSalesRes getTodaySales() {
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = start.plusDays(1);
-        long total = posPayRepository.sumTodaySales(start, end);
-        return DashboardDto.RealtimeSalesRes.builder().todaySales(total).build();
-    }
-
-    // 실시간 대시보드: 매장별 매출 랭킹 TOP 3
-    public DashboardDto.RankingRes getTopStores() {
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = start.plusDays(1);
-        List<Object[]> rows = posPayRepository.findTopStoresByPeriod(start, end, PageRequest.of(0, 3));
-        List<DashboardDto.RankingItem> items = rows.stream()
-                .map(r -> DashboardDto.RankingItem.builder()
-                        .idx((Long) r[0])
-                        .name((String) r[1])
-                        .score((Long) r[2])
-                        .build())
-                .toList();
-        return DashboardDto.RankingRes.builder().rankings(items).build();
-    }
-
-    // 실시간 대시보드: 메뉴별 판매 수량 랭킹 TOP 3
-    public DashboardDto.RankingRes getTopMenus() {
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = start.plusDays(1);
-        List<Object[]> rows = posOrdersItemRepository.findTopMenusByPeriod(start, end, PageRequest.of(0, 3));
-        List<DashboardDto.RankingItem> items = rows.stream()
-                .map(r -> DashboardDto.RankingItem.builder()
-                        .idx((Long) r[0])
-                        .name((String) r[1])
-                        .score((Long) r[2])
-                        .build())
-                .toList();
-        return DashboardDto.RankingRes.builder().rankings(items).build();
-    }
-
     // 본사 대시보드 입점 매장 카드 데이터 조회 메서드
     public DashboardDto.StoreKpiRes getStoreKpi() {
 

--- a/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/dashboard/model/DashboardDto.java
@@ -122,24 +122,4 @@ public class DashboardDto {
         private boolean hasNext;
     }
 
-    // 실시간 대시보드 DTO
-    @Getter
-    @Builder
-    public static class RealtimeSalesRes {
-        private long todaySales;
-    }
-
-    @Getter
-    @Builder
-    public static class RankingItem {
-        private Long idx;
-        private String name;
-        private long score;
-    }
-
-    @Getter
-    @Builder
-    public static class RankingRes {
-        private List<RankingItem> rankings;
-    }
 }

--- a/backend/src/main/java/com/example/nexus/domain/statistics/StatisticsController.java
+++ b/backend/src/main/java/com/example/nexus/domain/statistics/StatisticsController.java
@@ -1,0 +1,75 @@
+package com.example.nexus.domain.statistics;
+
+import com.example.nexus.common.model.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/statistics")
+@RequiredArgsConstructor
+public class StatisticsController {
+    private final StatisticsService statisticsService;
+
+    /**
+     * 오늘 실시간 총 매출 조회
+     *
+     * @return ResponseEntity 오늘 전체 매출 금액
+     */
+    @GetMapping("/sales/today")
+    public ResponseEntity<BaseResponse> getTodaySales() {
+        return ResponseEntity.ok(BaseResponse.success(statisticsService.getTodaySales()));
+    }
+
+    /**
+     * 매장 매출 랭킹 TOP 5 조회
+     *
+     * @return ResponseEntity 매출 상위 매장 5개 (매장명, 매출액)
+     */
+    @GetMapping("/store/top")
+    public ResponseEntity<BaseResponse> getTopStores() {
+        return ResponseEntity.ok(BaseResponse.success(statisticsService.getTopStores()));
+    }
+
+    /**
+     * 인기 메뉴 TOP 5 조회
+     *
+     * @return ResponseEntity 판매 수량 상위 메뉴 5개 (메뉴명, 판매 수량)
+     */
+    @GetMapping("/menu/top")
+    public ResponseEntity<BaseResponse> getTopMenus() {
+        return ResponseEntity.ok(BaseResponse.success(statisticsService.getTopMenus()));
+    }
+
+    /**
+     * 시간대별 매출 추이 조회 (0~23시)
+     *
+     * @return ResponseEntity 시간대별 매출 금액 리스트
+     */
+    @GetMapping("/sales/hourly")
+    public ResponseEntity<BaseResponse> getHourlySales() {
+        return ResponseEntity.ok(BaseResponse.success(statisticsService.getHourlySales()));
+    }
+
+    /**
+     * 카테고리별 매출 비율 조회
+     *
+     * @return ResponseEntity 메뉴 카테고리별 매출 금액 리스트
+     */
+    @GetMapping("/category/ratio")
+    public ResponseEntity<BaseResponse> getCategoryRatio() {
+        return ResponseEntity.ok(BaseResponse.success(statisticsService.getCategoryRatio()));
+    }
+
+    /**
+     * 결제 수단별 매출 비율 조회
+     *
+     * @return ResponseEntity 결제 수단별 매출 금액 리스트
+     */
+    @GetMapping("/payment/ratio")
+    public ResponseEntity<BaseResponse> getPaymentMethodRatio() {
+        return ResponseEntity.ok(BaseResponse.success(statisticsService.getPaymentMethodRatio()));
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/statistics/StatisticsRepository.java
+++ b/backend/src/main/java/com/example/nexus/domain/statistics/StatisticsRepository.java
@@ -1,0 +1,61 @@
+package com.example.nexus.domain.statistics;
+
+import com.example.nexus.domain.pos.model.PosPay;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface StatisticsRepository extends JpaRepository<PosPay, Long> {
+
+    // 오늘 총 매출
+    @Query("SELECT COALESCE(SUM(p.payAmount), 0) FROM PosPay p WHERE p.paidAt >= :start AND p.paidAt < :end")
+    long sumTodaySales(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    // 매장별 매출 랭킹
+    @Query("SELECT p.store.idx, p.store.storeName, SUM(p.payAmount) " +
+            "FROM PosPay p " +
+            "WHERE p.paidAt >= :start AND p.paidAt < :end " +
+            "GROUP BY p.store.idx, p.store.storeName " +
+            "ORDER BY SUM(p.payAmount) DESC")
+    List<Object[]> findTopStores(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end, Pageable pageable);
+
+    // 인기 메뉴 랭킹 (판매 수량 기준)
+    @Query("SELECT m.idx, m.menuName, SUM(poi.quantity) " +
+            "FROM PosOrdersItem poi " +
+            "JOIN poi.menu m " +
+            "JOIN poi.posPay p " +
+            "WHERE p.paidAt >= :start AND p.paidAt < :end " +
+            "GROUP BY m.idx, m.menuName " +
+            "ORDER BY SUM(poi.quantity) DESC")
+    List<Object[]> findTopMenus(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end, Pageable pageable);
+
+    // 시간대별 매출 추이
+    @Query("SELECT HOUR(p.paidAt), COALESCE(SUM(p.payAmount), 0) " +
+            "FROM PosPay p " +
+            "WHERE p.paidAt >= :start AND p.paidAt < :end " +
+            "GROUP BY HOUR(p.paidAt) " +
+            "ORDER BY HOUR(p.paidAt)")
+    List<Object[]> findHourlySales(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    // 카테고리별 매출 비율
+    @Query("SELECT mc.menuCategoryName, COALESCE(SUM(poi.quantity * m.price), 0) " +
+            "FROM PosOrdersItem poi " +
+            "JOIN poi.menu m " +
+            "JOIN m.menuCategory mc " +
+            "JOIN poi.posPay p " +
+            "WHERE p.paidAt >= :start AND p.paidAt < :end " +
+            "GROUP BY mc.menuCategoryName " +
+            "ORDER BY SUM(poi.quantity * m.price) DESC")
+    List<Object[]> findSalesByCategory(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    // 결제 수단별 매출 비율
+    @Query("SELECT p.method, COALESCE(SUM(p.payAmount), 0) " +
+            "FROM PosPay p " +
+            "WHERE p.paidAt >= :start AND p.paidAt < :end " +
+            "GROUP BY p.method")
+    List<Object[]> findSalesByPayMethod(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+}

--- a/backend/src/main/java/com/example/nexus/domain/statistics/StatisticsService.java
+++ b/backend/src/main/java/com/example/nexus/domain/statistics/StatisticsService.java
@@ -1,0 +1,91 @@
+package com.example.nexus.domain.statistics;
+
+import com.example.nexus.common.enums.PosPayMethod;
+import com.example.nexus.domain.statistics.model.StatisticsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+    private final StatisticsRepository statisticsRepository;
+
+    public StatisticsDto.TodaySalesRes getTodaySales() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+        long total = statisticsRepository.sumTodaySales(start, end);
+        return StatisticsDto.TodaySalesRes.builder().todaySales(total).build();
+    }
+
+    public StatisticsDto.RankingRes getTopStores() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+        List<Object[]> rows = statisticsRepository.findTopStores(start, end, PageRequest.of(0, 5));
+        List<StatisticsDto.RankingItem> items = rows.stream()
+                .map(r -> StatisticsDto.RankingItem.builder()
+                        .idx((Long) r[0])
+                        .name((String) r[1])
+                        .score((Long) r[2])
+                        .build())
+                .toList();
+        return StatisticsDto.RankingRes.builder().rankings(items).build();
+    }
+
+    public StatisticsDto.RankingRes getTopMenus() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+        List<Object[]> rows = statisticsRepository.findTopMenus(start, end, PageRequest.of(0, 5));
+        List<StatisticsDto.RankingItem> items = rows.stream()
+                .map(r -> StatisticsDto.RankingItem.builder()
+                        .idx((Long) r[0])
+                        .name((String) r[1])
+                        .score((Long) r[2])
+                        .build())
+                .toList();
+        return StatisticsDto.RankingRes.builder().rankings(items).build();
+    }
+
+    public StatisticsDto.HourlySalesRes getHourlySales() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+        List<Object[]> rows = statisticsRepository.findHourlySales(start, end);
+        List<StatisticsDto.HourlySalesItem> items = rows.stream()
+                .map(r -> StatisticsDto.HourlySalesItem.builder()
+                        .hour((Integer) r[0])
+                        .sales((Long) r[1])
+                        .build())
+                .toList();
+        return StatisticsDto.HourlySalesRes.builder().hourlyData(items).build();
+    }
+
+    public StatisticsDto.RatioRes getCategoryRatio() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+        List<Object[]> rows = statisticsRepository.findSalesByCategory(start, end);
+        List<StatisticsDto.RatioItem> items = rows.stream()
+                .map(r -> StatisticsDto.RatioItem.builder()
+                        .name((String) r[0])
+                        .amount((Long) r[1])
+                        .build())
+                .toList();
+        return StatisticsDto.RatioRes.builder().ratios(items).build();
+    }
+
+    public StatisticsDto.RatioRes getPaymentMethodRatio() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+        List<Object[]> rows = statisticsRepository.findSalesByPayMethod(start, end);
+        List<StatisticsDto.RatioItem> items = rows.stream()
+                .map(r -> StatisticsDto.RatioItem.builder()
+                        .name(((PosPayMethod) r[0]).name())
+                        .amount((Long) r[1])
+                        .build())
+                .toList();
+        return StatisticsDto.RatioRes.builder().ratios(items).build();
+    }
+}

--- a/backend/src/main/java/com/example/nexus/domain/statistics/model/StatisticsDto.java
+++ b/backend/src/main/java/com/example/nexus/domain/statistics/model/StatisticsDto.java
@@ -1,0 +1,55 @@
+package com.example.nexus.domain.statistics.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+public class StatisticsDto {
+
+    @Getter
+    @Builder
+    public static class TodaySalesRes {
+        private long todaySales;
+    }
+
+    @Getter
+    @Builder
+    public static class RankingItem {
+        private Long idx;
+        private String name;
+        private long score;
+    }
+
+    @Getter
+    @Builder
+    public static class RankingRes {
+        private List<RankingItem> rankings;
+    }
+
+    @Getter
+    @Builder
+    public static class HourlySalesItem {
+        private int hour;
+        private long sales;
+    }
+
+    @Getter
+    @Builder
+    public static class HourlySalesRes {
+        private List<HourlySalesItem> hourlyData;
+    }
+
+    @Getter
+    @Builder
+    public static class RatioItem {
+        private String name;
+        private long amount;
+    }
+
+    @Getter
+    @Builder
+    public static class RatioRes {
+        private List<RatioItem> ratios;
+    }
+}


### PR DESCRIPTION
## Summary
- 대시보드에 임시로 구현되어 있던 실시간 API 3개를 제거하고, 통계(Statistics) 도메인을 신규 생성하여 6개 API로 확장 구현                                                                                                          
                                                                                                                                                                                                                                
## 변경 파일
- `domain/dashboard/DashboardController.java` — realtime API 3개 제거
- `domain/dashboard/DashboardService.java` — realtime 메서드 및 의존성 제거
- `domain/dashboard/model/DashboardDto.java` — realtime DTO 제거
- `domain/statistics/StatisticsController.java` — 신규 생성
- `domain/statistics/StatisticsService.java` — 신규 생성
- `domain/statistics/StatisticsRepository.java` — 신규 생성
- `domain/statistics/model/StatisticsDto.java` — 신규 생성

## 주요 변경 사항
- Statistics 도메인 패키지 구조 생성 (Controller, Service, Repository, DTO)
- 실시간 통계 API 6개 구현 (모놀리식 DB 직접 쿼리 방식 — 개선 전 상태)
- GET /statistics/sales/today (오늘 총 매출)
- GET /statistics/store/top (매장 매출 랭킹 TOP 5)
- GET /statistics/menu/top (인기 메뉴 TOP 5)
- GET /statistics/sales/hourly (시간대별 매출 추이)
- GET /statistics/category/ratio (카테고리별 매출 비율)
- GET /statistics/payment/ratio (결제 수단별 매출 비율)
- DashboardController에서 realtime 관련 코드 완전 제거

## Test Plan
- [ ] 6개 API 정상 응답 확인 (Postman/Swagger)
- [ ] 빌드 성공 확인 (compileJava)

## Issue
- Closes #811, Closes #812, Closes #813, Closes #814, Closes #815, Closes #816