### PR TITLE
[Feat] #832 - Reader→Processor→Writer 분리 리팩토링

### DIFF
--- a/backend/batch/src/main/java/com/example/batch/job/OrderApproveProcessor.java
+++ b/backend/batch/src/main/java/com/example/batch/job/OrderApproveProcessor.java
@@ -1,0 +1,25 @@
+package com.example.batch.job;
+
+import com.example.batch.common.enums.OrdersStatus;
+import com.example.batch.domain.orders.OrdersRepository;
+import com.example.batch.domain.orders.model.Orders;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderApproveProcessor implements ItemProcessor<Long, Orders> {
+
+    private final OrdersRepository ordersRepository;
+
+    @Override
+    public Orders process(Long orderId) {
+        log.info("processing orderId={}", orderId);
+        return ordersRepository.findByIdWithDetailsForUpdate(orderId)
+                .filter(o -> o.getOrdersStatus() == OrdersStatus.CONFIRMED)
+                .orElse(null);
+    }
+}

--- a/backend/batch/src/main/java/com/example/batch/job/OrderApproveWriter.java
+++ b/backend/batch/src/main/java/com/example/batch/job/OrderApproveWriter.java
@@ -2,7 +2,6 @@ package com.example.batch.job;
 
 import com.example.batch.common.enums.DeliveryStatus;
 import com.example.batch.common.enums.InventoryStatus;
-import com.example.batch.common.enums.OrdersStatus;
 import com.example.batch.common.exception.BaseException;
 import com.example.batch.common.model.BaseResponseStatus;
 import com.example.batch.domain.delivery.DeliveryRepository;
@@ -13,21 +12,21 @@ import com.example.batch.domain.head.model.HeadIncome;
 import com.example.batch.domain.head.model.HeadInventory;
 import com.example.batch.domain.inventory.InventoryMovementRepository;
 import com.example.batch.domain.inventory.model.InventoryMovement;
-import com.example.batch.domain.orders.OrdersRepository;
 import com.example.batch.domain.orders.model.Orders;
 import com.example.batch.domain.orders.model.OrdersItem;
 import com.example.batch.domain.store.StoreInventoryRepository;
 import com.example.batch.domain.store.model.StoreInventory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class OrderApproveWriter implements ItemWriter<Long> {
+@Slf4j
+public class OrderApproveWriter implements ItemWriter<Orders> {
 
-    private final OrdersRepository ordersRepository;
     private final HeadInventoryRepository headInventoryRepository;
     private final HeadIncomeRepository headIncomeRepository;
     private final StoreInventoryRepository storeInventoryRepository;
@@ -35,28 +34,17 @@ public class OrderApproveWriter implements ItemWriter<Long> {
     private final DeliveryRepository deliveryRepository;
 
     @Override
-    public void write(Chunk<? extends Long> chunk) {
-        for (Long orderId : chunk) {
+    public void write(Chunk<? extends Orders> chunk) {
+        for (Orders orders : chunk) {
+            log.info("writing orderId={}", orders.getIdx());
             try {
-                processOrder(orderId);
+                applyOutbound(orders);
+                orders.approve();
+                saveHeadIncome(orders);
+                startDelivery(orders);
             } catch (BaseException e) {
             }
         }
-    }
-
-    private void processOrder(Long orderId) {
-        Orders orders = ordersRepository.findByIdWithDetailsForUpdate(orderId)
-                .filter(o -> o.getOrdersStatus() == OrdersStatus.CONFIRMED)
-                .orElse(null);
-
-        if (orders == null) {
-            return;
-        }
-
-        applyOutbound(orders);
-        orders.approve();
-        saveHeadIncome(orders);
-        startDelivery(orders);
     }
 
     private void applyOutbound(Orders orders) {

--- a/backend/batch/src/main/java/com/example/batch/job/OrdersApproveJobConfig.java
+++ b/backend/batch/src/main/java/com/example/batch/job/OrdersApproveJobConfig.java
@@ -1,11 +1,13 @@
 package com.example.batch.job;
 
+import com.example.batch.domain.orders.model.Orders;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.database.JdbcCursorItemReader;
@@ -34,10 +36,13 @@ public class OrdersApproveJobConfig {
     }
 
     @Bean
-    public Step approveConfirmedOrdersStep(ItemWriter<Long> orderApproveWriter) {
+    public Step approveConfirmedOrdersStep(
+            ItemProcessor<Long, Orders> orderApproveProcessor,
+            ItemWriter<Orders> orderApproveWriter) {
         return new StepBuilder("approveConfirmedOrdersStep", jobRepository)
-                .<Long, Long>chunk(CHUNK_SIZE, transactionManager)
+                .<Long, Orders>chunk(CHUNK_SIZE, transactionManager)
                 .reader(confirmedOrderIdsReader())
+                .processor(orderApproveProcessor)
                 .writer(orderApproveWriter)
                 .build();
     }


### PR DESCRIPTION
- ItemProcessor<Long, Orders> 분리: FOR UPDATE 락 및 CONFIRMED 상태 검증
- ItemWriter<Orders>로 변경: Processor에서 넘겨받은 Orders 직접 처리 (재조회 제거)
- JdbcCursorItemReader WHERE CONFIRMED 필터 및 직렬 처리 구조 복원

Closes #832 