### PR TITLE
[Refactor] #844 - Kafka 트랜잭션 정합성 + 메시지 순서 보장

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -8,12 +8,13 @@ import com.example.nexus.domain.menu.model.MenuItem;
 import com.example.nexus.domain.product.ProductRepository;
 import com.example.nexus.domain.product.model.Product;
 import com.example.nexus.event.KafkaTopics;
+import com.example.nexus.event.MenuDomainEvent;
 import com.example.nexus.event.MenuEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -36,7 +37,7 @@ public class MenuService {
     private final MenuRepository menuRepository;
     private final MenuCategoryRepository menuCategoryRepository;
     private final ProductRepository productRepository;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     private final S3Presigner s3Presigner;
     private final S3Client s3Client;
@@ -157,7 +158,7 @@ public class MenuService {
                     saved.isDeleted()
             );
 
-            kafkaTemplate.send(KafkaTopics.MENU_CREATED, event);
+            applicationEventPublisher.publishEvent(new MenuDomainEvent(event, KafkaTopics.MENU_CREATED));
 
         } catch (Exception e) {
             // 등록 중 에러가 나면 DB는 롤백되지만, 이미 업로드된 파일은 좀비가 되므로 삭제 처리
@@ -249,7 +250,7 @@ public class MenuService {
                     menu.isDeleted()
             );
 
-            kafkaTemplate.send(KafkaTopics.MENU_UPDATED, event);
+            applicationEventPublisher.publishEvent(new MenuDomainEvent(event, KafkaTopics.MENU_UPDATED));
 
         }catch (Exception e) {
             if (newFilePath != null && !newFilePath.isEmpty()
@@ -306,7 +307,7 @@ public class MenuService {
                 true
         );
 
-        kafkaTemplate.send(KafkaTopics.MENU_DELETED, event);
+        applicationEventPublisher.publishEvent(new MenuDomainEvent(event, KafkaTopics.MENU_DELETED));
     }
 
     @Transactional(readOnly = true)

--- a/backend/monolith/src/main/java/com/example/nexus/domain/pos/PosService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/pos/PosService.java
@@ -18,13 +18,13 @@ import com.example.nexus.domain.store.StoreInventoryRepository;
 import com.example.nexus.domain.store.StoreRepository;
 import com.example.nexus.domain.store.model.Store;
 import com.example.nexus.domain.store.model.StoreInventory;
-import com.example.nexus.event.KafkaTopics;
+import com.example.nexus.event.PaymentDomainEvent;
 import com.example.nexus.event.PaymentEvent;
 import com.example.nexus.event.PaymentEventItem;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,7 +51,7 @@ public class PosService {
     private final MenuItemRepository menuItemRepository;
     private final PosPayRepository posPayRepository;
     private final PosOrdersItemRepository posOrdersItemRepository;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public PageResponse<PosStoreInventoryDto.ListRes> listByUserIdxPaged(Long idx, int page, int size) {
         Store store = storeRepository.findByUserIdx(idx)
@@ -269,7 +269,7 @@ public class PosService {
 
         // Kafka 이벤트 발행
         PaymentEvent event = buildPaymentEvent(savedPay, store, lines);
-        kafkaTemplate.send(KafkaTopics.POS_PAYMENT_CREATED, event);
+        applicationEventPublisher.publishEvent(new PaymentDomainEvent(event));
 
         return PosPayDto.PayRes.builder()
                 .posPayIdx(savedPay.getIdx())

--- a/backend/monolith/src/main/java/com/example/nexus/domain/store/StoreService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/store/StoreService.java
@@ -9,13 +9,14 @@ import com.example.nexus.domain.store.model.StoreInventoryDto;
 import com.example.nexus.domain.user.UserRepository;
 import com.example.nexus.domain.user.model.User;
 import com.example.nexus.event.KafkaTopics;
+import com.example.nexus.event.StoreDomainEvent;
 import com.example.nexus.event.StoreEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -40,7 +41,7 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final StoreInventoryRepository storeInventoryRepository;
     private final UserRepository userRepository;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     // URL을 발행해주는 핵심 도구
     private final S3Presigner s3Presigner;
@@ -190,7 +191,7 @@ public class StoreService {
                     saved.isDeleted()
             );
 
-            kafkaTemplate.send(KafkaTopics.STORE_CREATED, event);
+            applicationEventPublisher.publishEvent(new StoreDomainEvent(event, KafkaTopics.STORE_CREATED));
 
         } catch (Exception e) {
             // 5. 예외 발생 시 S3 롤백 삭제
@@ -297,7 +298,7 @@ public class StoreService {
                     store.isDeleted()
             );
 
-            kafkaTemplate.send(KafkaTopics.STORE_UPDATED, event);
+            applicationEventPublisher.publishEvent(new StoreDomainEvent(event, KafkaTopics.STORE_UPDATED));
 
         } catch (Exception e) {
             if (newFilePath != null && !newFilePath.isEmpty() && !newFilePath.equals(oldFilePath)) {

--- a/backend/monolith/src/main/java/com/example/nexus/event/MenuDomainEvent.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/MenuDomainEvent.java
@@ -1,0 +1,9 @@
+package com.example.nexus.event;
+
+/**
+ * 메뉴 도메인 이벤트.
+ *
+ * topic 으로 created/updated/deleted 같은 하위 이벤트를 구분한다.
+ * 값은 KafkaTopics.MENU_CREATED, KafkaTopics.MENU_UPDATED, KafkaTopics.MENU_DELETED 중 하나.
+ */
+public record MenuDomainEvent(MenuEvent event, String topic) {}

--- a/backend/monolith/src/main/java/com/example/nexus/event/MenuKafkaPublisher.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/MenuKafkaPublisher.java
@@ -1,0 +1,23 @@
+package com.example.nexus.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class MenuKafkaPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onMenuDomainEvent(MenuDomainEvent e) {
+        kafkaTemplate.send(
+                e.topic(),
+                String.valueOf(e.event().menuIdx()),
+                e.event()
+        );
+    }
+}

--- a/backend/monolith/src/main/java/com/example/nexus/event/PaymentDomainEvent.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/PaymentDomainEvent.java
@@ -1,0 +1,9 @@
+package com.example.nexus.event;
+
+/**
+ * 결제 도메인 이벤트.
+ *
+ * Spring의 ApplicationEventPublisher로 발행되어 트랜잭션 commit 이후
+ * PaymentKafkaPublisher가 수신해서 Kafka로 전달한다.
+ */
+public record PaymentDomainEvent(PaymentEvent event) {}

--- a/backend/monolith/src/main/java/com/example/nexus/event/PaymentKafkaPublisher.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/PaymentKafkaPublisher.java
@@ -1,0 +1,23 @@
+package com.example.nexus.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentKafkaPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPaymentDomainEvent(PaymentDomainEvent e) {
+        kafkaTemplate.send(
+                KafkaTopics.POS_PAYMENT_CREATED,
+                String.valueOf(e.event().storeIdx()),  // partition key
+                e.event()
+        );
+    }
+}

--- a/backend/monolith/src/main/java/com/example/nexus/event/StoreDomainEvent.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/StoreDomainEvent.java
@@ -1,0 +1,9 @@
+package com.example.nexus.event;
+
+/**
+ * 매장 도메인 이벤트.
+ *
+ * topic 으로 created/updated 같은 하위 이벤트를 구분한다.
+ * 값은 KafkaTopics.STORE_CREATED, KafkaTopics.STORE_UPDATED 중 하나.
+ */
+public record StoreDomainEvent(StoreEvent event, String topic) {}

--- a/backend/monolith/src/main/java/com/example/nexus/event/StoreKafkaPublisher.java
+++ b/backend/monolith/src/main/java/com/example/nexus/event/StoreKafkaPublisher.java
@@ -1,0 +1,23 @@
+package com.example.nexus.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class StoreKafkaPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onStoreDomainEvent(StoreDomainEvent e) {
+        kafkaTemplate.send(
+                e.topic(),
+                String.valueOf(e.event().storeIdx()),
+                e.event()
+        );
+    }
+}

--- a/k8s/load-test/test-statistics-configmap.yaml
+++ b/k8s/load-test/test-statistics-configmap.yaml
@@ -10,4 +10,4 @@ data:
   DB_USER: root
   KAFKA_BOOTSTRAP_SERVERS: nexus-kafka-kafka-bootstrap.kafka.svc:9092
   KAFKA_GROUP_ID: test-statistics-prod
-  SQL_INIT_MODE: always
+  SQL_INIT_MODE: never


### PR DESCRIPTION
## Summary
- 결제 실패(rollback) 시에도 Kafka 메시지가 발행되던 phantom 4건 문제를 트랜잭션 commit 후 발행 패턴으로 해결
- 같은 매장 이벤트가 다른 partition으로 분산되던 문제를 partition key=storeIdx로 해결
- 2차 부하테스트로 두 문제 모두 해결 검증 완료 (Kafka 발행 == monolith DB INSERT == 4,055건 일치)

## 변경 파일
### 신규 (6개)
- backend/monolith/src/main/java/com/example/nexus/event/PaymentDomainEvent.java
- backend/monolith/src/main/java/com/example/nexus/event/StoreDomainEvent.java
- backend/monolith/src/main/java/com/example/nexus/event/MenuDomainEvent.java
- backend/monolith/src/main/java/com/example/nexus/event/PaymentKafkaPublisher.java
- backend/monolith/src/main/java/com/example/nexus/event/StoreKafkaPublisher.java
- backend/monolith/src/main/java/com/example/nexus/event/MenuKafkaPublisher.java

### 수정 (4개)
- backend/monolith/src/main/java/com/example/nexus/domain/pos/PosService.java
- backend/monolith/src/main/java/com/example/nexus/domain/store/StoreService.java
- backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuService.java
- k8s/load-test/test-statistics-configmap.yaml

## 주요 변경 사항
- 도메인 이벤트 record 3개 신설 (Spring `ApplicationEventPublisher` 발행용 wrapper, 외부 메시지 스키마와 내부 이벤트 분리)
- Kafka Publisher 컴포넌트 3개 신설, `@TransactionalEventListener(phase = AFTER_COMMIT)` 적용으로 DB commit 성공 후에만 Kafka 발행
- PosService / StoreService / MenuService 의 `KafkaTemplate` 의존성 제거 → `ApplicationEventPublisher` 로 교체
- Producer 호출 시 partition key 명시
  - Payment, Store → `storeIdx` (매장 단위 순서 보장)
  - Menu → `menuIdx` (메뉴는 본사 전역 리소스이므로 매장 종속 아님)
- Store/Menu 도메인 이벤트는 `topic` 필드를 통해 created/updated/deleted 분기를 listener 안에서 분기 없이 처리
- StoreService 의 기존 try/catch 트랜잭션 구조와 호환 검증 (예외 시 rollback → listener 미호출)


## Test Plan
- [x] 로컬 monolith 띄워 Postman으로 시나리오 A(정상 결제) 호출 → DB INSERT + Kafka 메시지(key=storeIdx) 정상 발행 확인
- [x] 시나리오 B(존재하지 않는 menuIdx로 rollback 유도) → DB INSERT 없음 + Kafka 메시지 발행 안 됨 확인 (문제 1 해결 핵심 증거)
- [x] 2차 부하테스트(k6, 5분, VU 1→100) 실행 → successful_payments 4055, pay_error_rate 0.22%
- [x] Kafka offset 검증: M2 - M1 = 4055 = monolith DB 새 INSERT 일치
- [x] partition key 동작: 시나리오 A 메시지가 key="1", partition 0 으로 발행됨 확인
- [ ] statistics DB 정합성 회복은 진행 중 (Consumer 처리량 한계 — 다음 이슈에서 해결)

## Issue
- Closes #844
