### PR TITLE
[Feat] #855 - 통계 응답시간 Redis 사전 집계 도입

### DIFF
--- a/backend/statistics/build.gradle
+++ b/backend/statistics/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     // --- Kafka ---
     implementation 'org.springframework.kafka:spring-kafka'
 
+    // --- Redis ---
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/backend/statistics/src/main/java/com/example/statistics/StatisticsService.java
+++ b/backend/statistics/src/main/java/com/example/statistics/StatisticsService.java
@@ -1,89 +1,118 @@
 package com.example.statistics;
 
-import com.example.statistics.common.enums.PosPayMethod;
 import com.example.statistics.model.StatisticsDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class StatisticsService {
-    private final StatisticsRepository statisticsRepository;
+    private final StringRedisTemplate redisTemplate;
 
+    /**
+    * 1. 오늘 총 매출
+    * - GET sales:today:DATE
+    * */
     public StatisticsDto.TodaySalesRes getTodaySales() {
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = start.plusDays(1);
-        long total = statisticsRepository.sumTodaySales(start, end);
+        String key = "sales:today:" + LocalDate.now();
+        String value = redisTemplate.opsForValue().get(key);
+        long total = (value == null) ? 0L : Long.parseLong(value);
         return StatisticsDto.TodaySalesRes.builder().todaySales(total).build();
     }
-
+    /**
+     * 2. 매장 매출 랭킹 TOP 5
+     * — ZREVRANGE WITHSCORES
+     * */
     public StatisticsDto.RankingRes getTopStores() {
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = start.plusDays(1);
-        List<Object[]> rows = statisticsRepository.findTopStores(start, end, PageRequest.of(0, 5));
-        List<StatisticsDto.RankingItem> items = rows.stream()
-                .map(r -> StatisticsDto.RankingItem.builder()
-                        .idx((Long) r[0])
-                        .name((String) r[1])
-                        .score((Long) r[2])
-                        .build())
-                .toList();
-        return StatisticsDto.RankingRes.builder().rankings(items).build();
+        String key = "sales:store:ranking:" + LocalDate.now();
+        Set<ZSetOperations.TypedTuple<String>> tuples =
+                redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, 4);
+        return StatisticsDto.RankingRes.builder()
+                .rankings(toRankingItems(tuples))
+                .build();
     }
 
+    /**
+     * 3. 메뉴 판매 랭킹 TOP 5
+     * — ZREVRANGE WITHSCORES
+     * */
     public StatisticsDto.RankingRes getTopMenus() {
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = start.plusDays(1);
-        List<Object[]> rows = statisticsRepository.findTopMenus(start, end, PageRequest.of(0, 5));
-        List<StatisticsDto.RankingItem> items = rows.stream()
-                .map(r -> StatisticsDto.RankingItem.builder()
-                        .idx((Long) r[0])
-                        .name((String) r[1])
-                        .score((Long) r[2])
-                        .build())
-                .toList();
-        return StatisticsDto.RankingRes.builder().rankings(items).build();
+        String key = "sales:menu:ranking:" + LocalDate.now();
+        Set<ZSetOperations.TypedTuple<String>> tuples =
+                redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, 4);
+        return StatisticsDto.RankingRes.builder()
+                .rankings(toRankingItems(tuples))
+                .build();
     }
 
+    /**
+     * 4. 시간대별 매출
+     * — HGETALL
+     * */
     public StatisticsDto.HourlySalesRes getHourlySales() {
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = start.plusDays(1);
-        List<Object[]> rows = statisticsRepository.findHourlySales(start, end);
-        List<StatisticsDto.HourlySalesItem> items = rows.stream()
-                .map(r -> StatisticsDto.HourlySalesItem.builder()
-                        .hour((Integer) r[0])
-                        .sales((Long) r[1])
+        String key = "sales:hourly:" + LocalDate.now();
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+        List<StatisticsDto.HourlySalesItem> items = entries.entrySet().stream()
+                .map(e -> StatisticsDto.HourlySalesItem.builder()
+                        .hour(Integer.parseInt((String) e.getKey()))
+                        .sales(Long.parseLong((String) e.getValue()))
                         .build())
+                .sorted(Comparator.comparingInt(StatisticsDto.HourlySalesItem::getHour))
                 .toList();
         return StatisticsDto.HourlySalesRes.builder().hourlyData(items).build();
     }
 
+    /**
+     * 5. 카테고리별 매출 비율
+     * — HGETALL
+     * */
     public StatisticsDto.RatioRes getCategoryRatio() {
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = start.plusDays(1);
-        List<Object[]> rows = statisticsRepository.findSalesByCategory(start, end);
-        List<StatisticsDto.RatioItem> items = rows.stream()
-                .map(r -> StatisticsDto.RatioItem.builder()
-                        .name((String) r[0])
-                        .amount((Long) r[1])
-                        .build())
-                .toList();
-        return StatisticsDto.RatioRes.builder().ratios(items).build();
+        return toRatioRes("sales:category:" + LocalDate.now());
     }
 
+    /**
+     * 6. 결제수단별 매출 비율
+     * — HGETALL
+     * */
     public StatisticsDto.RatioRes getPaymentMethodRatio() {
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = start.plusDays(1);
-        List<Object[]> rows = statisticsRepository.findSalesByPayMethod(start, end);
-        List<StatisticsDto.RatioItem> items = rows.stream()
-                .map(r -> StatisticsDto.RatioItem.builder()
-                        .name(((PosPayMethod) r[0]).name())
-                        .amount((Long) r[1])
+        return toRatioRes("sales:payment:" + LocalDate.now());
+    }
+
+    // ─── private helpers ───────────────────────────────────
+
+    /**
+     * ZSET 의 TypedTuple → RankingItem 변환. member 는 "idx|name" 형식.
+     * */
+    private List<StatisticsDto.RankingItem> toRankingItems(Set<ZSetOperations.TypedTuple<String>> tuples) {
+        if (tuples == null) return List.of();
+        return tuples.stream()
+                .map(tuple -> {
+                    String member = tuple.getValue();
+                    Double score = tuple.getScore();
+                    String[] parts = member.split("\\|", 2);  // "idx|name"
+                    return StatisticsDto.RankingItem.builder()
+                            .idx(Long.parseLong(parts[0]))
+                            .name(parts[1])
+                            .score(score == null ? 0L : score.longValue())
+                            .build();
+                })
+                .toList();
+    }
+
+    /**
+     * Hash → RatioRes 변환 (카테고리/결제수단 공통).
+     * */
+    private StatisticsDto.RatioRes toRatioRes(String key) {
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+        List<StatisticsDto.RatioItem> items = entries.entrySet().stream()
+                .map(e -> StatisticsDto.RatioItem.builder()
+                        .name((String) e.getKey())
+                        .amount(Long.parseLong((String) e.getValue()))
                         .build())
                 .toList();
         return StatisticsDto.RatioRes.builder().ratios(items).build();

--- a/backend/statistics/src/main/java/com/example/statistics/config/RedisConfig.java
+++ b/backend/statistics/src/main/java/com/example/statistics/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package com.example.statistics.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+/**
+ * Redis 설정.
+ *
+ * 사전 집계(INCRBY / ZINCRBY / HINCRBY) + 조회 모두
+ * StringRedisTemplate 한 빈으로 처리한다.
+ *
+ * Spring Boot 의 RedisAutoConfiguration 이 동일한 빈을 자동 등록하지만,
+ * 명시적으로 둠으로써 의도 명확 + 미래 확장 (JSON Serializer 등) 자리 마련.
+ */
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+}

--- a/backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
+++ b/backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
@@ -91,7 +91,11 @@ public class PaymentEventConsumer {
 
         // 2. 매장 매출 랭킹
         String storeRankKey = "sales:store:ranking:" + date;
-        redisTemplate.opsForZSet().incrementScore(storeRankKey, event.storeName(), event.payAmount());
+        redisTemplate.opsForZSet().incrementScore(
+                storeRankKey,
+                event.storeIdx() + "|" + event.storeName(),
+                event.payAmount()
+        );
         redisTemplate.expire(storeRankKey, ttl);
 
         // 3. 시간대별 매출
@@ -108,7 +112,11 @@ public class PaymentEventConsumer {
         String menuRankKey = "sales:menu:ranking:" + date;
         String categoryKey = "sales:category:" + date;
         for (PaymentEventItem item : event.items()) {
-            redisTemplate.opsForZSet().incrementScore(menuRankKey, item.menuName(), item.quantity());
+            redisTemplate.opsForZSet().incrementScore(
+                    menuRankKey,
+                    item.menuIdx() + "|" + item.menuName(),
+                    item.quantity()
+            );
             redisTemplate.opsForHash().increment(categoryKey, item.menuCategoryName(), item.lineAmount());
         }
         redisTemplate.expire(menuRankKey, ttl);

--- a/backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
+++ b/backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
@@ -9,12 +9,15 @@ import com.example.statistics.domain.pos.model.PosPay;
 import com.example.statistics.domain.store.StoreRepository;
 import com.example.statistics.event.KafkaTopics;
 import com.example.statistics.event.PaymentEvent;
+import com.example.statistics.event.PaymentEventItem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.List;
 
 @Slf4j
@@ -26,6 +29,7 @@ public class PaymentEventConsumer {
     private final PosOrdersItemRepository posOrdersItemRepository;
     private final StoreRepository storeRepository;
     private final MenuRepository menuRepository;
+    private final StringRedisTemplate redisTemplate;
 
     @KafkaListener(topics = KafkaTopics.POS_PAYMENT_CREATED, concurrency = "3")
     @Transactional
@@ -58,5 +62,56 @@ public class PaymentEventConsumer {
                         .build())
                 .toList();
         posOrdersItemRepository.saveAll(orderItems);
+
+        // Redis 사전 집계 (DB INSERT 다음 호출)
+        aggregateToRedis(event);
+    }
+
+    /**
+     * 결제 이벤트로부터 6개 통계 키에 사전 집계.
+     *
+     * - sales:today:DATE          (String, INCRBY)
+     * - sales:store:ranking:DATE  (Sorted Set, ZINCRBY)
+     * - sales:menu:ranking:DATE   (Sorted Set, ZINCRBY)
+     * - sales:hourly:DATE         (Hash, HINCRBY)
+     * - sales:category:DATE       (Hash, HINCRBY)
+     * - sales:payment:DATE        (Hash, HINCRBY)
+     *
+     * 각 키에 7일 TTL 설정 (Redis 메모리 관리).
+     */
+    private void aggregateToRedis(PaymentEvent event) {
+        String date = event.paidAt().toLocalDate().toString();   // "2026-05-21"
+        int hour = event.paidAt().getHour();
+        Duration ttl = Duration.ofDays(7);
+
+        // 1. 오늘 총 매출
+        String todayKey = "sales:today:" + date;
+        redisTemplate.opsForValue().increment(todayKey, event.payAmount());
+        redisTemplate.expire(todayKey, ttl);
+
+        // 2. 매장 매출 랭킹
+        String storeRankKey = "sales:store:ranking:" + date;
+        redisTemplate.opsForZSet().incrementScore(storeRankKey, event.storeName(), event.payAmount());
+        redisTemplate.expire(storeRankKey, ttl);
+
+        // 3. 시간대별 매출
+        String hourlyKey = "sales:hourly:" + date;
+        redisTemplate.opsForHash().increment(hourlyKey, String.valueOf(hour), event.payAmount());
+        redisTemplate.expire(hourlyKey, ttl);
+
+        // 4. 결제수단별 매출
+        String paymentKey = "sales:payment:" + date;
+        redisTemplate.opsForHash().increment(paymentKey, event.method(), event.payAmount());
+        redisTemplate.expire(paymentKey, ttl);
+
+        // 5, 6. 메뉴 판매 랭킹 + 카테고리별 매출 (items 순회)
+        String menuRankKey = "sales:menu:ranking:" + date;
+        String categoryKey = "sales:category:" + date;
+        for (PaymentEventItem item : event.items()) {
+            redisTemplate.opsForZSet().incrementScore(menuRankKey, item.menuName(), item.quantity());
+            redisTemplate.opsForHash().increment(categoryKey, item.menuCategoryName(), item.lineAmount());
+        }
+        redisTemplate.expire(menuRankKey, ttl);
+        redisTemplate.expire(categoryKey, ttl);
     }
 }

--- a/backend/statistics/src/main/resources/application-prod.yaml
+++ b/backend/statistics/src/main/resources/application-prod.yaml
@@ -33,6 +33,17 @@ spring:
         spring.json.trusted.packages: "*"
         spring.json.type.mapping: paymentEvent:com.example.statistics.event.PaymentEvent,storeEvent:com.example.statistics.event.StoreEvent,menuEvent:com.example.statistics.event.MenuEvent
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+      timeout: 2000ms
+      lettuce:
+        pool:
+          max-active: 16
+          max-idle: 8
+          min-idle: 2
+
 server:
   port: 8081
 

--- a/k8s/load-test/test-redis-statefulset.yaml
+++ b/k8s/load-test/test-redis-statefulset.yaml
@@ -1,0 +1,68 @@
+## 부하 테스트 전용 Redis (statistics MSA 의 사전 집계 저장소)
+## 운영 Redis 와 완전히 분리된 별도 인스턴스
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-redis-statefulset
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      type: test-redis
+  serviceName: test-redis-service
+  template:
+    metadata:
+      labels:
+        type: test-redis
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          # AOF 영구 저장 활성화 + 메모리 상한 256mb + LRU 정책
+          command:
+            - redis-server
+            - --appendonly
+            - "yes"
+            - --maxmemory
+            - "256mb"
+            - --maxmemory-policy
+            - "allkeys-lru"
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 384Mi
+          volumeMounts:
+            - name: volume
+              mountPath: /data
+      terminationGracePeriodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: volume
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+        storageClassName: longhorn
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-redis-service
+  namespace: test
+spec:
+  clusterIP: None
+  selector:
+    type: test-redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/k8s/load-test/test-statistics-configmap.yaml
+++ b/k8s/load-test/test-statistics-configmap.yaml
@@ -11,3 +11,4 @@ data:
   KAFKA_BOOTSTRAP_SERVERS: nexus-kafka-kafka-bootstrap.kafka.svc:9092
   KAFKA_GROUP_ID: test-statistics-prod
   SQL_INIT_MODE: never
+  REDIS_HOST: "test-redis-service"

--- a/k8s/load-test/test-statistics-deployment.yaml
+++ b/k8s/load-test/test-statistics-deployment.yaml
@@ -24,6 +24,7 @@ spec:
       containers:
         - name: nexus-statistics
           image: deatytim/nexusstat:dev-msa
+          imagePullPolicy: Always
           ports:
             - containerPort: 8081
           env:


### PR DESCRIPTION
## Summary
- Redis 사전 집계로 statistics MSA 의 통계 조회를 DB SUM/GROUP BY → Redis O(1) 로 전환
- 통계 응답 6개 메서드 모두 94~133ms 로 균일 수렴 (4차 94~401ms 편차 큼 대비)
- 부수 효과: 결제 p95 -47% (2.74s → 1.45s), 처리량 +39% (9,128 → 12,680)
- 정합성 4박자 일치 (Kafka = monolith DB = statistics DB = Redis sales:today = 101,045,000원)
- Trade-off: 회복 시간 ~20분 (Redis 명령 10여 개 추가 부담) — 후속 이슈로 분리

## 변경 파일
### 신규 (3개)
- k8s/load-test/test-redis-statefulset.yaml (Redis 7-alpine + AOF + maxmemory 256mb + LRU)
- backend/statistics/src/main/java/com/example/statistics/config/RedisConfig.java
- (Redis 키 패턴 / 자료구조 / TTL 설계 — Sorted Set + Hash + String 조합)

### 수정 (4개)
- backend/statistics/build.gradle (Spring Data Redis 의존성)
- backend/statistics/src/main/resources/application-prod.yaml (spring.data.redis 설정)
- k8s/load-test/test-statistics-configmap.yaml (REDIS_HOST 환경변수)
- backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java (aggregateToRedis 6가지)
- backend/statistics/src/main/java/com/example/statistics/StatisticsService.java (Redis 조회로 전면 재작성)

## 주요 변경 사항
- K8s test 네임스페이스에 Redis StatefulSet 배포 — AOF 활성화로 Pod 재시작 시 데이터 보존
- Spring Data Redis (Lettuce) 의존성 추가, application-prod.yaml 에 connection pool 설정
- 결제 이벤트 수신 시 6가지 통계 키에 사전 집계 — `sales:today` / `sales:store:ranking` / `sales:menu:ranking` / `sales:hourly` / `sales:category` / `sales:payment`
- ZSET member 를 `"idx|name"` 형식으로 저장하여 조회 시 idx 복원 가능
- TTL 7일 + maxmemory-policy `allkeys-lru` 로 메모리 자동 관리
- StatisticsService 의 6개 메서드를 Redis 명령 (GET / ZREVRANGE / HGETALL) 으로 재작성
- monolith → ApplicationEventPublisher → Kafka → statistics Consumer 흐름은 그대로 유지 (멱등성 / partition key / DLQ 안전망 모두 보존)

## DB & Infrastructure
- K8s 신규: test-redis StatefulSet (replicas 1, longhorn 1Gi PVC, headless Service)
- ConfigMap 변경: REDIS_HOST 환경변수 추가 → Pod 시작 시 주입
- [x] 성능 테스트 결과: docs/load-test/after-analysis.md 5차 부하 섹션 추가
  - 통계 p95 모든 메서드 균일 수렴 (94~133ms)
  - menu/top -76%, category/ratio -72% (가장 무거운 쿼리들 큰 단축)
  - 결제 p95 -47% (statistics DB 부담 해소 부수 효과)
  - 정합성 100% (Kafka 발행 = monolith DB SUM = statistics DB SUM = Redis sales:today 모두 101,045,000원)

## Test Plan
- [x] K8s test-redis StatefulSet 배포 + redis-cli PING 검증
- [x] 결제 1건으로 Redis 6개 키 생성 + 값 정확성 검증
- [x] 5차 부하테스트 (k6, 5분, VU 1→100) 실행
- [x] Kafka 발행 = monolith DB INSERT = statistics DB INSERT 일치 (12,680건)
- [x] Redis 합계 = monolith DB SUM 일치 (101,045,000원)
- [x] ZSET member "idx|name" 형식 정상 분리 (매장 랭킹 TOP 5 검증)
- [ ] 회복 시간 ~20분 (운영 환경에서는 추가 단축 필요 — 후속 이슈)

## Issue
- Closes #855