### PR TITLE
[Perf] #850 - Kafka Consumer 처리량 + Race Condition 회피

### DIFF
--- a/backend/statistics/src/main/java/com/example/statistics/config/KafkaErrorConfig.java
+++ b/backend/statistics/src/main/java/com/example/statistics/config/KafkaErrorConfig.java
@@ -1,0 +1,29 @@
+package com.example.statistics.config;
+
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * Kafka Consumer 처리 실패 시 동작 정의.
+ *
+ * - 1초 간격으로 3회 retry
+ * - 그래도 실패하면 메시지를 <원본토픽>.DLT 로 격리하고 offset commit
+ * - 같은 partition 번호를 유지하여 순서 추적 가능
+ */
+@Configuration
+public class KafkaErrorConfig {
+
+    @Bean
+    public DefaultErrorHandler errorHandler(KafkaTemplate<Object, Object> template) {
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+                template,
+                (record, ex) -> new TopicPartition(record.topic() + ".DLT", record.partition())
+        );
+        return new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3));
+    }
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/menu/model/Menu.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/menu/model/Menu.java
@@ -6,9 +6,18 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.SQLInsert;
 
 @Entity
 @Table(name = "menu")
+@SQLInsert(sql =
+        "INSERT INTO menu (menu_idx, menu_name, price, is_deleted, menu_category_idx) " +
+        "VALUES (?, ?, ?, ?, ?) " +
+        "ON DUPLICATE KEY UPDATE " +
+        "menu_name = VALUES(menu_name), " +
+        "price = VALUES(price), " +
+        "is_deleted = VALUES(is_deleted), " +
+        "menu_category_idx = VALUES(menu_category_idx)")
 @Getter
 @Setter
 @Builder

--- a/backend/statistics/src/main/java/com/example/statistics/domain/menu/model/MenuCategory.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/menu/model/MenuCategory.java
@@ -6,9 +6,16 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.SQLInsert;
 
 @Entity
 @Table(name = "menu_category")
+@SQLInsert(sql =                                        // ← 추가
+        "INSERT INTO menu_category (menu_category_idx, menu_category_name, is_deleted) " +
+        "VALUES (?, ?, ?) " +
+        "ON DUPLICATE KEY UPDATE " +
+        "menu_category_name = VALUES(menu_category_name), " +
+        "is_deleted = VALUES(is_deleted)")
 @Getter
 @Setter
 @Builder

--- a/backend/statistics/src/main/java/com/example/statistics/domain/store/model/Store.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/store/model/Store.java
@@ -6,9 +6,16 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.SQLInsert;
 
 @Entity
 @Table(name = "store")
+@SQLInsert(sql =
+        "INSERT INTO store (store_idx, store_name, is_deleted) " +
+        "VALUES (?, ?, ?) " +
+        "ON DUPLICATE KEY UPDATE " +
+        "store_name = VALUES(store_name), " +
+        "is_deleted = VALUES(is_deleted)")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/statistics/src/main/java/com/example/statistics/kafka/MenuEventConsumer.java
+++ b/backend/statistics/src/main/java/com/example/statistics/kafka/MenuEventConsumer.java
@@ -20,7 +20,7 @@ public class MenuEventConsumer {
     private final MenuRepository menuRepository;
     private final MenuCategoryRepository menuCategoryRepository;
 
-    @KafkaListener(topics = KafkaTopics.MENU_CREATED)
+    @KafkaListener(topics = KafkaTopics.MENU_CREATED, concurrency = "3")
     @Transactional
     public void onMenuCreated(MenuEvent event) {
         log.info("[menu.created] received: idx={}, name={}, category={}",
@@ -28,14 +28,14 @@ public class MenuEventConsumer {
         upsert(event);
     }
 
-    @KafkaListener(topics = KafkaTopics.MENU_UPDATED)
+    @KafkaListener(topics = KafkaTopics.MENU_UPDATED, concurrency = "3")
     @Transactional
     public void onMenuUpdated(MenuEvent event) {
         log.info("[menu.updated] received: idx={}, name={}", event.menuIdx(), event.menuName());
         upsert(event);
     }
 
-    @KafkaListener(topics = KafkaTopics.MENU_DELETED)
+    @KafkaListener(topics = KafkaTopics.MENU_DELETED, concurrency = "3")
     @Transactional
     public void onMenuDeleted(MenuEvent event) {
         log.info("[menu.deleted] received: idx={}", event.menuIdx());

--- a/backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
+++ b/backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
@@ -27,7 +27,7 @@ public class PaymentEventConsumer {
     private final StoreRepository storeRepository;
     private final MenuRepository menuRepository;
 
-    @KafkaListener(topics = KafkaTopics.POS_PAYMENT_CREATED)
+    @KafkaListener(topics = KafkaTopics.POS_PAYMENT_CREATED, concurrency = "3")
     @Transactional
     public void onPaymentCreated(PaymentEvent event) {
         log.info("[pos.payment.created] received: posPayIdx={}, storeIdx={}, payAmount={}, items={}",

--- a/backend/statistics/src/main/java/com/example/statistics/kafka/StoreEventConsumer.java
+++ b/backend/statistics/src/main/java/com/example/statistics/kafka/StoreEventConsumer.java
@@ -16,13 +16,13 @@ public class StoreEventConsumer {
 
     private final StoreRepository storeRepository;
 
-    @KafkaListener(topics = KafkaTopics.STORE_CREATED)
+    @KafkaListener(topics = KafkaTopics.STORE_CREATED, concurrency = "3")
     public void onStoreCreated(StoreEvent event) {
         log.info("[store.created] received: idx = {}, name = {}", event.storeIdx(), event.storeName());
         upsert(event);
     }
 
-    @KafkaListener(topics = KafkaTopics.STORE_UPDATED)
+    @KafkaListener(topics = KafkaTopics.STORE_UPDATED, concurrency = "3")
     public void onStoreUpdated(StoreEvent event) {
         log.info("[store.updated] received: idx={}, name={}, isDeleted={}",
                 event.storeIdx(), event.storeName(), event.isDeleted());

--- a/k8s/load-test/test-statistics-deployment.yaml
+++ b/k8s/load-test/test-statistics-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: test-statistics
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: test-statistics


### PR DESCRIPTION
## Summary
- statistics Consumer 측 3가지 변경 (`@SQLInsert ON DUPLICATE KEY UPDATE` + DLQ + replicas/concurrency 확대) 으로 정합성 회복 시간 ~40분 → **~2-3분 (90% 단축)** 달성
- cross-topic race condition 으로 인한 메시지 누락 ~500건 → **0건**
- 3차 부하테스트로 누락 0 + DLT 0 + 3 Pod partition 1:1 매핑 검증 완료
- 트러블슈팅 문서(#002)의 4가지 문제 모두 종료 (#844 + #850)

## 변경 파일
### 신규 (1개)
- backend/statistics/src/main/java/com/example/statistics/config/KafkaErrorConfig.java

### 수정 (7개)
- backend/statistics/src/main/java/com/example/statistics/domain/store/model/Store.java
- backend/statistics/src/main/java/com/example/statistics/domain/menu/model/Menu.java
- backend/statistics/src/main/java/com/example/statistics/domain/menu/model/MenuCategory.java
- backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
- backend/statistics/src/main/java/com/example/statistics/kafka/StoreEventConsumer.java
- backend/statistics/src/main/java/com/example/statistics/kafka/MenuEventConsumer.java
- k8s/load-test/test-statistics-deployment.yaml

## 주요 변경 사항
- Store / Menu / MenuCategory entity 에 Hibernate `@SQLInsert ON DUPLICATE KEY UPDATE` 적용으로 PK 충돌 시 자동 UPDATE → cross-topic race condition (예: store.created vs store.updated 동시 도착) 흡수
- `KafkaErrorConfig` 신규 — `DeadLetterPublishingRecoverer` + `FixedBackOff(1000ms, 3회)` 로 처리 실패 메시지를 `<원본토픽>.DLT` 로 격리. lag=0 인데 누락되던 메시지를 추적 가능하게 함
- 6개 `@KafkaListener` 메서드에 `concurrency = "3"` 추가 (Pod 안 thread 풀 확대, 향후 partition 확장 대비)
- `test-statistics-deployment.yaml` 의 `replicas` 를 1 → 3 으로 변경. partition 3개 × Pod 3개 1:1 매핑으로 병렬 처리량 3배
- `PaymentEventConsumer` 의 기존 `existsById` 멱등성 체크는 그대로 유지 — Kafka at-least-once delivery 대비 운영 정합성 패턴

## DB & Infrastructure
- test-statistics Deployment replicas 1 → 3 (3개 노드에 분산 확인: 100.100.100.115 / 127 / 148)
- [x] 성능 테스트 결과: docs/load-test/after-analysis.md 에 3차 부하 섹션 추가
  - 정합성 회복 시간: 1차 ~40분 / 2차 ~30분 / **3차 ~2-3분 (90% 단축)**
  - statistics 누락 건수: 1차 ~500 / 2차 0 / **3차 0**
  - DLT 토픽 메시지: 3차에서도 0 (처리 실패 자체 없음)
  - Kafka 발행 = monolith DB INSERT = statistics DB INSERT = **3,562건 정합** ✅

## Test Plan
- [x] 단계별 빌드 통과: `@SQLInsert` 적용 / `KafkaErrorConfig` 추가 / `concurrency=3` 적용
- [x] 새 이미지(`deatytim/nexusstat:dev-msa`) 빌드 + push + rollout restart
- [x] 3차 부하테스트 (k6, 5분, VU 1→100) 실행
- [x] Kafka 발행(M3-M3_baseline) == monolith DB INSERT == statistics DB 처리분 (3,562) 일치 확인
- [x] partition 1:1 매핑 동작 확인 (3 Pod이 partition 0/1/2 각각 1개씩 점유)
- [x] DLT 토픽 미생성 확인 (처리 실패 0건)
- [ ] 운영 환경 모니터링: DLT 토픽 size 알람 셋업 (향후)

## Issue
- Closes #850
