### PR TITLE
[Infra] 전체 모듈 유레카 주소 환경변수 통합 및 DB 초기화 설정 변경

### DIFF
--- a/backend/gateway/src/main/resources/application.yml
+++ b/backend/gateway/src/main/resources/application.yml
@@ -12,7 +12,7 @@ eureka:
     prefer-ip-address: true
   client:
     service-url:
-      defaultZone: ${EUREKA_SERVICE_URL:http://192.100.30.50:32567/eureka}
+      defaultZone: ${EUREKA_SERVICE_URL}
     register-with-eureka: false
     fetch-registry: true
 

--- a/backend/monolith/src/main/resources/application-dev.yaml
+++ b/backend/monolith/src/main/resources/application-dev.yaml
@@ -96,7 +96,7 @@ eureka:
     prefer-ip-address: true                   # 내 주소를 알려줄 때 Hostname 대신 IP 주소 알려주기
   client:
     service-url:
-      defaultZone: ${EUREKA_SERVICE_URL:http://192.100.30.50:32567/eureka}
+      defaultZone: ${EUREKA_SERVICE_URL}
     register-with-eureka: true # 현재 자신의 IP주소를 유레카에 등록
     fetch-registry: true       # 유레카에 등록된 주소들을 받아오는 것
 

--- a/backend/pos/src/main/resources/application-dev.yaml
+++ b/backend/pos/src/main/resources/application-dev.yaml
@@ -36,4 +36,4 @@ spring:
     defer-datasource-initialization: true
   sql:
     init:
-      mode: always
+      mode: never

--- a/backend/statistics/src/main/resources/application-dev.yaml
+++ b/backend/statistics/src/main/resources/application-dev.yaml
@@ -5,7 +5,7 @@ eureka:
     prefer-ip-address: true                   # 내 주소를 알려줄 때 Hostname 대신 IP 주소 알려주기
   client:
     service-url:
-      defaultZone: ${EUREKA_SERVICE_URL:http://192.100.30.50:32567/eureka}
+      defaultZone: ${EUREKA_SERVICE_URL}
     register-with-eureka: true # 현재 자신의 IP주소를 유레카에 등록
     fetch-registry: true       # 유레카에 등록된 주소들을 받아오는 것
 


### PR DESCRIPTION
## Summary
- 마이크로서비스 전반(`gateway`, `monolith`, `statistics`)에 걸쳐 유레카(Discovery) 서버 주소의 하드코딩된 기본값(Fallback)을 제거하고, 쿠버네티스/도커 환경변수(`EUREKA_SERVICE_URL`)를 100% 의존하도록 통일했습니다.
- `pos` 모듈의 불필요한 데이터베이스 자동 초기화 쿼리가 매번 실행되는 것을 방지하기 위해 `sql.init.mode`를 수정했습니다.

## 변경 파일
- `backend/gateway/src/main/resources/application.yml`
- `backend/monolith/src/main/resources/application-dev.yaml`
- `backend/pos/src/main/resources/application-dev.yaml`
- `backend/statistics/src/main/resources/application-dev.yaml`

## 주요 변경 사항
- [x] **Gateway, Monolith, Statistics 유레카 설정 통일**
  - 기존에 적혀있던 IP 하드코딩 기본값(`http://192.100.30.50...`)을 완전히 제거
  - `eureka.client.service-url.defaultZone: ${EUREKA_SERVICE_URL}` 로 코드를 통일하여 외부 환경변수 주입을 강제하도록 개선
- [x] **POS 모듈 DB 설정 변경**
  - `spring.sql.init.mode` 값을 `always`에서 `never`로 변경하여 서버 재시작 시 데이터가 덮어씌워지거나 에러가 발생하는 현상 방지

## DB & Infrastructure (해당 시)
- [x] 도커/쿠버네티스 실행 시 반드시 `EUREKA_SERVICE_URL` 환경변수를 주입해야만 서버가 켜지도록 인프라 의존성 변경

