### PR TITLE
[Feat] K8s Warning 이벤트 한국어 Discord 알림 시스템 추가  

### DIFF
--- a/k8s/monitoring/korean-alerter/korean-alerter.py
+++ b/k8s/monitoring/korean-alerter/korean-alerter.py
@@ -1,0 +1,106 @@
+import os
+import time
+import json
+import requests
+from kubernetes import client, config, watch
+
+WEBHOOK_URL = os.environ["DISCORD_WEBHOOK_URL"]
+NAMESPACES = os.environ.get("WATCH_NAMESPACES", "default,nexus,monitoring").split(",")
+CLUSTER_NAME = os.environ.get("CLUSTER_NAME", "nexus-cluster")
+
+REASON_KR = {
+    "BackOff": "컨테이너 재시작 반복",
+    "CrashLoopBackOff": "컨테이너 크래시 반복",
+    "ImagePullBackOff": "이미지 Pull 실패 (반복)",
+    "ErrImagePull": "이미지 Pull 실패",
+    "OOMKilled": "메모리 부족으로 종료",
+    "FailedScheduling": "스케줄링 실패 (자원 부족)",
+    "Unhealthy": "헬스체크 실패",
+    "FailedMount": "볼륨 마운트 실패",
+    "NodeNotReady": "노드 준비 안 됨",
+    "Evicted": "리소스 부족으로 추방됨",
+    "FailedCreate": "리소스 생성 실패",
+    "FailedDelete": "리소스 삭제 실패",
+}
+
+COLOR_MAP = {
+    "Warning": 0xFF6B35,  # 주황
+    "Normal": 0x2ECC71,   # 초록
+}
+
+
+def translate_reason(reason):
+    return REASON_KR.get(reason, reason)
+
+
+def send_discord(embed):
+    payload = {"embeds": [embed]}
+    try:
+        resp = requests.post(WEBHOOK_URL, json=payload, timeout=10)
+        if resp.status_code == 429:
+            retry_after = resp.json().get("retry_after", 5)
+            time.sleep(retry_after)
+            requests.post(WEBHOOK_URL, json=payload, timeout=10)
+    except requests.RequestException as e:
+        print(f"Discord 전송 실패: {e}")
+
+
+def build_embed(event):
+    obj = event.involved_object
+    reason = event.reason or "Unknown"
+    reason_kr = translate_reason(reason)
+    namespace = obj.namespace or "-"
+    name = obj.name or "Unknown"
+    kind = obj.kind or "Unknown"
+    message = event.message or ""
+    event_type = event.type or "Warning"
+
+    color = COLOR_MAP.get(event_type, 0xFF0000)
+
+    return {
+        "title": f"[{reason_kr}] {kind}/{name}",
+        "color": color,
+        "fields": [
+            {"name": "클러스터", "value": CLUSTER_NAME, "inline": True},
+            {"name": "네임스페이스", "value": namespace, "inline": True},
+            {"name": "원인", "value": f"{reason_kr} (`{reason}`)", "inline": False},
+            {"name": "상세", "value": message[:1024] if message else "-", "inline": False},
+        ],
+        "footer": {"text": f"{CLUSTER_NAME} | korean-alerter"},
+    }
+
+
+def main():
+    try:
+        config.load_incluster_config()
+    except config.ConfigException:
+        config.load_kube_config()
+
+    v1 = client.CoreV1Api()
+    print(f"korean-alerter 시작 - 감시 네임스페이스: {NAMESPACES}")
+
+    while True:
+        try:
+            for ns in NAMESPACES:
+                w = watch.Watch()
+                # 기존 이벤트 건너뛰고 새 이벤트만 감시
+                resource_version = v1.list_namespaced_event(ns).metadata.resource_version
+
+                for event in w.stream(v1.list_namespaced_event, ns,
+                                      resource_version=resource_version,
+                                      timeout_seconds=60):
+                    k8s_event = event["object"]
+                    if k8s_event.type == "Warning":
+                        embed = build_embed(k8s_event)
+                        send_discord(embed)
+
+        except client.exceptions.ApiException as e:
+            print(f"K8s API 에러: {e.status} - 재시도...")
+            time.sleep(5)
+        except Exception as e:
+            print(f"에러 발생: {e} - 재시도...")
+            time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/k8s/monitoring/korean-alerter/korean-alerter.yaml
+++ b/k8s/monitoring/korean-alerter/korean-alerter.yaml
@@ -1,0 +1,212 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: korean-alerter-secret
+  namespace: monitoring
+type: Opaque
+stringData:
+  webhook-url: "여기에_DISCORD_WEBHOOK_URL_붙여넣기"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: korean-alerter-code
+  namespace: monitoring
+data:
+  korean-alerter.py: |
+    import os
+    import time
+    import json
+    import requests
+    from kubernetes import client, config, watch
+
+    WEBHOOK_URL = os.environ["DISCORD_WEBHOOK_URL"]
+    NAMESPACES = os.environ.get("WATCH_NAMESPACES", "default,nexus,monitoring").split(",")
+    CLUSTER_NAME = os.environ.get("CLUSTER_NAME", "nexus-cluster")
+
+    REASON_KR = {
+        "BackOff": "컨테이너 재시작 반복",
+        "CrashLoopBackOff": "컨테이너 크래시 반복",
+        "ImagePullBackOff": "이미지 Pull 실패 (반복)",
+        "ErrImagePull": "이미지 Pull 실패",
+        "OOMKilled": "메모리 부족으로 종료",
+        "FailedScheduling": "스케줄링 실패 (자원 부족)",
+        "Unhealthy": "헬스체크 실패",
+        "FailedMount": "볼륨 마운트 실패",
+        "NodeNotReady": "노드 준비 안 됨",
+        "Evicted": "리소스 부족으로 추방됨",
+        "FailedCreate": "리소스 생성 실패",
+        "FailedDelete": "리소스 삭제 실패",
+    }
+
+    COLOR_MAP = {
+        "Warning": 0xFF6B35,
+        "Normal": 0x2ECC71,
+    }
+
+
+    def translate_reason(reason):
+        return REASON_KR.get(reason, reason)
+
+
+    def send_discord(embed):
+        payload = {"embeds": [embed]}
+        try:
+            resp = requests.post(WEBHOOK_URL, json=payload, timeout=10)
+            if resp.status_code == 429:
+                retry_after = resp.json().get("retry_after", 5)
+                time.sleep(retry_after)
+                requests.post(WEBHOOK_URL, json=payload, timeout=10)
+        except requests.RequestException as e:
+            print(f"Discord 전송 실패: {e}")
+
+
+    def build_embed(event):
+        obj = event.involved_object
+        reason = event.reason or "Unknown"
+        reason_kr = translate_reason(reason)
+        namespace = obj.namespace or "-"
+        name = obj.name or "Unknown"
+        kind = obj.kind or "Unknown"
+        message = event.message or ""
+        event_type = event.type or "Warning"
+
+        color = COLOR_MAP.get(event_type, 0xFF0000)
+
+        return {
+            "title": f"[{reason_kr}] {kind}/{name}",
+            "color": color,
+            "fields": [
+                {"name": "클러스터", "value": CLUSTER_NAME, "inline": True},
+                {"name": "네임스페이스", "value": namespace, "inline": True},
+                {"name": "원인", "value": f"{reason_kr} (`{reason}`)", "inline": False},
+                {"name": "상세", "value": message[:1024] if message else "-", "inline": False},
+            ],
+            "footer": {"text": f"{CLUSTER_NAME} | korean-alerter"},
+        }
+
+
+    def main():
+        try:
+            config.load_incluster_config()
+        except config.ConfigException:
+            config.load_kube_config()
+
+        v1 = client.CoreV1Api()
+        print(f"korean-alerter 시작 - 감시 네임스페이스: {NAMESPACES}")
+
+        while True:
+            try:
+                for ns in NAMESPACES:
+                    w = watch.Watch()
+                    resource_version = v1.list_namespaced_event(ns).metadata.resource_version
+
+                    for event in w.stream(v1.list_namespaced_event, ns,
+                                          resource_version=resource_version,
+                                          timeout_seconds=60):
+                        k8s_event = event["object"]
+                        if k8s_event.type == "Warning":
+                            embed = build_embed(k8s_event)
+                            send_discord(embed)
+
+            except client.exceptions.ApiException as e:
+                print(f"K8s API 에러: {e.status} - 재시도...")
+                time.sleep(5)
+            except Exception as e:
+                print(f"에러 발생: {e} - 재시도...")
+                time.sleep(5)
+
+
+    if __name__ == "__main__":
+        main()
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: korean-alerter
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korean-alerter
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: korean-alerter
+subjects:
+  - kind: ServiceAccount
+    name: korean-alerter
+    namespace: monitoring
+roleRef:
+  kind: ClusterRole
+  name: korean-alerter
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: korean-alerter
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: korean-alerter
+  template:
+    metadata:
+      labels:
+        app: korean-alerter
+    spec:
+      serviceAccountName: korean-alerter
+      initContainers:
+        - name: install-deps
+          image: python:3.12-slim
+          command: ["pip", "install", "--target=/deps", "kubernetes==30.1.0", "requests==2.32.3"]
+          volumeMounts:
+            - name: deps
+              mountPath: /deps
+      containers:
+        - name: korean-alerter
+          image: python:3.12-slim
+          command: ["python", "-u", "/app/korean-alerter.py"]
+          env:
+            - name: PYTHONPATH
+              value: "/deps"
+            - name: DISCORD_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: korean-alerter-secret
+                  key: webhook-url
+            - name: WATCH_NAMESPACES
+              value: "default,nexus,monitoring"
+            - name: CLUSTER_NAME
+              value: "nexus-cluster"
+          volumeMounts:
+            - name: code
+              mountPath: /app
+            - name: deps
+              mountPath: /deps
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      volumes:
+        - name: code
+          configMap:
+            name: korean-alerter-code
+        - name: deps
+          emptyDir: {}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- K8s 클러스터 Warning 이벤트를 감시하여 Discord Webhook으로 한국어 알림을 전송하는 Korean Alerter 추가                                                                                                                           
- ConfigMap + initContainer 방식으로 Docker 빌드 없이 배포 가능                                                                                                                                                                   
- default, nexus, monitoring 네임스페이스의 Warning 이벤트 감시 (ErrImagePull, CrashLoopBackOff, OOMKilled 등 12종 한국어 번역)                                                                                                   

## 주요 변경사항
- `k8s/monitoring/korean-alerter/korean-alerter.py`: K8s 이벤트 감시 및 Discord 전송 스크립트
- `k8s/monitoring/korean-alerter/korean-alerter.yaml`: Namespace, Secret, ConfigMap, RBAC, Deployment 매니페스트