### PR TITLE
[Feat] #833 - Kafka 이벤트 publish/consume 도입

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,5 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
-.env
+monolith/.env
 datalocal.sql

--- a/backend/monolith/build.gradle
+++ b/backend/monolith/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation 'com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10'
 
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // --- Kafka ---
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 bootRun {

--- a/backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -7,10 +7,13 @@ import com.example.nexus.domain.menu.model.MenuDto;
 import com.example.nexus.domain.menu.model.MenuItem;
 import com.example.nexus.domain.product.ProductRepository;
 import com.example.nexus.domain.product.model.Product;
+import com.example.nexus.event.KafkaTopics;
+import com.example.nexus.event.MenuEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -33,6 +36,7 @@ public class MenuService {
     private final MenuRepository menuRepository;
     private final MenuCategoryRepository menuCategoryRepository;
     private final ProductRepository productRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     private final S3Presigner s3Presigner;
     private final S3Client s3Client;
@@ -141,7 +145,19 @@ public class MenuService {
 
 
             Menu menu = dto.toEntity(category, products);
-            menuRepository.save(menu);
+            Menu saved = menuRepository.save(menu);
+
+            // kafka 이벤트 발생
+            MenuEvent event = new MenuEvent(
+                    saved.getIdx(),
+                    saved.getMenuName(),
+                    saved.getPrice(),
+                    category.getIdx(),
+                    category.getMenuCategoryName(),
+                    saved.isDeleted()
+            );
+
+            kafkaTemplate.send(KafkaTopics.MENU_CREATED, event);
 
         } catch (Exception e) {
             // 등록 중 에러가 나면 DB는 롤백되지만, 이미 업로드된 파일은 좀비가 되므로 삭제 처리
@@ -223,6 +239,18 @@ public class MenuService {
                 menu.getMenuItemList().add(newItem);
             }
 
+            // kafka 이벤트 발생
+            MenuEvent event = new MenuEvent(
+                    menu.getIdx(),
+                    menu.getMenuName(),
+                    menu.getPrice(),
+                    category.getIdx(),
+                    category.getMenuCategoryName(),
+                    menu.isDeleted()
+            );
+
+            kafkaTemplate.send(KafkaTopics.MENU_UPDATED, event);
+
         }catch (Exception e) {
             if (newFilePath != null && !newFilePath.isEmpty()
                     && !newFilePath.equals(oldFilePath)
@@ -267,6 +295,18 @@ public class MenuService {
                 .orElseThrow(() -> new BaseException(NOT_FOUND_MENU));
 
         menu.deleteTrue();
+
+        // kafka 이벤트 발생
+        MenuEvent event = new MenuEvent(
+                menu.getIdx(),
+                menu.getMenuName(),
+                menu.getPrice(),
+                menu.getMenuCategory() != null ? menu.getMenuCategory().getIdx() : null,
+                menu.getMenuCategory() != null ? menu.getMenuCategory().getMenuCategoryName() : null,
+                true
+        );
+
+        kafkaTemplate.send(KafkaTopics.MENU_DELETED, event);
     }
 
     @Transactional(readOnly = true)

--- a/backend/monolith/src/main/java/com/example/nexus/domain/pos/PosService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/pos/PosService.java
@@ -18,9 +18,13 @@ import com.example.nexus.domain.store.StoreInventoryRepository;
 import com.example.nexus.domain.store.StoreRepository;
 import com.example.nexus.domain.store.model.Store;
 import com.example.nexus.domain.store.model.StoreInventory;
+import com.example.nexus.event.KafkaTopics;
+import com.example.nexus.event.PaymentEvent;
+import com.example.nexus.event.PaymentEventItem;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +51,7 @@ public class PosService {
     private final MenuItemRepository menuItemRepository;
     private final PosPayRepository posPayRepository;
     private final PosOrdersItemRepository posOrdersItemRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     public PageResponse<PosStoreInventoryDto.ListRes> listByUserIdxPaged(Long idx, int page, int size) {
         Store store = storeRepository.findByUserIdx(idx)
@@ -262,6 +267,10 @@ public class PosService {
         }
         posOrdersItemRepository.saveAll(orderLines);
 
+        // Kafka 이벤트 발행
+        PaymentEvent event = buildPaymentEvent(savedPay, store, lines);
+        kafkaTemplate.send(KafkaTopics.POS_PAYMENT_CREATED, event);
+
         return PosPayDto.PayRes.builder()
                 .posPayIdx(savedPay.getIdx())
                 .storeIdx(store.getIdx())
@@ -270,6 +279,30 @@ public class PosService {
                 .paidAt(savedPay.getPaidAt())
                 .items(lineResList)
                 .build();
+    }
+
+    private PaymentEvent buildPaymentEvent(PosPay savedPay, Store store, List<MenuOrderLine> lines) {
+        List<PaymentEventItem> items = lines.stream()
+                .map(row -> new PaymentEventItem(
+                        row.menu().getIdx(),
+                        row.menu().getMenuName(),
+                        row.menu().getMenuCategory() != null ? row.menu().getMenuCategory().getIdx() : null,
+                        row.menu().getMenuCategory() != null ? row.menu().getMenuCategory().getMenuCategoryName() : null,
+                        row.menu().getPrice(),
+                        row.quantity(),
+                        (long) row.menu().getPrice() * row.quantity()
+                ))
+                .toList();
+
+        return new PaymentEvent(
+                savedPay.getIdx(),
+                store.getIdx(),
+                store.getStoreName(),
+                savedPay.getMethod().name(),       // PosPayMethod enum → String
+                savedPay.getPaidAt(),
+                savedPay.getPayAmount(),
+                items
+        );
     }
 
     private Map<Long, Integer> aggregateProductNeedFromRecipes(List<MenuOrderLine> lines) {

--- a/backend/monolith/src/main/java/com/example/nexus/domain/store/StoreService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/store/StoreService.java
@@ -8,12 +8,14 @@ import com.example.nexus.domain.store.model.StoreInventory;
 import com.example.nexus.domain.store.model.StoreInventoryDto;
 import com.example.nexus.domain.user.UserRepository;
 import com.example.nexus.domain.user.model.User;
-import com.example.nexus.domain.wastelog.model.WasteLog;
+import com.example.nexus.event.KafkaTopics;
+import com.example.nexus.event.StoreEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -38,6 +40,7 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final StoreInventoryRepository storeInventoryRepository;
     private final UserRepository userRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     // URL을 발행해주는 핵심 도구
     private final S3Presigner s3Presigner;
@@ -178,7 +181,17 @@ public class StoreService {
                     .user(owner)
                     .build();
 
-            storeRepository.save(store);
+            // kafka 이벤트 발생
+            Store saved = storeRepository.save(store);
+
+            StoreEvent event = new StoreEvent(
+                    saved.getIdx(),
+                    saved.getStoreName(),
+                    saved.isDeleted()
+            );
+
+            kafkaTemplate.send(KafkaTopics.STORE_CREATED, event);
+
         } catch (Exception e) {
             // 5. 예외 발생 시 S3 롤백 삭제
             // 트랜잭션 도중 에러가 나면 DB는 롤백되지만, S3에 업로드된 파일은 남으므로 삭제 처리
@@ -276,6 +289,15 @@ public class StoreService {
 
             store.update(dto);
             owner.updateOwner(dto.getOwnerName(), dto.getOwnerEmail());
+
+            // kafka 이벤트 발생
+            StoreEvent event = new StoreEvent(
+                    store.getIdx(),
+                    store.getStoreName(),
+                    store.isDeleted()
+            );
+
+            kafkaTemplate.send(KafkaTopics.STORE_UPDATED, event);
 
         } catch (Exception e) {
             if (newFilePath != null && !newFilePath.isEmpty() && !newFilePath.equals(oldFilePath)) {

--- a/backend/monolith/src/main/java/com/example/nexus/event/KafkaTopics.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/KafkaTopics.java
@@ -1,0 +1,12 @@
+package com.example.nexus.event;
+
+public final class KafkaTopics {
+    public static final String POS_PAYMENT_CREATED = "pos.payment.created";
+    public static final String STORE_CREATED = "store.created";
+    public static final String STORE_UPDATED = "store.updated";
+    public static final String MENU_CREATED = "menu.created";
+    public static final String MENU_UPDATED = "menu.updated";
+    public static final String MENU_DELETED = "menu.deleted";
+
+    private KafkaTopics() {}
+}

--- a/backend/monolith/src/main/java/com/example/nexus/event/MenuEvent.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/MenuEvent.java
@@ -1,0 +1,10 @@
+package com.example.nexus.event;
+
+public record MenuEvent(
+        Long menuIdx,
+        String menuName,
+        Integer price,
+        Long menuCategoryIdx,
+        String menuCategoryName,
+        Boolean isDeleted
+) {}

--- a/backend/monolith/src/main/java/com/example/nexus/event/PaymentEvent.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/PaymentEvent.java
@@ -1,0 +1,14 @@
+package com.example.nexus.event;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PaymentEvent(
+        Long posPayIdx,
+        Long storeIdx,
+        String storeName,
+        String method,            // "CARD" or "CASH"
+        LocalDateTime paidAt,
+        Long payAmount,
+        List<PaymentEventItem> items
+) {}

--- a/backend/monolith/src/main/java/com/example/nexus/event/PaymentEventItem.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/PaymentEventItem.java
@@ -1,0 +1,11 @@
+package com.example.nexus.event;
+
+public record PaymentEventItem(
+        Long menuIdx,
+        String menuName,
+        Long menuCategoryIdx,
+        String menuCategoryName,
+        Integer unitPrice,
+        Integer quantity,
+        Long lineAmount           // unitPrice * quantity
+) {}

--- a/backend/monolith/src/main/java/com/example/nexus/event/StoreEvent.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/StoreEvent.java
@@ -1,0 +1,7 @@
+package com.example.nexus.event;
+
+public record StoreEvent(
+        Long storeIdx,
+        String storeName,
+        Boolean isDeleted
+) {}

--- a/backend/monolith/src/main/resources/application-dev.yaml
+++ b/backend/monolith/src/main/resources/application-dev.yaml
@@ -11,6 +11,13 @@ spring:
       ddl-auto: update
     show-sql: false
     defer-datasource-initialization: true
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
 
   ai:
     openai:

--- a/backend/monolith/src/main/resources/application-dev.yaml
+++ b/backend/monolith/src/main/resources/application-dev.yaml
@@ -17,7 +17,8 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
-        spring.json.add.type.headers: false
+        spring.json.add.type.headers: true
+        spring.json.type.mapping: paymentEvent:com.example.nexus.event.PaymentEvent,storeEvent:com.example.nexus.event.StoreEvent,menuEvent:com.example.nexus.event.MenuEvent
 
   ai:
     openai:

--- a/backend/statistics/build.gradle
+++ b/backend/statistics/build.gradle
@@ -7,12 +7,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    // --- DB / JPA (신규 추가) ---
+    // --- DB / JPA ---
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.mariadb.jdbc:mariadb-java-client:3.4.1'
 
-    // --- env (신규 추가) ---
+    // --- env ---
     implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+
+    // --- Kafka ---
+    implementation 'org.springframework.kafka:spring-kafka'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/statistics/src/main/java/com/example/statistics/domain/menu/MenuCategoryRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/menu/MenuCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.statistics.domain.menu;
+
+import com.example.statistics.domain.menu.model.MenuCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuCategoryRepository extends JpaRepository<MenuCategory, Long> {
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/menu/MenuRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/menu/MenuRepository.java
@@ -1,0 +1,7 @@
+package com.example.statistics.domain.menu;
+
+import com.example.statistics.domain.menu.model.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/menu/model/Menu.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/menu/model/Menu.java
@@ -5,30 +5,28 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "menu")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Menu {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "menu_idx")
     private Long idx;
 
-    @Column(name = "menu_name", nullable = false, unique = true)
+    @Column(name = "menu_name", nullable = false)
     private String menuName;
 
     @Column(name = "price", nullable = false)
     private Integer price;
 
-    @Column(name = "img_path", nullable = false)
-    private String imgPath;
-
     @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
+    private boolean isDeleted;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_category_idx")

--- a/backend/statistics/src/main/java/com/example/statistics/domain/menu/model/MenuCategory.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/menu/model/MenuCategory.java
@@ -5,22 +5,23 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "menu_category")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class MenuCategory {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "menu_category_idx")
     private Long idx;
 
-    @Column(name = "menu_category_name", nullable = false, unique = true)
+    @Column(name = "menu_category_name", nullable = false)
     private String menuCategoryName;
 
     @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
+    private boolean isDeleted;
 }

--- a/backend/statistics/src/main/java/com/example/statistics/domain/pos/PosOrdersItemRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/pos/PosOrdersItemRepository.java
@@ -1,0 +1,7 @@
+package com.example.statistics.domain.pos;
+
+import com.example.statistics.domain.pos.model.PosOrdersItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PosOrdersItemRepository extends JpaRepository<PosOrdersItem, Long> {
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/pos/PosPayRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/pos/PosPayRepository.java
@@ -1,0 +1,7 @@
+package com.example.statistics.domain.pos;
+
+import com.example.statistics.domain.pos.model.PosPay;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PosPayRepository extends JpaRepository<PosPay, Long> {
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/pos/model/PosPay.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/pos/model/PosPay.java
@@ -16,7 +16,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class PosPay {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "pos_pay_idx")
     private Long idx;
 

--- a/backend/statistics/src/main/java/com/example/statistics/domain/store/StoreRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/store/StoreRepository.java
@@ -1,0 +1,7 @@
+package com.example.statistics.domain.store;
+
+import com.example.statistics.domain.store.model.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/store/model/Store.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/store/model/Store.java
@@ -5,46 +5,24 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import lombok.Setter;
 
 @Entity
 @Table(name = "store")
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Store {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "store_idx")
-    private Long idx;
+    private Long idx;                            // ← @GeneratedValue 제거 (이벤트에서 받은 ID 그대로 사용)
 
-    @Column(name = "store_name", nullable = false, unique = true)
+    @Column(name = "store_name", nullable = false)
     private String storeName;
 
-    @Column(nullable = false)
-    private String address;
-
-    @Column(name = "address_detail", nullable = false)
-    private String addressDetail;
-
-    @Column(name = "file_path", nullable = false)
-    private String filePath;
-
-    @Column(nullable = false, unique = true)
-    private String business;
-
-    @Column(nullable = false)
-    private String postcode;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "closed_at")
-    private LocalDateTime closedAt;
-
     @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
+    private boolean isDeleted;
 }

--- a/backend/statistics/src/main/java/com/example/statistics/event/KafkaTopics.java
+++ b/backend/statistics/src/main/java/com/example/statistics/event/KafkaTopics.java
@@ -1,0 +1,12 @@
+package com.example.statistics.event;
+
+public final class KafkaTopics {
+    public static final String POS_PAYMENT_CREATED = "pos.payment.created";
+    public static final String STORE_CREATED = "store.created";
+    public static final String STORE_UPDATED = "store.updated";
+    public static final String MENU_CREATED = "menu.created";
+    public static final String MENU_UPDATED = "menu.updated";
+    public static final String MENU_DELETED = "menu.deleted";
+
+    private KafkaTopics() {}
+}

--- a/backend/statistics/src/main/java/com/example/statistics/event/MenuEvent.java
+++ b/backend/statistics/src/main/java/com/example/statistics/event/MenuEvent.java
@@ -1,0 +1,10 @@
+package com.example.statistics.event;
+
+public record MenuEvent(
+        Long menuIdx,
+        String menuName,
+        Integer price,
+        Long menuCategoryIdx,
+        String menuCategoryName,
+        Boolean isDeleted
+) {}

--- a/backend/statistics/src/main/java/com/example/statistics/event/PaymentEvent.java
+++ b/backend/statistics/src/main/java/com/example/statistics/event/PaymentEvent.java
@@ -1,0 +1,16 @@
+package com.example.statistics.event;
+
+import com.example.statistics.event.PaymentEventItem;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PaymentEvent(
+        Long posPayIdx,
+        Long storeIdx,
+        String storeName,
+        String method,            // "CARD" or "CASH"
+        LocalDateTime paidAt,
+        Long payAmount,
+        List<PaymentEventItem> items
+) {}

--- a/backend/statistics/src/main/java/com/example/statistics/event/PaymentEventItem.java
+++ b/backend/statistics/src/main/java/com/example/statistics/event/PaymentEventItem.java
@@ -1,0 +1,11 @@
+package com.example.statistics.event;
+
+public record PaymentEventItem(
+        Long menuIdx,
+        String menuName,
+        Long menuCategoryIdx,
+        String menuCategoryName,
+        Integer unitPrice,
+        Integer quantity,
+        Long lineAmount           // unitPrice * quantity
+) {}

--- a/backend/statistics/src/main/java/com/example/statistics/event/StoreEvent.java
+++ b/backend/statistics/src/main/java/com/example/statistics/event/StoreEvent.java
@@ -1,0 +1,7 @@
+package com.example.statistics.event;
+
+public record StoreEvent(
+        Long storeIdx,
+        String storeName,
+        Boolean isDeleted
+) {}

--- a/backend/statistics/src/main/java/com/example/statistics/kafka/MenuEventConsumer.java
+++ b/backend/statistics/src/main/java/com/example/statistics/kafka/MenuEventConsumer.java
@@ -1,0 +1,67 @@
+package com.example.statistics.kafka;
+
+import com.example.statistics.domain.menu.MenuCategoryRepository;
+import com.example.statistics.domain.menu.MenuRepository;
+import com.example.statistics.domain.menu.model.Menu;
+import com.example.statistics.domain.menu.model.MenuCategory;
+import com.example.statistics.event.KafkaTopics;
+import com.example.statistics.event.MenuEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MenuEventConsumer {
+
+    private final MenuRepository menuRepository;
+    private final MenuCategoryRepository menuCategoryRepository;
+
+    @KafkaListener(topics = KafkaTopics.MENU_CREATED)
+    @Transactional
+    public void onMenuCreated(MenuEvent event) {
+        log.info("[menu.created] received: idx={}, name={}, category={}",
+                event.menuIdx(), event.menuName(), event.menuCategoryName());
+        upsert(event);
+    }
+
+    @KafkaListener(topics = KafkaTopics.MENU_UPDATED)
+    @Transactional
+    public void onMenuUpdated(MenuEvent event) {
+        log.info("[menu.updated] received: idx={}, name={}", event.menuIdx(), event.menuName());
+        upsert(event);
+    }
+
+    @KafkaListener(topics = KafkaTopics.MENU_DELETED)
+    @Transactional
+    public void onMenuDeleted(MenuEvent event) {
+        log.info("[menu.deleted] received: idx={}", event.menuIdx());
+        upsert(event);   // isDeleted=true 페이로드라 자연스레 soft delete
+    }
+
+    private void upsert(MenuEvent event) {
+        // 1) 카테고리 먼저 upsert (Menu의 FK 무결성 보장)
+        MenuCategory category = null;
+        if (event.menuCategoryIdx() != null) {
+            category = MenuCategory.builder()
+                    .idx(event.menuCategoryIdx())
+                    .menuCategoryName(event.menuCategoryName())
+                    .isDeleted(false)
+                    .build();
+            menuCategoryRepository.save(category);
+        }
+
+        // 2) 메뉴 upsert
+        Menu menu = Menu.builder()
+                .idx(event.menuIdx())
+                .menuName(event.menuName())
+                .price(event.price())
+                .isDeleted(Boolean.TRUE.equals(event.isDeleted()))
+                .menuCategory(category)
+                .build();
+        menuRepository.save(menu);
+    }
+}

--- a/backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
+++ b/backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
@@ -1,0 +1,62 @@
+package com.example.statistics.kafka;
+
+import com.example.statistics.common.enums.PosPayMethod;
+import com.example.statistics.domain.menu.MenuRepository;
+import com.example.statistics.domain.pos.PosOrdersItemRepository;
+import com.example.statistics.domain.pos.PosPayRepository;
+import com.example.statistics.domain.pos.model.PosOrdersItem;
+import com.example.statistics.domain.pos.model.PosPay;
+import com.example.statistics.domain.store.StoreRepository;
+import com.example.statistics.event.KafkaTopics;
+import com.example.statistics.event.PaymentEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventConsumer {
+
+    private final PosPayRepository posPayRepository;
+    private final PosOrdersItemRepository posOrdersItemRepository;
+    private final StoreRepository storeRepository;
+    private final MenuRepository menuRepository;
+
+    @KafkaListener(topics = KafkaTopics.POS_PAYMENT_CREATED)
+    @Transactional
+    public void onPaymentCreated(PaymentEvent event) {
+        log.info("[pos.payment.created] received: posPayIdx={}, storeIdx={}, payAmount={}, items={}",
+                event.posPayIdx(), event.storeIdx(), event.payAmount(), event.items().size());
+
+        // 멱등성: 같은 결제 중복 수신 시 skip
+        if (posPayRepository.existsById(event.posPayIdx())) {
+            log.warn("[pos.payment.created] duplicate payment skipped: posPayIdx={}", event.posPayIdx());
+            return;
+        }
+
+        // 1) PosPay 저장 (이벤트의 idx 그대로)
+        PosPay posPay = PosPay.builder()
+                .idx(event.posPayIdx())
+                .method(PosPayMethod.valueOf(event.method()))
+                .paidAt(event.paidAt())
+                .payAmount(event.payAmount())
+                .store(storeRepository.getReferenceById(event.storeIdx()))   // FK proxy
+                .build();
+        posPayRepository.save(posPay);
+
+        // 2) PosOrdersItem 각각 저장
+        List<PosOrdersItem> orderItems = event.items().stream()
+                .map(item -> PosOrdersItem.builder()
+                        .menu(menuRepository.getReferenceById(item.menuIdx()))   // FK proxy
+                        .posPay(posPay)
+                        .quantity(item.quantity())
+                        .build())
+                .toList();
+        posOrdersItemRepository.saveAll(orderItems);
+    }
+}

--- a/backend/statistics/src/main/java/com/example/statistics/kafka/StoreEventConsumer.java
+++ b/backend/statistics/src/main/java/com/example/statistics/kafka/StoreEventConsumer.java
@@ -1,0 +1,40 @@
+package com.example.statistics.kafka;
+
+import com.example.statistics.domain.store.StoreRepository;
+import com.example.statistics.domain.store.model.Store;
+import com.example.statistics.event.KafkaTopics;
+import com.example.statistics.event.StoreEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StoreEventConsumer {
+
+    private final StoreRepository storeRepository;
+
+    @KafkaListener(topics = KafkaTopics.STORE_CREATED)
+    public void onStoreCreated(StoreEvent event) {
+        log.info("[store.created] received: idx = {}, name = {}", event.storeIdx(), event.storeName());
+        upsert(event);
+    }
+
+    @KafkaListener(topics = KafkaTopics.STORE_UPDATED)
+    public void onStoreUpdated(StoreEvent event) {
+        log.info("[store.updated] received: idx={}, name={}, isDeleted={}",
+                event.storeIdx(), event.storeName(), event.isDeleted());
+        upsert(event);
+    }
+
+    private void upsert(StoreEvent event) {
+        Store store = Store.builder()
+                .idx(event.storeIdx())
+                .storeName(event.storeName())
+                .isDeleted(event.isDeleted())
+                .build();
+        storeRepository.save(store);
+    }
+}

--- a/backend/statistics/src/main/resources/application-dev.yaml
+++ b/backend/statistics/src/main/resources/application-dev.yaml
@@ -23,8 +23,10 @@ spring:
     consumer:
       group-id: statistics-kafka
       auto-offset-reset: earliest              # 토픽 처음부터 읽기
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
       properties:
-        spring.json.trusted.packages: "*"     # 모든 패키지 역직렬화 허용
-        spring.json.use.type.headers: false
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: "*"
+        spring.json.type.mapping: paymentEvent:com.example.statistics.event.PaymentEvent,storeEvent:com.example.statistics.event.StoreEvent,menuEvent:com.example.statistics.event.MenuEvent

--- a/backend/statistics/src/main/resources/application-dev.yaml
+++ b/backend/statistics/src/main/resources/application-dev.yaml
@@ -11,9 +11,20 @@ spring:
       connection-timeout: 30000
   jpa:
     hibernate:
-      ddl-auto: update             # 엔티티 복제 단계(B-1-3c)에서 테이블 자동 생성
+      ddl-auto: update             # 엔티티 복제 단계에서 테이블 자동 생성
     show-sql: false
     defer-datasource-initialization: true
   sql:
     init:
       mode: always
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    consumer:
+      group-id: statistics-kafka
+      auto-offset-reset: earliest              # 토픽 처음부터 읽기
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "*"     # 모든 패키지 역직렬화 허용
+        spring.json.use.type.headers: false

--- a/backend/statistics/src/main/resources/data.sql
+++ b/backend/statistics/src/main/resources/data.sql
@@ -5,9 +5,8 @@ DELETE FROM menu;
 DELETE FROM menu_category;
 DELETE FROM store;
 
--- pos_pay, pos_orders_item만 AUTO_INCREMENT 사용 (store/menu/menu_category는 idx 직접 지정)
+-- pos_orders_item만 AUTO_INCREMENT 사용 (pos_pay/store/menu/menu_category는 idx 직접 지정)
 ALTER TABLE pos_orders_item AUTO_INCREMENT = 1;
-ALTER TABLE pos_pay AUTO_INCREMENT = 1;
 
 -- menu_category (4) — idx 직접 지정
 INSERT INTO menu_category (menu_category_idx, menu_category_name, is_deleted) VALUES
@@ -42,43 +41,43 @@ INSERT INTO store (store_idx, store_name, is_deleted) VALUES
 (4, '신촌점', false),
 (5, '광화문점', false);
 
--- pos_pay (30건, 오늘 CURDATE, 시간/매장/method 분산)
-INSERT INTO pos_pay (store_idx, method, paid_at, pay_amount) VALUES
+-- pos_pay (30건, 오늘 CURDATE, 시간/매장/method 분산) — pos_pay_idx 직접 지정
+INSERT INTO pos_pay (pos_pay_idx, store_idx, method, paid_at, pay_amount) VALUES
 -- 강남점 (10건)
-(1, 'CARD', CONCAT(CURDATE(), ' 08:15:00'), 1500),
-(1, 'CARD', CONCAT(CURDATE(), ' 09:20:00'), 5500),
-(1, 'CASH', CONCAT(CURDATE(), ' 10:45:00'), 2500),
-(1, 'CARD', CONCAT(CURDATE(), ' 11:30:00'), 7000),
-(1, 'CARD', CONCAT(CURDATE(), ' 12:05:00'), 4500),
-(1, 'CARD', CONCAT(CURDATE(), ' 12:40:00'), 6000),
-(1, 'CARD', CONCAT(CURDATE(), ' 13:15:00'), 3000),
-(1, 'CASH', CONCAT(CURDATE(), ' 15:30:00'), 5000),
-(1, 'CARD', CONCAT(CURDATE(), ' 17:00:00'), 4000),
-(1, 'CARD', CONCAT(CURDATE(), ' 19:20:00'), 3500),
+(1,  1, 'CARD', CONCAT(CURDATE(), ' 08:15:00'), 1500),
+(2,  1, 'CARD', CONCAT(CURDATE(), ' 09:20:00'), 5500),
+(3,  1, 'CASH', CONCAT(CURDATE(), ' 10:45:00'), 2500),
+(4,  1, 'CARD', CONCAT(CURDATE(), ' 11:30:00'), 7000),
+(5,  1, 'CARD', CONCAT(CURDATE(), ' 12:05:00'), 4500),
+(6,  1, 'CARD', CONCAT(CURDATE(), ' 12:40:00'), 6000),
+(7,  1, 'CARD', CONCAT(CURDATE(), ' 13:15:00'), 3000),
+(8,  1, 'CASH', CONCAT(CURDATE(), ' 15:30:00'), 5000),
+(9,  1, 'CARD', CONCAT(CURDATE(), ' 17:00:00'), 4000),
+(10, 1, 'CARD', CONCAT(CURDATE(), ' 19:20:00'), 3500),
 -- 홍대점 (8건)
-(2, 'CARD', CONCAT(CURDATE(), ' 09:00:00'), 2500),
-(2, 'CARD', CONCAT(CURDATE(), ' 11:15:00'), 4000),
-(2, 'CASH', CONCAT(CURDATE(), ' 12:30:00'), 5500),
-(2, 'CARD', CONCAT(CURDATE(), ' 13:00:00'), 3500),
-(2, 'CARD', CONCAT(CURDATE(), ' 14:45:00'), 7000),
-(2, 'CARD', CONCAT(CURDATE(), ' 16:20:00'), 4500),
-(2, 'CASH', CONCAT(CURDATE(), ' 18:00:00'), 3000),
-(2, 'CARD', CONCAT(CURDATE(), ' 20:00:00'), 5000),
+(11, 2, 'CARD', CONCAT(CURDATE(), ' 09:00:00'), 2500),
+(12, 2, 'CARD', CONCAT(CURDATE(), ' 11:15:00'), 4000),
+(13, 2, 'CASH', CONCAT(CURDATE(), ' 12:30:00'), 5500),
+(14, 2, 'CARD', CONCAT(CURDATE(), ' 13:00:00'), 3500),
+(15, 2, 'CARD', CONCAT(CURDATE(), ' 14:45:00'), 7000),
+(16, 2, 'CARD', CONCAT(CURDATE(), ' 16:20:00'), 4500),
+(17, 2, 'CASH', CONCAT(CURDATE(), ' 18:00:00'), 3000),
+(18, 2, 'CARD', CONCAT(CURDATE(), ' 20:00:00'), 5000),
 -- 잠실점 (6건)
-(3, 'CARD', CONCAT(CURDATE(), ' 10:00:00'), 3000),
-(3, 'CARD', CONCAT(CURDATE(), ' 11:45:00'), 4500),
-(3, 'CASH', CONCAT(CURDATE(), ' 12:55:00'), 6000),
-(3, 'CARD', CONCAT(CURDATE(), ' 14:20:00'), 2500),
-(3, 'CARD', CONCAT(CURDATE(), ' 16:00:00'), 3500),
-(3, 'CARD', CONCAT(CURDATE(), ' 18:30:00'), 5000),
+(19, 3, 'CARD', CONCAT(CURDATE(), ' 10:00:00'), 3000),
+(20, 3, 'CARD', CONCAT(CURDATE(), ' 11:45:00'), 4500),
+(21, 3, 'CASH', CONCAT(CURDATE(), ' 12:55:00'), 6000),
+(22, 3, 'CARD', CONCAT(CURDATE(), ' 14:20:00'), 2500),
+(23, 3, 'CARD', CONCAT(CURDATE(), ' 16:00:00'), 3500),
+(24, 3, 'CARD', CONCAT(CURDATE(), ' 18:30:00'), 5000),
 -- 신촌점 (4건)
-(4, 'CARD', CONCAT(CURDATE(), ' 11:00:00'), 2000),
-(4, 'CASH', CONCAT(CURDATE(), ' 12:20:00'), 4000),
-(4, 'CARD', CONCAT(CURDATE(), ' 14:00:00'), 3000),
-(4, 'CARD', CONCAT(CURDATE(), ' 17:30:00'), 5500),
+(25, 4, 'CARD', CONCAT(CURDATE(), ' 11:00:00'), 2000),
+(26, 4, 'CASH', CONCAT(CURDATE(), ' 12:20:00'), 4000),
+(27, 4, 'CARD', CONCAT(CURDATE(), ' 14:00:00'), 3000),
+(28, 4, 'CARD', CONCAT(CURDATE(), ' 17:30:00'), 5500),
 -- 광화문점 (2건)
-(5, 'CARD', CONCAT(CURDATE(), ' 12:15:00'), 3500),
-(5, 'CASH', CONCAT(CURDATE(), ' 15:00:00'), 4500);
+(29, 5, 'CARD', CONCAT(CURDATE(), ' 12:15:00'), 3500),
+(30, 5, 'CASH', CONCAT(CURDATE(), ' 15:00:00'), 4500);
 
 -- pos_orders_item (~45건, 결제당 1~3개)
 INSERT INTO pos_orders_item (pos_pay_idx, menu_idx, quantity) VALUES

--- a/backend/statistics/src/main/resources/data.sql
+++ b/backend/statistics/src/main/resources/data.sql
@@ -5,44 +5,42 @@ DELETE FROM menu;
 DELETE FROM menu_category;
 DELETE FROM store;
 
+-- pos_pay, pos_orders_item만 AUTO_INCREMENT 사용 (store/menu/menu_category는 idx 직접 지정)
 ALTER TABLE pos_orders_item AUTO_INCREMENT = 1;
 ALTER TABLE pos_pay AUTO_INCREMENT = 1;
-ALTER TABLE menu AUTO_INCREMENT = 1;
-ALTER TABLE menu_category AUTO_INCREMENT = 1;
-ALTER TABLE store AUTO_INCREMENT = 1;
 
--- menu_category (4)
-INSERT INTO menu_category (menu_category_name, is_deleted) VALUES
-                                                               ('커피', false),
-                                                               ('베버리지', false),
-                                                               ('아이스블렌디드', false),
-                                                               ('티 & 에이드', false);
+-- menu_category (4) — idx 직접 지정
+INSERT INTO menu_category (menu_category_idx, menu_category_name, is_deleted) VALUES
+(1, '커피', false),
+(2, '베버리지', false),
+(3, '아이스블렌디드', false),
+(4, '티 & 에이드', false);
 
--- menu (15)
-INSERT INTO menu (menu_name, price, img_path, is_deleted, menu_category_idx) VALUES
-                                                                                 ('아메리카노', 1500, '/uploads/menu/americano.jpg', false, 1),
-                                                                                 ('카페라떼', 2500, '/uploads/menu/cafelatte.jpg', false, 1),
-                                                                                 ('바닐라라떼', 3000, '/uploads/menu/vanillalatte.jpg', false, 1),
-                                                                                 ('카라멜마끼아또', 3500, '/uploads/menu/caramelmacchiato.jpg', false, 1),
-                                                                                 ('카푸치노', 2500, '/uploads/menu/cappuccino.jpg', false, 1),
-                                                                                 ('녹차라떼', 3000, '/uploads/menu/greentealatte.jpg', false, 2),
-                                                                                 ('초코라떼', 3000, '/uploads/menu/chocolatte.jpg', false, 2),
-                                                                                 ('딸기스무디', 3500, '/uploads/menu/strawberrysmoothie.jpg', false, 3),
-                                                                                 ('망고스무디', 3500, '/uploads/menu/mangosmoothie.jpg', false, 3),
-                                                                                 ('복숭아아이스티', 2500, '/uploads/menu/peachicedtea.jpg', false, 4),
-                                                                                 ('레몬에이드', 2500, '/uploads/menu/lemonade.jpg', false, 4),
-                                                                                 ('자몽에이드', 3000, '/uploads/menu/grapefruitade.jpg', false, 4),
-                                                                                 ('얼그레이티', 2000, '/uploads/menu/earlgrey.jpg', false, 4),
-                                                                                 ('캐모마일티', 2000, '/uploads/menu/chamomile.jpg', false, 4),
-                                                                                 ('히비스커스티', 2000, '/uploads/menu/hibiscus.jpg', false, 4);
+-- menu (15) — idx 직접, imgPath 제거
+INSERT INTO menu (menu_idx, menu_name, price, is_deleted, menu_category_idx) VALUES
+(1, '아메리카노', 1500, false, 1),
+(2, '카페라떼', 2500, false, 1),
+(3, '바닐라라떼', 3000, false, 1),
+(4, '카라멜마끼아또', 3500, false, 1),
+(5, '카푸치노', 2500, false, 1),
+(6, '녹차라떼', 3000, false, 2),
+(7, '초코라떼', 3000, false, 2),
+(8, '딸기스무디', 3500, false, 3),
+(9, '망고스무디', 3500, false, 3),
+(10, '복숭아아이스티', 2500, false, 4),
+(11, '레몬에이드', 2500, false, 4),
+(12, '자몽에이드', 3000, false, 4),
+(13, '얼그레이티', 2000, false, 4),
+(14, '캐모마일티', 2000, false, 4),
+(15, '히비스커스티', 2000, false, 4);
 
--- store (5)
-INSERT INTO store (store_name, address, address_detail, file_path, business, postcode, created_at, is_deleted) VALUES
-                                                                                                                   ('강남점', '서울 강남구 테헤란로 123', '1층', '/uploads/store/gangnam.jpg', '123-45-67890', '06234', NOW(), false),
-                                                                                                                   ('홍대점', '서울 마포구 와우산로 45', '2층', '/uploads/store/hongdae.jpg', '123-45-67891', '04057', NOW(), false),
-                                                                                                                   ('잠실점', '서울 송파구 올림픽로 240', '1층', '/uploads/store/jamsil.jpg', '123-45-67892', '05551', NOW(), false),
-                                                                                                                   ('신촌점', '서울 서대문구 연세로 14', '1층', '/uploads/store/sinchon.jpg', '123-45-67893', '03729', NOW(), false),
-                                                                                                                   ('광화문점', '서울 종로구 새문안로 1', '1층', '/uploads/store/gwanghwamun.jpg', '123-45-67894', '03174', NOW(), false);
+-- store (5) — idx 직접, 부수 컬럼 제거
+INSERT INTO store (store_idx, store_name, is_deleted) VALUES
+(1, '강남점', false),
+(2, '홍대점', false),
+(3, '잠실점', false),
+(4, '신촌점', false),
+(5, '광화문점', false);
 
 -- pos_pay (30건, 오늘 CURDATE, 시간/매장/method 분산)
 INSERT INTO pos_pay (store_idx, method, paid_at, pay_amount) VALUES


### PR DESCRIPTION
## Summary
- monolith의 store/menu/pos 도메인 이벤트를 Kafka로 발행하고 Statistics MSA가 consume해서 자체 DB에 적재
- B-1(통계 MSA 분리) 후속 단계 — 시드 데이터 의존 해소, 실 데이터 흐름 확립
- 로컬 환경에서 동작 검증 완료 (K8s 통합 검증은 후속 PR에서)

## 변경 파일
- backend/monolith/build.gradle — spring-kafka 의존성
- backend/monolith/src/main/resources/application-dev.yaml — Kafka producer 설정
- backend/monolith/src/main/java/com/example/nexus/event/ — 이벤트 페이로드 5종
- backend/monolith/src/main/java/com/example/nexus/domain/pos/PosService.java — pos.payment.created 발행
- backend/monolith/src/main/java/com/example/nexus/domain/store/StoreService.java — store.created/updated 발행
- backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuService.java — menu.created/updated/deleted 발행
- backend/statistics/build.gradle — spring-kafka 의존성
- backend/statistics/src/main/resources/application-dev.yaml — Consumer 설정 (ErrorHandlingDeserializer + type.mapping)
- backend/statistics/src/main/resources/data.sql — slim schema에 맞게 idx 명시
- backend/statistics/src/main/java/com/example/statistics/event/ — 이벤트 페이로드 5종 + Consumer 3종
- backend/statistics/src/main/java/com/example/statistics/domain/{store,menu,pos}/ — Repository 신규, 엔티티 슬림화

## 주요 변경 사항
- 이벤트 도입 (Kafka 토픽 6개)
- pos.payment.created, store.created/updated, menu.created/updated/deleted
- 이벤트 페이로드 비정규화 (storeName/menuName 스냅샷 박음)
- monolith → 결제/매장/메뉴 변경 시 KafkaTemplate.send() 직접 호출
- statistics → @KafkaListener로 받아 자체 DB에 upsert (Builder + save로 JPA merge)
- 멱등성 — PosPay는 existsById 체크, Store/Menu는 같은 ID로 자연스레 덮어쓰기
- statistics 엔티티 슬림화 (Store/Menu에서 통계 무관 컬럼 제거)

## DB & Infrastructure
- statistics 자체 DB(nexus-mariadb-statistics, 호스트 3307) 사용
- 새 토픽 6개 자동 생성 (Strimzi nexus-kafka 클러스터)
- Kafka 외부 listener 경유
- statistics 엔티티 schema 변경 → docker compose down -v 필요
- monolith DB 변경 없음

## Test Plan
- [ ] git pull 후 backend/statistics/.env에 KAFKA_BOOTSTRAP_SERVERS 추가
- [ ] cd backend/statistics/docker && docker compose down -v && docker compose up -d (DB 재초기화)
- [ ] IntelliJ에서 NexusApplication, StatisticsApplication 둘 다 실행
- [ ] Kafka UI에서 토픽 자동 생성 확인
- [ ] Postman으로 다음 호출 → statistics 로그에 [event-name] received 라인 + DB upsert 확인
- POST /pos/pay → pos.payment.created
- POST /store/new/register → store.created
- PUT /store/update/{idx} → store.updated
- POST /menu/new/register → menu.created
- PUT /menu/update/{idx} → menu.updated
- PUT /menu/delete/{idx} → menu.deleted
- [ ] GET /statistics/sales/today → 시드 + 새 결제 합계 반영 확인

## 알려진 한계 (후속 PR 보강 예정)
- LocalDateTime이 ISO 문자열이 아닌 배열로 직렬화 (양쪽 동일 동작이라 동작엔 무관)
- @Transactional 결제 메서드 내 KafkaTemplate.send → rollback 시 정합성 깨질 위험 (Outbox 패턴 후속)
- Consumer 멱등성은 PosPay만 (Store/Menu는 같은 ID 덮어쓰기로 자연 멱등)
- K8s 배포 yaml 미포함 (Statistics Pod, Statistics DB StatefulSet 등은 다음 PR)

## Issue
- Closes #833 