### PR TITLE
[Feat] #825 - 통계 페이지 실시간 데이터 애니메이션 적용

### DIFF
--- a/frontend/src/components/statistics/AnimatedScore.vue
+++ b/frontend/src/components/statistics/AnimatedScore.vue
@@ -1,0 +1,19 @@
+<script setup>
+import { toRef } from 'vue'
+import { useAnimatedNumber } from '@/composables/useAnimatedNumber'
+
+const props = defineProps({
+  value: { type: Number, required: true },
+  suffix: { type: String, default: '' },
+  prefix: { type: String, default: '' },
+})
+
+const source = toRef(props, 'value')
+const display = useAnimatedNumber(source)
+
+const formatted = (val) => val.toLocaleString('ko-KR')
+</script>
+
+<template>
+  <span>{{ prefix }}{{ formatted(display) }}{{ suffix }}</span>
+</template>

--- a/frontend/src/components/statistics/CategoryRatioChart.vue
+++ b/frontend/src/components/statistics/CategoryRatioChart.vue
@@ -20,7 +20,7 @@ const fetchAndRender = async () => {
     if (chartInstance) {
       chartInstance.data.labels = labels
       chartInstance.data.datasets[0].data = amounts
-      chartInstance.update('none')
+      chartInstance.update()
       return
     }
 

--- a/frontend/src/components/statistics/HourlySalesChart.vue
+++ b/frontend/src/components/statistics/HourlySalesChart.vue
@@ -20,7 +20,7 @@ const fetchAndRender = async () => {
 
     if (chartInstance) {
       chartInstance.data.datasets[0].data = salesByHour
-      chartInstance.update('none')
+      chartInstance.update()
       return
     }
 

--- a/frontend/src/components/statistics/MenuRankingList.vue
+++ b/frontend/src/components/statistics/MenuRankingList.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue'
 import { getTopMenus } from '@/api/statistics'
+import AnimatedScore from '@/components/statistics/AnimatedScore.vue'
 
 const rankings = ref([])
 let polling = null
@@ -22,16 +23,14 @@ onMounted(() => {
 onUnmounted(() => {
   if (polling) clearInterval(polling)
 })
-
-const formatted = (val) => val.toLocaleString('ko-KR')
 </script>
 
 <template>
   <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col" style="min-height:280px">
     <h2 class="font-bold text-gray-900 mb-1">인기 메뉴 TOP 5</h2>
     <p class="text-xs text-gray-400 mb-4">오늘 판매 수량 기준</p>
-    <ul class="space-y-3 flex-1">
-      <li v-for="(item, i) in rankings" :key="item.idx" class="flex items-center justify-between">
+    <TransitionGroup tag="ul" name="rank" class="space-y-3 flex-1 relative">
+      <li v-for="(item, i) in rankings" :key="item.idx" class="flex items-center justify-between rank-item">
         <div class="flex items-center gap-3">
           <span class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
             :class="i < 3 ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-500'">
@@ -39,9 +38,35 @@ const formatted = (val) => val.toLocaleString('ko-KR')
           </span>
           <span class="text-sm font-medium text-gray-800">{{ item.name }}</span>
         </div>
-        <span class="text-sm font-semibold text-gray-600">{{ formatted(item.score) }}잔</span>
+        <span class="text-sm font-semibold text-gray-600">
+          <AnimatedScore :value="item.score" suffix="잔" />
+        </span>
       </li>
-      <li v-if="rankings.length === 0" class="text-sm text-gray-400 text-center py-4">데이터 없음</li>
-    </ul>
+      <li v-if="rankings.length === 0" key="empty" class="text-sm text-gray-400 text-center py-4">데이터 없음</li>
+    </TransitionGroup>
   </div>
 </template>
+
+<style scoped>
+.rank-item {
+  transition: all 0.5s ease;
+}
+.rank-move {
+  transition: transform 0.5s ease;
+}
+.rank-enter-active {
+  transition: all 0.3s ease;
+}
+.rank-leave-active {
+  transition: all 0.3s ease;
+  position: absolute;
+}
+.rank-enter-from {
+  opacity: 0;
+  transform: translateX(30px);
+}
+.rank-leave-to {
+  opacity: 0;
+  transform: translateX(-30px);
+}
+</style>

--- a/frontend/src/components/statistics/PaymentRatioChart.vue
+++ b/frontend/src/components/statistics/PaymentRatioChart.vue
@@ -25,7 +25,7 @@ const fetchAndRender = async () => {
     if (chartInstance) {
       chartInstance.data.labels = labels
       chartInstance.data.datasets[0].data = amounts
-      chartInstance.update('none')
+      chartInstance.update()
       return
     }
 

--- a/frontend/src/components/statistics/StoreRankingList.vue
+++ b/frontend/src/components/statistics/StoreRankingList.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue'
 import { getTopStores } from '@/api/statistics'
+import AnimatedScore from '@/components/statistics/AnimatedScore.vue'
 
 const rankings = ref([])
 let polling = null
@@ -22,16 +23,14 @@ onMounted(() => {
 onUnmounted(() => {
   if (polling) clearInterval(polling)
 })
-
-const formatted = (val) => val.toLocaleString('ko-KR')
 </script>
 
 <template>
   <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col" style="min-height:280px">
     <h2 class="font-bold text-gray-900 mb-1">매장 매출 TOP 5</h2>
     <p class="text-xs text-gray-400 mb-4">오늘 매출 기준</p>
-    <ul class="space-y-3 flex-1">
-      <li v-for="(item, i) in rankings" :key="item.idx" class="flex items-center justify-between">
+    <TransitionGroup tag="ul" name="rank" class="space-y-3 flex-1 relative">
+      <li v-for="(item, i) in rankings" :key="item.idx" class="flex items-center justify-between rank-item">
         <div class="flex items-center gap-3">
           <span class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
             :class="i < 3 ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-500'">
@@ -39,9 +38,35 @@ const formatted = (val) => val.toLocaleString('ko-KR')
           </span>
           <span class="text-sm font-medium text-gray-800">{{ item.name }}</span>
         </div>
-        <span class="text-sm font-semibold text-gray-600">₩ {{ formatted(item.score) }}</span>
+        <span class="text-sm font-semibold text-gray-600">
+          <AnimatedScore :value="item.score" prefix="₩ " />
+        </span>
       </li>
-      <li v-if="rankings.length === 0" class="text-sm text-gray-400 text-center py-4">데이터 없음</li>
-    </ul>
+      <li v-if="rankings.length === 0" key="empty" class="text-sm text-gray-400 text-center py-4">데이터 없음</li>
+    </TransitionGroup>
   </div>
 </template>
+
+<style scoped>
+.rank-item {
+  transition: all 0.5s ease;
+}
+.rank-move {
+  transition: transform 0.5s ease;
+}
+.rank-enter-active {
+  transition: all 0.3s ease;
+}
+.rank-leave-active {
+  transition: all 0.3s ease;
+  position: absolute;
+}
+.rank-enter-from {
+  opacity: 0;
+  transform: translateX(30px);
+}
+.rank-leave-to {
+  opacity: 0;
+  transform: translateX(-30px);
+}
+</style>

--- a/frontend/src/components/statistics/TodaySalesCard.vue
+++ b/frontend/src/components/statistics/TodaySalesCard.vue
@@ -1,8 +1,10 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue'
 import { getTodaySales } from '@/api/statistics'
+import { useAnimatedNumber } from '@/composables/useAnimatedNumber'
 
 const todaySales = ref(0)
+const displaySales = useAnimatedNumber(todaySales)
 let polling = null
 
 const fetchData = async () => {
@@ -30,7 +32,7 @@ const formatted = (val) => val.toLocaleString('ko-KR')
   <div class="col-span-full bg-white rounded-2xl border border-gray-200 shadow-sm p-6">
     <p class="text-[11px] font-semibold text-gray-400 uppercase tracking-[0.14em]">오늘 실시간 총 매출</p>
     <div class="flex items-end gap-2 mt-3">
-      <p class="text-[36px] leading-none font-extrabold text-gray-900 tracking-tight">₩ {{ formatted(todaySales) }}</p>
+      <p class="text-[36px] leading-none font-extrabold text-gray-900 tracking-tight">₩ {{ formatted(displaySales) }}</p>
     </div>
     <p class="text-xs text-gray-400 mt-2">2초 간격 실시간 갱신</p>
   </div>

--- a/frontend/src/composables/useAnimatedNumber.js
+++ b/frontend/src/composables/useAnimatedNumber.js
@@ -1,0 +1,32 @@
+import { ref, watch, onUnmounted } from 'vue'
+
+export function useAnimatedNumber(source, duration = 600) {
+  const display = ref(0)
+  let animFrame = null
+
+  watch(source, (to, from) => {
+    from = from ?? 0
+    if (animFrame) cancelAnimationFrame(animFrame)
+    const start = from || 0
+    const diff = to - start
+    if (diff === 0) return
+    const startTime = performance.now()
+
+    const step = (now) => {
+      const elapsed = now - startTime
+      const progress = Math.min(elapsed / duration, 1)
+      const ease = 1 - Math.pow(1 - progress, 3)
+      display.value = Math.round(start + diff * ease)
+      if (progress < 1) {
+        animFrame = requestAnimationFrame(step)
+      }
+    }
+    animFrame = requestAnimationFrame(step)
+  }, { immediate: true })
+
+  onUnmounted(() => {
+    if (animFrame) cancelAnimationFrame(animFrame)
+  })
+
+  return display
+}


### PR DESCRIPTION
## Summary
- 통계 페이지 데이터 변경 시 카운트업/슬라이드/차트 애니메이션 적용

## 변경 파일
- `frontend/src/composables/useAnimatedNumber.js` — 카운트업 애니메이션 composable (신규)
- `frontend/src/components/statistics/AnimatedScore.vue` — 랭킹 항목용 애니메이션 컴포넌트 (신규)
- `frontend/src/components/statistics/TodaySalesCard.vue` — 카운트업 적용
- `frontend/src/components/statistics/StoreRankingList.vue` — 카운트업 + 순위 슬라이드 적용
- `frontend/src/components/statistics/MenuRankingList.vue` — 카운트업 + 순위 슬라이드 적용
- `frontend/src/components/statistics/HourlySalesChart.vue` — Chart.js 전환 애니메이션 활성화
- `frontend/src/components/statistics/CategoryRatioChart.vue` — Chart.js 전환 애니메이션 활성화
- `frontend/src/components/statistics/PaymentRatioChart.vue` — Chart.js 전환 애니메이션 활성화

## 주요 변경 사항
- useAnimatedNumber composable 생성 (ease-out-cubic, 600ms 카운트업 공통 로직)
- AnimatedScore 컴포넌트 생성 (랭킹 리스트 항목 숫자용)
- 랭킹 순위 변동 시 TransitionGroup + move 트랜지션으로 슬라이드 효과
- 차트 3개 update('none') → update()로 변경하여 전환 애니메이션 활성화

## Test Plan
- [ ] 매출 금액 변경 시 카운트업 애니메이션 동작 확인
- [ ] 랭킹 순위 변동 시 슬라이드 애니메이션 동작 확인
- [ ] 차트 데이터 갱신 시 부드러운 전환 확인

## Issue
- Closes #825