### PR TITLE
[Perf] #870 - 통계 MSA Consumer Redis Pipeline 적용으로 회복 시간 7배 단축

### DIFF
--- a/backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
+++ b/backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java
@@ -5,6 +5,8 @@ import com.example.statistics.event.PaymentEvent;
 import com.example.statistics.event.PaymentEventItem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -51,44 +53,48 @@ public class PaymentEventConsumer {
     private void aggregateToRedis(PaymentEvent event) {
         String date = event.paidAt().toLocalDate().toString();   // "2026-05-21"
         int hour = event.paidAt().getHour();
-        Duration ttl = Duration.ofDays(7);
+        long ttlSeconds = Duration.ofDays(7).getSeconds();
 
-        // 1. 오늘 총 매출
-        String todayKey = "sales:today:" + date;
-        redisTemplate.opsForValue().increment(todayKey, event.payAmount());
-        redisTemplate.expire(todayKey, ttl);
+        String todayKey      = "sales:today:" + date;
+        String storeRankKey  = "sales:store:ranking:" + date;
+        String hourlyKey     = "sales:hourly:" + date;
+        String paymentKey    = "sales:payment:" + date;
+        String menuRankKey   = "sales:menu:ranking:" + date;
+        String categoryKey   = "sales:category:" + date;
 
-        // 2. 매장 매출 랭킹
-        String storeRankKey = "sales:store:ranking:" + date;
-        redisTemplate.opsForZSet().incrementScore(
-                storeRankKey,
-                event.storeIdx() + "|" + event.storeName(),
-                event.payAmount()
-        );
-        redisTemplate.expire(storeRankKey, ttl);
+        redisTemplate.executePipelined((RedisCallback<?>) connection -> {
+            StringRedisConnection conn = (StringRedisConnection) connection;
 
-        // 3. 시간대별 매출
-        String hourlyKey = "sales:hourly:" + date;
-        redisTemplate.opsForHash().increment(hourlyKey, String.valueOf(hour), event.payAmount());
-        redisTemplate.expire(hourlyKey, ttl);
+            // 1. 오늘 총 매출
+            conn.incrBy(todayKey, event.payAmount());
 
-        // 4. 결제수단별 매출
-        String paymentKey = "sales:payment:" + date;
-        redisTemplate.opsForHash().increment(paymentKey, event.method(), event.payAmount());
-        redisTemplate.expire(paymentKey, ttl);
+            // 2. 매장 매출 랭킹
+            conn.zIncrBy(storeRankKey, event.payAmount(),
+                    event.storeIdx() + "|" + event.storeName());
 
-        // 5, 6. 메뉴 판매 랭킹 + 카테고리별 매출 (items 순회)
-        String menuRankKey = "sales:menu:ranking:" + date;
-        String categoryKey = "sales:category:" + date;
-        for (PaymentEventItem item : event.items()) {
-            redisTemplate.opsForZSet().incrementScore(
-                    menuRankKey,
-                    item.menuIdx() + "|" + item.menuName(),
-                    item.quantity()
-            );
-            redisTemplate.opsForHash().increment(categoryKey, item.menuCategoryName(), item.lineAmount());
-        }
-        redisTemplate.expire(menuRankKey, ttl);
-        redisTemplate.expire(categoryKey, ttl);
+            // 3. 시간대별 매출
+            conn.hIncrBy(hourlyKey, String.valueOf(hour), event.payAmount());
+
+            // 4. 결제수단별 매출
+            conn.hIncrBy(paymentKey, event.method(), event.payAmount());
+
+            // 5, 6. 메뉴 판매 랭킹 + 카테고리별 매출 (items 순회)
+            for (PaymentEventItem item : event.items()) {
+                conn.zIncrBy(menuRankKey, item.quantity(),
+                        item.menuIdx() + "|" + item.menuName());
+                conn.hIncrBy(categoryKey, item.menuCategoryName(), item.lineAmount());
+            }
+
+            // TTL — 6개 키 모두 같은 RTT 안에서 묶음
+            conn.expire(todayKey,     ttlSeconds);
+            conn.expire(storeRankKey, ttlSeconds);
+            conn.expire(hourlyKey,    ttlSeconds);
+            conn.expire(paymentKey,   ttlSeconds);
+            conn.expire(menuRankKey,  ttlSeconds);
+            conn.expire(categoryKey,  ttlSeconds);
+
+            return null; // Pipeline 결과 미사용
+        });
+
     }
 }


### PR DESCRIPTION
## Summary
- 통계 MSA Consumer 의 Redis 사전 집계 명령을 **`executePipelined` 로 묶어 메시지당 RTT 를 약 15회 → 2회로 절감**
- 회복 시간 14분 → **~2분 (−86%)** 으로 **Phase 1A 가설(3~5분) 완전 초과 달성**
- Consumer 처리량 ~21 msg/s → **~150 msg/s (~7배)**, 결제 p95 313ms → 250ms (−20%), 통계 조회 p95 평균도 추가 −10%
- 멱등성 SETNX 는 Pipeline 외부에 두어 atomic 단일 명령 분기 로직 유지 (의도적 분리)

## 변경 파일
- `backend/statistics/src/main/java/com/example/statistics/kafka/PaymentEventConsumer.java`

## 주요 변경 사항
- `aggregateToRedis()` 의 ~12개 Redis 명령(INCRBY 1 + ZINCRBY 2 + HINCRBY 3 + EXPIRE 6)을 `redisTemplate.executePipelined(...)` 한 번의 RTT 로 묶음
- `StringRedisConnection` 캐스팅으로 String 직렬화 유지 (`StringRedisTemplate` 호환)
- 멱등성 체크 `setIfAbsent` (SETNX) 는 Pipeline 외부 유지 — 반환값으로 중복 분기해야 하므로 atomic 단일 명령 필요
- TTL 6개 키 `EXPIRE` 모두 같은 RTT 안에서 묶음
- Import 2개 추가: `RedisCallback`, `StringRedisConnection`

## DB & Infrastructure
- 테이블 스키마 변경 없음
- K8s yaml 변경 없음
- 성능 테스트 결과 (7차 부하, 6차 대비)
  - **회복 시간: 14분 → ~2분 (−86%)** 🎯 Phase 1A 가설 완전 초과 달성
  - **Consumer 처리량: 21 → ~150 msg/s (~7배)**
  - 결제 p95: 313ms → **250.48ms** (−20%)
  - 결제 성공률: 99.95% → **99.96%** (k6 18,310 / 18,318)
  - 통계 조회 p95 평균: 99ms → **89ms** (−10%)
  - 메시지당 RTT: ~15 → **2** (−87%)
- 3-way 정합성 (7차 delta 기준)
  - monolith `pos_pay` 증가: **18,310 건 / 146,639,500 원**
  - Kafka offset 증가: **18,310 메시지** (68,595 → 86,905)
  - Redis `sales:today:2026-05-22`: **146,639,500 원** ← monolith delta 완벽 일치 ✅

## 트레이드오프
- Pipeline 은 atomic 보장 없음 — 중간에 다른 클라이언트 명령이 끼어들 수 있음
  - 우리 시나리오는 ① 멱등성 SETNX 가 중복 처리 차단, ② 통계 키가 카운터(INCRBY)라 끼어들어도 최종 합산값 정확 → atomic 부재 OK
  - 진짜 atomic 필요한 시나리오라면 MULTI/EXEC 또는 Lua script 사용
- Pipeline 안에서는 결과 즉시 수신 불가 (List 일괄 반환) → 결과 분기 필요한 SETNX 는 외부 분리

## Phase 1A 가설 검증 — 완전 달성 + 초과
- ✅ Consumer 처리량 ~7배 향상 (5차 10 → 7차 150 msg/s)
- ✅ 회복 시간 5차 20분 → 7차 ~2분 (−90%)
- ✅ 결제 p95 5차 1.45s → 7차 250ms (−83%)
- ✅ 3-way 정합성 100% 검증
- ✅ 통계 조회 p95 6개 모두 추가 개선

## 1차 → 7차 누적 효과
- 회복 시간: 40분 → 2분 (**−95%**)
- 결제 p95: 4.0s → 250ms (**−94%**)
- 통계 p95: 1.97s → 95ms (**−95%**)
- 결제 성공 (k6): 6,529 → 18,310 (+180%, 더 많은 부하 견딤)

## Test Plan
- [x] gradle 빌드 통과
- [x] K8s rollout 정상 (3 pod Running, 새 이미지 ID 적용 확인)
- [x] 7차 부하 테스트 통과 (k6 threshold 모두 ✓, 18,310 결제)
- [x] Consumer LAG 0 도달 시간 측정 (~2분)
- [x] 3-way 정합성 검증 (monolith delta = Kafka delta = Redis)

## Issue
- Closes 