### PR TITLE
[Feat] #837 - Statistics MSA K8s 배포 + 부하테스트 환경 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ cookies.txt
 k8s/load-test/k6-load-test.js
 k8s/load-test/seed-data.sql
 k8s/load-test/README.md
+k8s/load-test/test-statistics-secret.yaml
+k8s/load-test/test-backend-secret.yaml

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 monolith/.env
 datalocal.sql
+k8s/load-test/test-db-statefulset.yaml

--- a/backend/monolith/build.gradle
+++ b/backend/monolith/build.gradle
@@ -3,6 +3,14 @@ plugins {
     id 'io.spring.dependency-management'
 }
 
+bootJar {
+    archiveFileName = 'monolith.jar'
+}
+
+jar {
+    enabled = false
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/backend/monolith/src/main/resources/application-prod.yaml
+++ b/backend/monolith/src/main/resources/application-prod.yaml
@@ -63,6 +63,15 @@ spring:
           auth: true
           timeout: 5000
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: true
+        spring.json.type.mapping: paymentEvent:com.example.nexus.event.PaymentEvent,storeEvent:com.example.nexus.event.StoreEvent,menuEvent:com.example.nexus.event.MenuEvent
+
 server:
   port: 8080
 

--- a/backend/statistics/build.gradle
+++ b/backend/statistics/build.gradle
@@ -14,6 +14,7 @@ jar {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // --- DB / JPA ---
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/backend/statistics/build.gradle
+++ b/backend/statistics/build.gradle
@@ -3,6 +3,14 @@ plugins {
     id 'io.spring.dependency-management'
 }
 
+bootJar {
+    archiveFileName = 'statistics.jar'
+}
+
+jar {
+    enabled = false
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/backend/statistics/src/main/resources/application-prod.yaml
+++ b/backend/statistics/src/main/resources/application-prod.yaml
@@ -1,0 +1,54 @@
+spring:
+  application:
+    name: NexusStatistics
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASS}
+    driver-class-name: ${DB_DRIVER}
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: ${SQL_INIT_MODE:always}        # 학습 단계 always, 운영 시 never로 가능
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    consumer:
+      group-id: ${KAFKA_GROUP_ID:statistics-prod}
+      auto-offset-reset: earliest
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: "*"
+        spring.json.type.mapping: paymentEvent:com.example.statistics.event.PaymentEvent,storeEvent:com.example.statistics.event.StoreEvent,menuEvent:com.example.statistics.event.MenuEvent
+
+server:
+  port: 8081
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus, metrics
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true
+  health:
+    mail:
+      enabled: false
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY mcp/naver-news-search /app/mcp
 RUN cd /app/mcp && npm install --omit=dev
 
-COPY backend/build/libs/monolith.jar app.jar
+COPY backend/monolith/build/libs/monolith.jar app.jar
 
 EXPOSE 8080
 ENTRYPOINT ["java", "-Xms512m", "-Xmx1024m", "-jar", "app.jar"]

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY mcp/naver-news-search /app/mcp
 RUN cd /app/mcp && npm install --omit=dev
 
-COPY backend/build/libs/*.jar app.jar
+COPY backend/build/libs/monolith.jar app.jar
 
 EXPOSE 8080
 ENTRYPOINT ["java", "-Xms512m", "-Xmx1024m", "-jar", "app.jar"]

--- a/docker/statistics/Dockerfile
+++ b/docker/statistics/Dockerfile
@@ -1,0 +1,8 @@
+FROM eclipse-temurin:17-jre-alpine
+
+WORKDIR /app
+
+COPY backend/statistics/build/libs/statistics.jar app.jar
+
+EXPOSE 8081
+ENTRYPOINT ["java", "-Xms512m", "-Xmx1024m", "-jar", "app.jar"]

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -102,7 +102,7 @@ const demoAccounts = [
     badgeClass: 'bg-orange-50 text-orange-600 border border-orange-200',
   },
   {
-    email: 'store01@theventi.co.kr', name: '김동현', avatar: 'KD', roleLabel: '점주 (가맹점)',
+    email: 'store0001@theventi.co.kr', name: '김동현', avatar: 'KD', roleLabel: '점주 (가맹점)',
     colorClass: 'bg-blue-500',
     badgeClass: 'bg-blue-50 text-blue-600 border border-blue-200',
   },

--- a/jenkins/backend/Jenkinsfile
+++ b/jenkins/backend/Jenkinsfile
@@ -41,7 +41,7 @@ spec:
                 container('gradle') {
                     dir('backend') {
                         // gradlew 실행 권한 부여 후 테스트 제외하고 JAR 생성
-                        sh 'chmod +x gradlew && ./gradlew bootJar -x test'
+                        sh 'chmod +x gradlew && ./gradlew :monolith:bootJar -x test'
                     }
                 }
             }

--- a/k8s/load-test/statistics-seed-data.sql
+++ b/k8s/load-test/statistics-seed-data.sql
@@ -1,0 +1,184 @@
+-- ============================================================
+-- 부하 테스트용 Statistics MSA 더미데이터 (slim schema 기반)
+-- 용도: test-statistics-db에 매장 3000개 + 결제 30000건 투입
+-- 실행: kubectl exec -i -n test test-statistics-db-statefulset-0 -- \
+--         mariadb -uroot -pqwer1234 nexus < statistics-seed-data.sql
+-- 멱등성: 여러 번 실행해도 안전 (기존 시드 정리 후 재생성)
+--
+-- monolith seed-data.sql과의 차이:
+--  - user/pos_store_inventory 테이블 없음 (statistics 무관)
+--  - store는 slim schema (storeName + isDeleted만)
+--  - pos_pay는 @GeneratedValue 제거되어 idx 직접 명시 (100001~)
+--  - 결제 분포 패턴은 동일 (3000 매장, 30000건, 피크타임 11~13시 40%)
+-- ============================================================
+
+-- ============================================================
+-- 0. 기존 시드 데이터 정리 (FK 순서: 자식 → 부모)
+-- ============================================================
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- 결제 관련 (data.sql 시드 + 부하테스트 시드 둘 다 정리)
+DELETE FROM pos_orders_item WHERE pos_pay_idx IN (SELECT pos_pay_idx FROM pos_pay WHERE paid_at >= CURDATE());
+DELETE FROM pos_pay WHERE paid_at >= CURDATE();
+
+-- 시드로 생성한 매장 정리 (data.sql의 1~5번은 유지, 6번 이후 삭제)
+DELETE FROM store WHERE store_idx > 5;
+
+-- pos_orders_item은 AUTO_INCREMENT 유지, 리셋만 (FK 영향 없음)
+ALTER TABLE pos_orders_item AUTO_INCREMENT = 1;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- ============================================================
+-- 1. 테스트용 매장 6~3000 생성 (slim schema: idx + storeName + isDeleted)
+-- ============================================================
+DELIMITER $$
+DROP PROCEDURE IF EXISTS seed_stores$$
+CREATE PROCEDURE seed_stores()
+BEGIN
+    DECLARE i INT DEFAULT 6;
+
+    SET autocommit = 0;
+
+    WHILE i <= 3000 DO
+        INSERT IGNORE INTO store (store_idx, store_name, is_deleted)
+        VALUES (
+            i,
+            CONCAT('더벤티 테스트', LPAD(i, 4, '0'), '점'),
+            0
+        );
+
+        IF i MOD 500 = 0 THEN
+            COMMIT;
+        END IF;
+        SET i = i + 1;
+    END WHILE;
+
+    COMMIT;
+    SET autocommit = 1;
+END$$
+DELIMITER ;
+
+CALL seed_stores();
+DROP PROCEDURE IF EXISTS seed_stores;
+
+-- ============================================================
+-- 2. 대량 결제 데이터 생성 (오늘 날짜 30000건)
+--    3000개 매장에 분산, 피크타임(11~13시)에 40% 집중
+--    pos_pay_idx는 100001부터 (monolith 결제 idx와 충돌 회피)
+-- ============================================================
+DELIMITER $$
+DROP PROCEDURE IF EXISTS seed_pos_pay$$
+CREATE PROCEDURE seed_pos_pay()
+BEGIN
+    DECLARE i INT DEFAULT 1;
+    DECLARE total INT DEFAULT 30000;
+    DECLARE start_idx BIGINT DEFAULT 100000;
+    DECLARE store_id INT;
+    DECLARE pay_method VARCHAR(10);
+    DECLARE pay_hour INT;
+    DECLARE pay_minute INT;
+    DECLARE pay_amount BIGINT;
+    DECLARE menu_id INT;
+    DECLARE qty INT;
+    DECLARE paid DATETIME;
+    DECLARE rand_val DOUBLE;
+    DECLARE pay_id BIGINT;
+
+    SET autocommit = 0;
+
+    WHILE i <= total DO
+        -- 매장 랜덤 선택 (1~3000)
+        SET store_id = 1 + FLOOR(RAND() * 3000);
+
+        -- 결제수단: CARD 70%, CASH 30%
+        IF RAND() < 0.7 THEN SET pay_method = 'CARD';
+        ELSE SET pay_method = 'CASH';
+        END IF;
+
+        -- 시간 분포: 피크(11~13시) 40%, 오전(8~10) 15%, 오후(14~17) 20%, 저녁(18~21) 25%
+        SET rand_val = RAND();
+        IF rand_val < 0.40 THEN
+            SET pay_hour = 11 + FLOOR(RAND() * 3);
+        ELSEIF rand_val < 0.55 THEN
+            SET pay_hour = 8 + FLOOR(RAND() * 3);
+        ELSEIF rand_val < 0.75 THEN
+            SET pay_hour = 14 + FLOOR(RAND() * 4);
+        ELSE
+            SET pay_hour = 18 + FLOOR(RAND() * 4);
+        END IF;
+        SET pay_minute = FLOOR(RAND() * 60);
+
+        SET paid = CONCAT(CURDATE(), ' ',
+                         LPAD(pay_hour, 2, '0'), ':',
+                         LPAD(pay_minute, 2, '0'), ':',
+                         LPAD(FLOOR(RAND() * 60), 2, '0'));
+
+        -- 메뉴 1~15 중 랜덤, 가격 매핑
+        SET menu_id = 1 + FLOOR(RAND() * 15);
+        SET qty = 1 + FLOOR(RAND() * 3);
+
+        CASE menu_id
+            WHEN 1  THEN SET pay_amount = 1500 * qty;
+            WHEN 2  THEN SET pay_amount = 2500 * qty;
+            WHEN 3  THEN SET pay_amount = 3000 * qty;
+            WHEN 4  THEN SET pay_amount = 3500 * qty;
+            WHEN 5  THEN SET pay_amount = 2500 * qty;
+            WHEN 6  THEN SET pay_amount = 3000 * qty;
+            WHEN 7  THEN SET pay_amount = 3000 * qty;
+            WHEN 8  THEN SET pay_amount = 3500 * qty;
+            WHEN 9  THEN SET pay_amount = 3500 * qty;
+            WHEN 10 THEN SET pay_amount = 2500 * qty;
+            WHEN 11 THEN SET pay_amount = 2500 * qty;
+            WHEN 12 THEN SET pay_amount = 3000 * qty;
+            WHEN 13 THEN SET pay_amount = 2000 * qty;
+            WHEN 14 THEN SET pay_amount = 2000 * qty;
+            WHEN 15 THEN SET pay_amount = 2000 * qty;
+        END CASE;
+
+        -- statistics의 pos_pay는 @GeneratedValue 없음 → idx 직접 지정
+        SET pay_id = start_idx + i;
+
+        INSERT INTO pos_pay (pos_pay_idx, store_idx, method, paid_at, pay_amount)
+        VALUES (pay_id, store_id, pay_method, paid, pay_amount);
+
+        -- pos_orders_item은 AUTO_INCREMENT (idx 자동 채번)
+        INSERT INTO pos_orders_item (pos_pay_idx, menu_idx, quantity)
+        VALUES (pay_id, menu_id, qty);
+
+        -- 30% 확률로 추가 메뉴 아이템
+        IF RAND() < 0.3 THEN
+            SET menu_id = 1 + FLOOR(RAND() * 15);
+            SET qty = 1;
+            INSERT INTO pos_orders_item (pos_pay_idx, menu_idx, quantity)
+            VALUES (pay_id, menu_id, qty);
+        END IF;
+
+        SET i = i + 1;
+
+        -- 5000건마다 커밋
+        IF i MOD 5000 = 0 THEN
+            COMMIT;
+        END IF;
+    END WHILE;
+
+    COMMIT;
+    SET autocommit = 1;
+END$$
+DELIMITER ;
+
+CALL seed_pos_pay();
+DROP PROCEDURE IF EXISTS seed_pos_pay;
+
+-- ============================================================
+-- 확인 쿼리
+-- ============================================================
+SELECT '=== Statistics 시드 데이터 확인 ===' AS info;
+SELECT COUNT(*) AS total_stores FROM store;
+SELECT COUNT(*) AS total_pos_pay FROM pos_pay WHERE paid_at >= CURDATE();
+SELECT COUNT(*) AS total_pos_orders_item FROM pos_orders_item;
+SELECT HOUR(paid_at) AS h, COUNT(*) AS cnt
+FROM pos_pay
+WHERE paid_at >= CURDATE()
+GROUP BY HOUR(paid_at)
+ORDER BY h;

--- a/k8s/load-test/test-backend-configmap.yaml
+++ b/k8s/load-test/test-backend-configmap.yaml
@@ -11,3 +11,4 @@ data:
   AWS_S3_STORE_BUCKET: nexus-store-archive
   AWS_S3_MENU_BUCKET: nexus-menu-assets
   AWS_S3_STATIC: ap-northeast-2
+  KAFKA_BOOTSTRAP_SERVERS: nexus-kafka-kafka-bootstrap.kafka.svc:9092

--- a/k8s/load-test/test-backend-configmap.yaml
+++ b/k8s/load-test/test-backend-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-backend-config
+  namespace: test
 data:
   SPRING_PROFILES_ACTIVE: prod
   DB_URL: jdbc:mariadb://test-db-service:3306/nexus

--- a/k8s/load-test/test-backend-deployment.yaml
+++ b/k8s/load-test/test-backend-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: nexus-backend
-          image: deatytim/nexusback:latest
+          image: deatytim/nexusback:dev-msa
           ports:
             - containerPort: 8080
           env:

--- a/k8s/load-test/test-namespace.yaml
+++ b/k8s/load-test/test-namespace.yaml
@@ -1,0 +1,9 @@
+## 부하 테스트 전용 네임스페이스
+## 운영(default)과 격리하여 리소스 충돌 방지 + 정리 용이
+## 부하테스트 종료 시 'kubectl delete namespace test' 한 줄로 전체 정리 가능
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+  labels:
+    purpose: load-test

--- a/k8s/load-test/test-statistics-configmap.yaml
+++ b/k8s/load-test/test-statistics-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-statistics-config
+  namespace: test
+data:
+  SPRING_PROFILES_ACTIVE: prod
+  DB_URL: jdbc:mariadb://test-statistics-db-service:3306/nexus
+  DB_DRIVER: org.mariadb.jdbc.Driver
+  DB_USER: root
+  KAFKA_BOOTSTRAP_SERVERS: nexus-kafka-kafka-bootstrap.kafka.svc:9092
+  KAFKA_GROUP_ID: test-statistics-prod
+  SQL_INIT_MODE: always

--- a/k8s/load-test/test-statistics-db-statefulset.yaml
+++ b/k8s/load-test/test-statistics-db-statefulset.yaml
@@ -1,31 +1,33 @@
-## 부하 테스트 전용 MariaDB
-## 운영 DB(db-statefulset)와 완전히 분리된 별도 인스턴스
+## 부하 테스트 전용 Statistics MariaDB (운영 DB와 별도 인스턴스)
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: test-db-statefulset
+  name: test-statistics-db-statefulset
   namespace: test
 spec:
   replicas: 1
   selector:
     matchLabels:
-      type: test-db
-  serviceName: test-db-service
+      type: test-statistics-db
+  serviceName: test-statistics-db-service
   template:
     metadata:
       labels:
-        type: test-db
+        type: test-statistics-db
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: mariadb
-          image: mariadb:latest
+          image: mariadb:11.4
           ports:
             - containerPort: 3306
           env:
             - name: MARIADB_ROOT_PASSWORD
-              value: qwer1234
+              valueFrom:
+                secretKeyRef:
+                  name: test-statistics-secret
+                  key: DB_PASS
             - name: MARIADB_ROOT_HOST
               value: '%'
             - name: MARIADB_DATABASE
@@ -57,12 +59,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: test-db-service
+  name: test-statistics-db-service
   namespace: test
 spec:
-  clusterIP: None
+  clusterIP: None         # Headless (statistics Pod이 DNS로 접근)
   selector:
-    type: test-db
+    type: test-statistics-db
   ports:
     - port: 3306
       targetPort: 3306

--- a/k8s/load-test/test-statistics-deployment.yaml
+++ b/k8s/load-test/test-statistics-deployment.yaml
@@ -1,52 +1,50 @@
-## 부하 테스트 전용 Backend Deployment
-## 운영 pod와 완전히 분리 (별도 이름, 별도 DB)
+## 부하 테스트 전용 Statistics MSA Deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: test-backend
+  name: test-statistics
   namespace: test
   labels:
-    app: test-backend
+    app: test-statistics
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: test-backend
+      app: test-statistics
   template:
     metadata:
       labels:
-        app: test-backend
+        app: test-statistics
       annotations:
-        sidecar.istio.io/inject: "false"   # 테스트용이라 Istio sidecar 불필요
+        sidecar.istio.io/inject: "false"
         prometheus.io/scrape: "true"
         prometheus.io/path: "/actuator/prometheus"
-        prometheus.io/port: "8080"
+        prometheus.io/port: "8081"
     spec:
       containers:
-        - name: nexus-backend
-          image: deatytim/nexusback:latest
+        - name: nexus-statistics
+          image: deatytim/nexusstat:dev-msa
           ports:
-            - containerPort: 8080
+            - containerPort: 8081
           env:
-            ## JVM 메모리 설정
             - name: JAVA_TOOL_OPTIONS
               value: "-Xms512m -Xmx1024m"
           envFrom:
             - configMapRef:
-                name: test-backend-config
+                name: test-statistics-config
             - secretRef:
-                name: test-backend-secret    # test namespace 자체 Secret (운영과 분리)
+                name: test-statistics-secret
           resources:
             requests:
               cpu: 500m
               memory: 1Gi
             limits:
-              cpu: 1000m          # 1 core
-              memory: 1536Mi      # Xmx 1024m + JVM 오버헤드 ~256m + 여유
+              cpu: 1000m
+              memory: 1536Mi
           readinessProbe:
             httpGet:
               path: /actuator/health
-              port: 8080
+              port: 8081
             initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 10
@@ -54,24 +52,23 @@ spec:
           livenessProbe:
             httpGet:
               path: /actuator/health
-              port: 8080
+              port: 8081
             initialDelaySeconds: 120
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 5
 ---
-## 테스트 Backend에 접근하기 위한 Service
-## NodePort로 외부에서 직접 k6 부하를 쏠 수 있게 함
+## Statistics Pod 디버깅용 NodePort (외부 actuator/health 확인용)
 apiVersion: v1
 kind: Service
 metadata:
-  name: test-backend-service
+  name: test-statistics-service
   namespace: test
 spec:
   type: NodePort
   selector:
-    app: test-backend
+    app: test-statistics
   ports:
-    - port: 8080
-      targetPort: 8080
-      nodePort: 30088        # 외부에서 <노드IP>:30088 으로 접근
+    - port: 8081
+      targetPort: 8081
+      nodePort: 30089           # 외부 <노드IP>:30089 으로 접근

--- a/k8s/monitoring/grafana-dashboard-test-statistics.json
+++ b/k8s/monitoring/grafana-dashboard-test-statistics.json
@@ -1,0 +1,265 @@
+{
+  "title": "Test Statistics Overview",
+  "tags": ["test", "spring-boot", "statistics", "kafka", "load-test"],
+  "timezone": "browser",
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": { "type": "prometheus" },
+        "query": "label_values(up{job=\"kubernetes-pods\", pod=~\"test-statistics.*\"}, instance)",
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Statistics MSA 상태",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "현재 TPS (HTTP)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "targets": [{ "expr": "sum(rate(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "reqps", "thresholds": { "steps": [{ "color": "blue", "value": null }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "title": "Kafka 소비 속도",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "targets": [{ "expr": "sum(rate(kafka_consumer_fetch_manager_records_consumed_total{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "ops", "decimals": 1, "thresholds": { "steps": [{ "color": "blue", "value": null }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "title": "Consumer Lag (Max)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "targets": [{ "expr": "max(kafka_consumer_fetch_manager_records_lag_max{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"})", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "decimals": 0, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 100 }, { "color": "red", "value": 1000 }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "title": "CPU 사용률",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "targets": [{ "expr": "avg(process_cpu_usage{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"})", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.5 }, { "color": "red", "value": 0.8 }] } } }
+    },
+    {
+      "title": "힙 메모리 사용률",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "targets": [{ "expr": "sum(jvm_memory_used_bytes{area=\"heap\", job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}) / sum(jvm_memory_max_bytes{area=\"heap\", job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"} > 0) * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 85 }] } } }
+    },
+    {
+      "title": "DB 활성 커넥션",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "targets": [{ "expr": "sum(hikaricp_connections_active{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"})", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "min": 0, "max": 20, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 15 }, { "color": "red", "value": 18 }] } } }
+    },
+
+    {
+      "title": "Kafka Consumer",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "토픽별 Consumer Lag",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [{ "expr": "sum by (topic) (kafka_consumer_fetch_manager_records_lag{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"})", "legendFormat": "{{topic}}" }],
+      "fieldConfig": { "defaults": { "decimals": 0, "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2 } } }
+    },
+    {
+      "title": "토픽별 소비 속도 (records/sec)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [{ "expr": "sum by (topic) (rate(kafka_consumer_fetch_manager_records_consumed_total{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{topic}}" }],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2 } } }
+    },
+    {
+      "title": "Listener 처리 시간 (AVG / P95 / P99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "targets": [
+        { "expr": "sum(rate(spring_kafka_listener_seconds_sum{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m])) / sum(rate(spring_kafka_listener_seconds_count{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "AVG" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(spring_kafka_listener_seconds_bucket{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m])))", "legendFormat": "P95" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(spring_kafka_listener_seconds_bucket{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m])))", "legendFormat": "P99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "Listener 에러 (실패한 메시지)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "targets": [{ "expr": "sum by (result) (rate(spring_kafka_listener_seconds_count{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\", result=\"failure\"}[5m]))", "legendFormat": "{{result}}" }],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 20, "lineWidth": 2 }, "color": { "mode": "fixed", "fixedColor": "red" } } }
+    },
+    {
+      "title": "Consumer Fetch 시간",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 22 },
+      "targets": [{ "expr": "rate(kafka_consumer_fetch_manager_fetch_latency_avg{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m])", "legendFormat": "Fetch latency avg" }],
+      "fieldConfig": { "defaults": { "unit": "ms", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "Partition별 Lag",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 22 },
+      "targets": [{ "expr": "kafka_consumer_fetch_manager_records_lag{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "{{topic}}-{{partition}}" }],
+      "fieldConfig": { "defaults": { "decimals": 0, "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1 } } }
+    },
+
+    {
+      "title": "HTTP 트래픽 (Statistics API)",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "HTTP 요청 수 (TPS)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "targets": [{ "expr": "sum by (method, uri) (rate(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{method}} {{uri}}" }],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2 } } }
+    },
+    {
+      "title": "응답 시간 (AVG / P95 / P99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "targets": [
+        { "expr": "sum by (pod) (rate(http_server_requests_seconds_sum{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m])) / sum by (pod) (rate(http_server_requests_seconds_count{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "AVG" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m])))", "legendFormat": "P95" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m])))", "legendFormat": "P99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+
+    {
+      "title": "JVM & 시스템",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "CPU 사용량 추이",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "targets": [
+        { "expr": "process_cpu_usage{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "Process CPU" },
+        { "expr": "system_cpu_usage{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "System CPU" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2 } } }
+    },
+    {
+      "title": "힙 메모리 사용량 추이",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "targets": [
+        { "expr": "sum by (id) (jvm_memory_used_bytes{area=\"heap\", job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"})", "legendFormat": "Used - {{id}}" },
+        { "expr": "sum(jvm_memory_max_bytes{area=\"heap\", job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"} > 0)", "legendFormat": "Max" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "GC 일시정지 시간",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "targets": [{ "expr": "sum by (action, cause) (rate(jvm_gc_pause_seconds_sum{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{action}} - {{cause}}" }],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "bars", "fillOpacity": 40, "lineWidth": 1 } } }
+    },
+    {
+      "title": "스레드 수",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "targets": [
+        { "expr": "jvm_threads_live_threads{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "Live" },
+        { "expr": "jvm_threads_daemon_threads{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "Daemon" },
+        { "expr": "jvm_threads_peak_threads{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "Peak" }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+
+    {
+      "title": "DB 커넥션 (Statistics DB)",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 56 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "DB 커넥션 풀",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 57 },
+      "targets": [
+        { "expr": "hikaricp_connections_active{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "Active" },
+        { "expr": "hikaricp_connections_idle{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "Idle" },
+        { "expr": "hikaricp_connections_pending{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "Pending" },
+        { "expr": "hikaricp_connections_max{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "Max" }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "DB 커넥션 획득 시간",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 57 },
+      "targets": [
+        { "expr": "hikaricp_connections_acquire_seconds_max{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}", "legendFormat": "Max 획득 시간" },
+        { "expr": "rate(hikaricp_connections_acquire_seconds_sum{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m]) / rate(hikaricp_connections_acquire_seconds_count{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[5m])", "legendFormat": "Avg 획득 시간" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } } }
+    },
+    {
+      "title": "DB 대기 스레드",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 65 },
+      "targets": [{ "expr": "sum(hikaricp_connections_pending{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"})", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "min": 0, "max": 10, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 5 }] } } }
+    },
+    {
+      "title": "DB 커넥션 타임아웃",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 65 },
+      "targets": [{ "expr": "sum(increase(hikaricp_connections_timeout_total{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[1h]))", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "title": "Non-Heap 메모리 사용률",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 65 },
+      "targets": [{ "expr": "sum(jvm_memory_used_bytes{area=\"nonheap\", job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}) / sum(jvm_memory_max_bytes{area=\"nonheap\", job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"} > 0) * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 85 }] } } }
+    },
+    {
+      "title": "서버 가동률",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 65 },
+      "targets": [{ "expr": "avg(avg_over_time(up{job=\"kubernetes-pods\", pod=~\"test-statistics.*\", instance=~\"$instance\"}[$__range])) * 100", "legendFormat": "" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 2, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 95 }, { "color": "yellow", "value": 99 }, { "color": "green", "value": 99.9 }] } } },
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "auto" }
+    }
+  ],
+  "schemaVersion": 39
+}


### PR DESCRIPTION
## Summary
- 멀티모듈 빌드(monolith.jar / statistics.jar) 정합 및 CI/CD 파이프라인 보정
- monolith·statistics prod Kafka 설정 분리 및 적용
- test 네임스페이스 분리 + Statistics MSA Pod/DB 배포
- 부하테스트용 시드 SQL과 Grafana 대시보드 추가

## 변경 파일
- backend/monolith/build.gradle, backend/statistics/build.gradle
- backend/monolith/src/main/resources/application-prod.yaml
- backend/statistics/src/main/resources/application-prod.yaml (신규)
- docker/backend/Dockerfile, docker/statistics/Dockerfile (신규)
- jenkins/backend/Jenkinsfile
- k8s/load-test/test-namespace.yaml (신규)
- k8s/load-test/test-statistics-deployment.yaml (신규)
- k8s/load-test/test-statistics-db-statefulset.yaml (신규)
- k8s/load-test/test-statistics-configmap.yaml (신규)
- k8s/load-test/test-backend-deployment.yaml
- k8s/load-test/test-backend-configmap.yaml
- k8s/load-test/test-db-statefulset.yaml
- k8s/load-test/statistics-seed-data.sql (신규)
- k8s/monitoring/grafana-dashboard-test-statistics.json (신규)
- .gitignore, backend/.gitignore

## 주요 변경 사항
- 멀티모듈 전환에 맞춰 bootJar archiveFileName을 monolith.jar/statistics.jar로 고정
- Dockerfile COPY 경로를 backend/monolith, backend/statistics 하위로 수정
- Jenkinsfile의 `./gradlew bootJar`를 `:monolith:bootJar`로 변경하여 모듈별 빌드 정합 확보
- monolith application-prod.yaml에 Kafka producer 설정(bootstrap-servers, JsonSerializer, add.type.headers, type.mapping) 추가
- statistics application-prod.yaml 신규 작성 (consumer 그룹, ErrorHandlingDeserializer, type.mapping, DB/JPA 설정)
- statistics 모듈에 micrometer-registry-prometheus 의존성 추가하여 /actuator/prometheus 노출
- 운영 리소스와 분리하기 위해 K8s test 네임스페이스 신설, 부하테스트 리소스 전부 이관
- Statistics MSA Pod + 전용 MariaDB StatefulSet 배포 매니페스트 작성
- test-backend Pod에서 Statistics MSA Kafka로 결제/매장/메뉴 이벤트 전달되는 경로 구성
- 부하테스트용 statistics-seed-data.sql 작성 (매장 3000개 + 결제 30000건, pos_pay_idx 100001~로 충돌 회피)
- Grafana test-statistics 대시보드 추가 (Consumer Lag, 처리 시간, JVM, DB Connections, HTTP)

## DB & Infrastructure
- Statistics 전용 DB(test-statistics-db) StatefulSet 신규
- K8s test 네임스페이스 분리, Secret 별도 관리

## Test Plan
- [ ] kubectl get pods -n test 로 backend/statistics/db Pod Running 확인
- [ ] /login + /pos/pay 호출 시 statistics DB의 pos_pay 적재 확인
- [ ] k6 부하테스트 5분 실행 (BASE_URL=NodePort, STORE_COUNT=100) 후 successful_payments 카운터 확인
- [ ] Grafana test-statistics 대시보드의 Consumer Lag / Processing Time 패널 정상 표시 확인
- [ ] /actuator/prometheus 200 응답 확인

## Issue
- Closes #837