### PR TITLE
[Feat] #817 - 실시간 통계 프론트엔드 페이지 구현      

### DIFF
--- a/frontend/src/api/statistics/index.js
+++ b/frontend/src/api/statistics/index.js
@@ -1,0 +1,13 @@
+import api from '@/plugins/axiosinterceptor'
+
+export const getTodaySales = () => api.get('/statistics/sales/today')
+
+export const getTopStores = () => api.get('/statistics/store/top')
+
+export const getTopMenus = () => api.get('/statistics/menu/top')
+
+export const getHourlySales = () => api.get('/statistics/sales/hourly')
+
+export const getCategoryRatio = () => api.get('/statistics/category/ratio')
+
+export const getPaymentRatio = () => api.get('/statistics/payment/ratio')

--- a/frontend/src/components/common/SideBar.vue
+++ b/frontend/src/components/common/SideBar.vue
@@ -40,7 +40,13 @@ const adminMenus = [
   { path: '/delivery',   name: '배송 관리', icon: Truck },
   { path: '/settlement', name: '정산 관리', icon: Calculator },
   { path: '/admin-account', name: '계정 관리', icon: UserPlus },
-  { path: '/statistics/esg', name: 'ESG 대시보드', icon: BarChart3 },
+  {
+    path: '/statistics', name: '통계', icon: BarChart3,
+    children: [
+      { path: '/statistics', name: '실시간 통계' },
+      { path: '/statistics/esg', name: 'ESG 대시보드' },
+    ],
+  },
   { path: '/report', name: '보고서', icon: FileText },
   { path: '/notification', name: '알림', icon: Bell },
 ]

--- a/frontend/src/components/statistics/CategoryRatioChart.vue
+++ b/frontend/src/components/statistics/CategoryRatioChart.vue
@@ -1,0 +1,90 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import { Chart } from 'chart.js/auto'
+import { getCategoryRatio } from '@/api/statistics'
+
+const doughnutCanvas = ref(null)
+let chartInstance = null
+let polling = null
+
+const COLORS = ['#f97316', '#fb923c', '#fdba74', '#fed7aa', '#ffedd5', '#fff7ed', '#9ca3af']
+
+const fetchAndRender = async () => {
+  try {
+    const { data } = await getCategoryRatio()
+    const ratios = data.result.ratios
+
+    const labels = ratios.map((r) => r.name)
+    const amounts = ratios.map((r) => r.amount)
+
+    if (chartInstance) {
+      chartInstance.data.labels = labels
+      chartInstance.data.datasets[0].data = amounts
+      chartInstance.update('none')
+      return
+    }
+
+    chartInstance = new Chart(doughnutCanvas.value, {
+      type: 'doughnut',
+      data: {
+        labels,
+        datasets: [
+          {
+            data: amounts,
+            backgroundColor: COLORS.slice(0, labels.length),
+            borderWidth: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: '60%',
+        plugins: {
+          legend: {
+            position: 'right',
+            labels: { color: '#6b7280', font: { size: 12 }, padding: 12 },
+          },
+          tooltip: {
+            backgroundColor: '#1f2937',
+            titleColor: '#f9fafb',
+            bodyColor: '#d1d5db',
+            padding: 10,
+            cornerRadius: 10,
+            callbacks: {
+              label: (ctx) => ` ₩ ${ctx.parsed.toLocaleString('ko-KR')}`,
+            },
+          },
+        },
+      },
+    })
+  } catch (e) {
+    console.error('카테고리별 매출 조회 실패', e)
+  }
+}
+
+onMounted(() => {
+  fetchAndRender()
+  polling = setInterval(fetchAndRender, 2000)
+})
+
+onUnmounted(() => {
+  if (polling) clearInterval(polling)
+  if (chartInstance) {
+    chartInstance.destroy()
+    chartInstance = null
+  }
+})
+</script>
+
+<template>
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col" style="min-height:280px">
+    <div class="mb-4 shrink-0">
+      <h2 class="font-bold text-gray-900">카테고리별 매출</h2>
+      <p class="text-xs text-gray-400 mt-0.5">오늘 메뉴 카테고리 기준</p>
+    </div>
+    <div class="flex-1 min-h-0 relative" style="height:200px">
+      <canvas ref="doughnutCanvas" style="display:block; width:100%; height:100%;"></canvas>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/statistics/HourlySalesChart.vue
+++ b/frontend/src/components/statistics/HourlySalesChart.vue
@@ -1,0 +1,106 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import { Chart } from 'chart.js/auto'
+import { getHourlySales } from '@/api/statistics'
+
+const barCanvas = ref(null)
+let chartInstance = null
+let polling = null
+
+const fetchAndRender = async () => {
+  try {
+    const { data } = await getHourlySales()
+    const hourlyData = data.result.hourlyData
+
+    const labels = Array.from({ length: 24 }, (_, i) => `${i}시`)
+    const salesByHour = new Array(24).fill(0)
+    hourlyData.forEach((item) => {
+      salesByHour[item.hour] = item.sales
+    })
+
+    if (chartInstance) {
+      chartInstance.data.datasets[0].data = salesByHour
+      chartInstance.update('none')
+      return
+    }
+
+    chartInstance = new Chart(barCanvas.value, {
+      type: 'bar',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: '매출',
+            data: salesByHour,
+            backgroundColor: 'rgba(249,115,22,0.7)',
+            borderRadius: 4,
+            barPercentage: 0.6,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            backgroundColor: '#1f2937',
+            titleColor: '#f9fafb',
+            bodyColor: '#d1d5db',
+            padding: 10,
+            cornerRadius: 10,
+            callbacks: {
+              label: (ctx) => ` ₩ ${ctx.parsed.y.toLocaleString('ko-KR')}`,
+            },
+          },
+        },
+        scales: {
+          x: {
+            grid: { display: false },
+            ticks: { color: '#9ca3af', font: { size: 11 } },
+            border: { display: false },
+          },
+          y: {
+            min: 0,
+            grid: { color: '#f3f4f6' },
+            ticks: {
+              color: '#9ca3af',
+              font: { size: 11 },
+              callback: (v) => `₩${(v / 10000).toFixed(0)}만`,
+            },
+            border: { display: false },
+          },
+        },
+      },
+    })
+  } catch (e) {
+    console.error('시간대별 매출 조회 실패', e)
+  }
+}
+
+onMounted(() => {
+  fetchAndRender()
+  polling = setInterval(fetchAndRender, 2000)
+})
+
+onUnmounted(() => {
+  if (polling) clearInterval(polling)
+  if (chartInstance) {
+    chartInstance.destroy()
+    chartInstance = null
+  }
+})
+</script>
+
+<template>
+  <div class="col-span-full bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col"
+    style="min-height:300px">
+    <div class="mb-5 shrink-0">
+      <h2 class="font-bold text-gray-900">시간대별 매출 추이</h2>
+      <p class="text-xs text-gray-400 mt-0.5">오늘 0시~23시 (단위: 원)</p>
+    </div>
+    <div class="flex-1 min-h-0 relative" style="height:220px">
+      <canvas ref="barCanvas" style="display:block; width:100%; height:100%;"></canvas>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/statistics/MenuRankingList.vue
+++ b/frontend/src/components/statistics/MenuRankingList.vue
@@ -1,0 +1,47 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import { getTopMenus } from '@/api/statistics'
+
+const rankings = ref([])
+let polling = null
+
+const fetchData = async () => {
+  try {
+    const { data } = await getTopMenus()
+    rankings.value = data.result.rankings
+  } catch (e) {
+    console.error('메뉴 랭킹 조회 실패', e)
+  }
+}
+
+onMounted(() => {
+  fetchData()
+  polling = setInterval(fetchData, 2000)
+})
+
+onUnmounted(() => {
+  if (polling) clearInterval(polling)
+})
+
+const formatted = (val) => val.toLocaleString('ko-KR')
+</script>
+
+<template>
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col" style="min-height:280px">
+    <h2 class="font-bold text-gray-900 mb-1">인기 메뉴 TOP 5</h2>
+    <p class="text-xs text-gray-400 mb-4">오늘 판매 수량 기준</p>
+    <ul class="space-y-3 flex-1">
+      <li v-for="(item, i) in rankings" :key="item.idx" class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <span class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
+            :class="i < 3 ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-500'">
+            {{ i + 1 }}
+          </span>
+          <span class="text-sm font-medium text-gray-800">{{ item.name }}</span>
+        </div>
+        <span class="text-sm font-semibold text-gray-600">{{ formatted(item.score) }}잔</span>
+      </li>
+      <li v-if="rankings.length === 0" class="text-sm text-gray-400 text-center py-4">데이터 없음</li>
+    </ul>
+  </div>
+</template>

--- a/frontend/src/components/statistics/PaymentRatioChart.vue
+++ b/frontend/src/components/statistics/PaymentRatioChart.vue
@@ -1,0 +1,95 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import { Chart } from 'chart.js/auto'
+import { getPaymentRatio } from '@/api/statistics'
+
+const doughnutCanvas = ref(null)
+let chartInstance = null
+let polling = null
+
+const COLORS = ['#3b82f6', '#60a5fa', '#93c5fd', '#bfdbfe', '#9ca3af']
+
+const LABEL_MAP = {
+  CARD: '카드',
+  CASH: '현금',
+}
+
+const fetchAndRender = async () => {
+  try {
+    const { data } = await getPaymentRatio()
+    const ratios = data.result.ratios
+
+    const labels = ratios.map((r) => LABEL_MAP[r.name] || r.name)
+    const amounts = ratios.map((r) => r.amount)
+
+    if (chartInstance) {
+      chartInstance.data.labels = labels
+      chartInstance.data.datasets[0].data = amounts
+      chartInstance.update('none')
+      return
+    }
+
+    chartInstance = new Chart(doughnutCanvas.value, {
+      type: 'doughnut',
+      data: {
+        labels,
+        datasets: [
+          {
+            data: amounts,
+            backgroundColor: COLORS.slice(0, labels.length),
+            borderWidth: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: '60%',
+        plugins: {
+          legend: {
+            position: 'right',
+            labels: { color: '#6b7280', font: { size: 12 }, padding: 12 },
+          },
+          tooltip: {
+            backgroundColor: '#1f2937',
+            titleColor: '#f9fafb',
+            bodyColor: '#d1d5db',
+            padding: 10,
+            cornerRadius: 10,
+            callbacks: {
+              label: (ctx) => ` ₩ ${ctx.parsed.toLocaleString('ko-KR')}`,
+            },
+          },
+        },
+      },
+    })
+  } catch (e) {
+    console.error('결제 수단별 매출 조회 실패', e)
+  }
+}
+
+onMounted(() => {
+  fetchAndRender()
+  polling = setInterval(fetchAndRender, 2000)
+})
+
+onUnmounted(() => {
+  if (polling) clearInterval(polling)
+  if (chartInstance) {
+    chartInstance.destroy()
+    chartInstance = null
+  }
+})
+</script>
+
+<template>
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col" style="min-height:280px">
+    <div class="mb-4 shrink-0">
+      <h2 class="font-bold text-gray-900">결제 수단별 매출</h2>
+      <p class="text-xs text-gray-400 mt-0.5">오늘 결제 방법 기준</p>
+    </div>
+    <div class="flex-1 min-h-0 relative" style="height:200px">
+      <canvas ref="doughnutCanvas" style="display:block; width:100%; height:100%;"></canvas>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/statistics/StoreRankingList.vue
+++ b/frontend/src/components/statistics/StoreRankingList.vue
@@ -1,0 +1,47 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import { getTopStores } from '@/api/statistics'
+
+const rankings = ref([])
+let polling = null
+
+const fetchData = async () => {
+  try {
+    const { data } = await getTopStores()
+    rankings.value = data.result.rankings
+  } catch (e) {
+    console.error('매장 랭킹 조회 실패', e)
+  }
+}
+
+onMounted(() => {
+  fetchData()
+  polling = setInterval(fetchData, 2000)
+})
+
+onUnmounted(() => {
+  if (polling) clearInterval(polling)
+})
+
+const formatted = (val) => val.toLocaleString('ko-KR')
+</script>
+
+<template>
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col" style="min-height:280px">
+    <h2 class="font-bold text-gray-900 mb-1">매장 매출 TOP 5</h2>
+    <p class="text-xs text-gray-400 mb-4">오늘 매출 기준</p>
+    <ul class="space-y-3 flex-1">
+      <li v-for="(item, i) in rankings" :key="item.idx" class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <span class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
+            :class="i < 3 ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-500'">
+            {{ i + 1 }}
+          </span>
+          <span class="text-sm font-medium text-gray-800">{{ item.name }}</span>
+        </div>
+        <span class="text-sm font-semibold text-gray-600">₩ {{ formatted(item.score) }}</span>
+      </li>
+      <li v-if="rankings.length === 0" class="text-sm text-gray-400 text-center py-4">데이터 없음</li>
+    </ul>
+  </div>
+</template>

--- a/frontend/src/components/statistics/TodaySalesCard.vue
+++ b/frontend/src/components/statistics/TodaySalesCard.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import { getTodaySales } from '@/api/statistics'
+
+const todaySales = ref(0)
+let polling = null
+
+const fetchData = async () => {
+  try {
+    const { data } = await getTodaySales()
+    todaySales.value = data.result.todaySales
+  } catch (e) {
+    console.error('매출 조회 실패', e)
+  }
+}
+
+onMounted(() => {
+  fetchData()
+  polling = setInterval(fetchData, 2000)
+})
+
+onUnmounted(() => {
+  if (polling) clearInterval(polling)
+})
+
+const formatted = (val) => val.toLocaleString('ko-KR')
+</script>
+
+<template>
+  <div class="col-span-full bg-white rounded-2xl border border-gray-200 shadow-sm p-6">
+    <p class="text-[11px] font-semibold text-gray-400 uppercase tracking-[0.14em]">오늘 실시간 총 매출</p>
+    <div class="flex items-end gap-2 mt-3">
+      <p class="text-[36px] leading-none font-extrabold text-gray-900 tracking-tight">₩ {{ formatted(todaySales) }}</p>
+    </div>
+    <p class="text-xs text-gray-400 mt-2">2초 간격 실시간 갱신</p>
+  </div>
+</template>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -23,6 +23,12 @@ const router = createRouter({
       meta: { role: 'ADMIN' },
     },
     {
+      path: '/statistics',
+      name: 'statistics',
+      component: () => import('@/views/hq/StatisticsView.vue'),
+      meta: { role: 'ADMIN' },
+    },
+    {
       path: '/statistics/esg',
       name: 'statisticsEsg',
       component: () => import('@/views/hq/EsgDashboardView.vue'),

--- a/frontend/src/views/hq/StatisticsView.vue
+++ b/frontend/src/views/hq/StatisticsView.vue
@@ -1,0 +1,46 @@
+<script setup>
+import { computed } from 'vue'
+import TodaySalesCard from '@/components/statistics/TodaySalesCard.vue'
+import StoreRankingList from '@/components/statistics/StoreRankingList.vue'
+import MenuRankingList from '@/components/statistics/MenuRankingList.vue'
+import HourlySalesChart from '@/components/statistics/HourlySalesChart.vue'
+import CategoryRatioChart from '@/components/statistics/CategoryRatioChart.vue'
+import PaymentRatioChart from '@/components/statistics/PaymentRatioChart.vue'
+
+const today = computed(() =>
+  new Date().toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric', weekday: 'short' }),
+)
+</script>
+
+<template>
+  <div class="flex-1 overflow-auto p-5 space-y-4">
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h1 class="text-[22px] font-bold text-gray-900 tracking-tight">실시간 통계</h1>
+      </div>
+      <span class="text-xs text-gray-400 border border-gray-200 px-3 py-1.5 rounded-md bg-white">{{ today }}</span>
+    </div>
+
+    <!-- 총 매출 KPI -->
+    <div class="grid grid-cols-1">
+      <TodaySalesCard />
+    </div>
+
+    <!-- 랭킹 -->
+    <div class="grid grid-cols-2 gap-4">
+      <StoreRankingList />
+      <MenuRankingList />
+    </div>
+
+    <!-- 시간대별 매출 차트 -->
+    <div class="grid grid-cols-1">
+      <HourlySalesChart />
+    </div>
+
+    <!-- 비율 차트 -->
+    <div class="grid grid-cols-2 gap-4">
+      <CategoryRatioChart />
+      <PaymentRatioChart />
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- 실시간 통계 페이지 프론트엔드 구현 (6개 컴포넌트 + 라우터 + 사이드바)                                                                                                                                                           
- 모놀리식 1단계: 2초 간격 polling 방식 (개선 전 상태)                                                                                                                                                                            

## 변경 파일
- `frontend/src/api/statistics/index.js` — 통계 API 호출 모듈 신규 생성
- `frontend/src/components/statistics/TodaySalesCard.vue` — 총 매출 KPI 카드
- `frontend/src/components/statistics/StoreRankingList.vue` — 매장 매출 랭킹 TOP 5
- `frontend/src/components/statistics/MenuRankingList.vue` — 인기 메뉴 TOP 5
- `frontend/src/components/statistics/HourlySalesChart.vue` — 시간대별 매출 바 차트
- `frontend/src/components/statistics/CategoryRatioChart.vue` — 카테고리별 도넛 차트
- `frontend/src/components/statistics/PaymentRatioChart.vue` — 결제 수단별 도넛 차트
- `frontend/src/views/hq/StatisticsView.vue` — 통계 페이지
- `frontend/src/router/index.js` — /statistics 라우트 추가
- `frontend/src/components/common/SideBar.vue` — 통계 메뉴 그룹 추가

## 주요 변경 사항
- 통계 API 6개 호출 함수 구현 (매출, 매장 랭킹, 메뉴 랭킹, 시간대별, 카테고리별, 결제수단별)
- Chart.js 기반 차트 컴포넌트 3개 (바 차트 1, 도넛 차트 2)
- 랭킹 리스트 컴포넌트 2개, KPI 카드 1개
- 모든 컴포넌트 2초 간격 setInterval polling으로 실시간 갱신
- 사이드바에 통계 드롭다운 메뉴 추가 (실시간 통계 + ESG 대시보드)

## Test Plan
- [ ] /statistics 페이지 접근 확인
- [ ] 6개 컴포넌트 정상 렌더링 확인
- [ ] 백엔드 API 연동 시 데이터 표시 확인
- [ ] 프론트엔드 빌드 성공 확인

## Issue
- Closes #817 
- Closes #818 
- Closes #819 
- Closes #820 
- Closes #821 
- Closes #822