### PR TITLE
[Feat] #874 - 일별 집계 MariaDB 영구 저장 (수동 트리거 API 까지)

### DIFF
--- a/backend/statistics/src/main/java/com/example/statistics/InternalStatisticsController.java
+++ b/backend/statistics/src/main/java/com/example/statistics/InternalStatisticsController.java
@@ -1,0 +1,42 @@
+package com.example.statistics;
+
+import com.example.statistics.domain.daily.DailyDumpService;
+import com.example.statistics.domain.daily.dto.DumpResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+/**
+ * 운영 도구 + 개발 검증용 내부 API.
+ * 자동 스케줄러 실패 시 수동 dump, 누락 복구 시 catch-up 등에 활용.
+ *
+ * ⚠️ 운영 환경에서는 K8s NetworkPolicy 또는 Spring Security 로 외부 접근 차단 필수.
+ */
+@RestController
+@RequestMapping("/internal/statistics")
+@RequiredArgsConstructor
+public class InternalStatisticsController {
+    private final DailyDumpService dailyDumpService;
+
+    /**
+     * 특정 날짜의 Redis 일별 집계를 MariaDB 에 수동 dump.
+     *
+     * @param date 처리할 날짜 (생략 시 어제)
+     * @return DumpResult — status (SUCCESS/FAILED/SKIPPED), 처리 건수, 소요 시간 등
+     */
+    @PostMapping("/dailyDump")
+    public ResponseEntity<DumpResult> manualDailyDump(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        LocalDate target = (date != null) ? date : LocalDate.now().minusDays(1);
+        DumpResult result = dailyDumpService.dump(target);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyCategorySalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyCategorySalesRepository.java
@@ -1,0 +1,33 @@
+package com.example.statistics.domain.daily;
+
+import com.example.statistics.domain.daily.model.DailyCategorySales;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 일별 카테고리별 매출 영구 저장소.
+ * Redis 키 `sales:category:DATE` (Hash) 의 카테고리별 집계를 MariaDB 에 dump 한 결과를 관리.
+ * 한 날짜에 판매된 카테고리 수만큼 row 가 존재 (aggregate_date + category_name 복합 UNIQUE).
+ */
+public interface DailyCategorySalesRepository extends JpaRepository<DailyCategorySales, Long> {
+
+    /**
+     * 특정 날짜의 카테고리별 매출을 조회.
+     * 판매된 카테고리 수만큼 row 가 반환되므로 List 형태.
+     *
+     * @param aggregateDate 조회할 집계 날짜
+     * @return 해당 날짜의 카테고리별 매출 목록 (없으면 빈 List)
+     */
+    List<DailyCategorySales> findByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 특정 날짜의 dump 가 이미 수행되었는지 확인.
+     * 스케줄러/수동 트리거 의 멱등성 체크에 사용.
+     *
+     * @param aggregateDate 확인할 집계 날짜
+     * @return 이미 dump 되었으면 true, 아니면 false
+     */
+    boolean existsByAggregateDate(LocalDate aggregateDate);
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyDumpInternalService.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyDumpInternalService.java
@@ -1,0 +1,185 @@
+package com.example.statistics.domain.daily;
+import com.example.statistics.domain.daily.dto.DumpResult;
+import com.example.statistics.domain.daily.model.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DailyDumpInternalService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final DailyTotalSalesRepository dailyTotalSalesRepository;
+    private final DailyStoreSalesRepository dailyStoreSalesRepository;
+    private final DailyMenuSalesRepository dailyMenuSalesRepository;
+    private final DailyHourlySalesRepository dailyHourlySalesRepository;
+    private final DailyCategorySalesRepository dailyCategorySalesRepository;
+    private final DailyPaymentSalesRepository dailyPaymentSalesRepository;
+    private final DailyDumpLogRepository dailyDumpLogRepository;
+
+    /** 메인 dump 로직 (트랜잭션 적용, 외부 클래스에서 호출되어야 동작) */
+    @Transactional
+    public DumpResult doDump(LocalDate date, long start) {
+        int totalCount    = dumpTotal(date);
+        int storeCount    = dumpStore(date);
+        int menuCount     = dumpMenu(date);
+        int hourlyCount   = dumpHourly(date);
+        int categoryCount = dumpCategory(date);
+        int paymentCount  = dumpPayment(date);
+
+        int recordTotal = totalCount + storeCount + menuCount
+                + hourlyCount + categoryCount + paymentCount;
+
+        dailyDumpLogRepository.save(DailyDumpLog.builder()
+                .aggregateDate(date)
+                .dumpStatus(DumpStatus.SUCCESS)
+                .recordCount(recordTotal)
+                .build());
+
+        long elapsed = System.currentTimeMillis() - start;
+        return DumpResult.success(date, totalCount, storeCount, menuCount,
+                hourlyCount, categoryCount, paymentCount, elapsed);
+    }
+
+    /** 실패 로그 기록 (별도 트랜잭션 — 메인 롤백돼도 살아남음) */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordFailure(LocalDate date, String errorMessage) {
+        dailyDumpLogRepository.save(DailyDumpLog.builder()
+                .aggregateDate(date)
+                .dumpStatus(DumpStatus.FAILED)
+                .recordCount(0)
+                .errorMessage(errorMessage)
+                .build());
+    }
+
+    private int dumpTotal(LocalDate date) {
+        String value = redisTemplate.opsForValue().get("sales:today:" + date);
+
+        if (value == null) {
+            return 0;
+        }
+
+        dailyTotalSalesRepository.save(DailyTotalSales.builder().aggregateDate(date).totalAmount(Long.parseLong(value)).build());
+
+        return 1;
+    }
+
+    private int dumpStore(LocalDate date) {
+        Set<ZSetOperations.TypedTuple<String>> tuples = redisTemplate.opsForZSet().reverseRangeWithScores("sales:store:ranking:" + date, 0, -1);
+
+        if (tuples == null || tuples.isEmpty()) {
+            return 0;
+        }
+
+        List<DailyStoreSales> entities = tuples.stream()
+                .map(t -> {
+                    String[] parts = t.getValue().split("\\|", 2);  // "idx|name"
+                    return DailyStoreSales.builder()
+                            .aggregateDate(date)
+                            .storeIdx(Long.parseLong(parts[0]))
+                            .storeName(parts[1])
+                            .amount(t.getScore() == null ? 0L : t.getScore().longValue())
+                            .build();
+                })
+                .toList();
+
+        dailyStoreSalesRepository.saveAll(entities);
+
+        return entities.size();
+    }
+
+    private int dumpMenu(LocalDate date) {
+        Set<ZSetOperations.TypedTuple<String>> tuples =
+                redisTemplate.opsForZSet().reverseRangeWithScores("sales:menu:ranking:" + date, 0, -1);
+
+        if (tuples == null || tuples.isEmpty()) {
+            return 0;
+        }
+
+        List<DailyMenuSales> entities = tuples.stream()
+                .map(t -> {
+                    String[] parts = t.getValue().split("\\|", 2);
+                    return DailyMenuSales.builder()
+                            .aggregateDate(date)
+                            .menuIdx(Long.parseLong(parts[0]))
+                            .menuName(parts[1])
+                            .quantity(t.getScore() == null ? 0L : t.getScore().longValue())
+                            .build();
+                })
+                .toList();
+
+        dailyMenuSalesRepository.saveAll(entities);
+
+        return entities.size();
+    }
+
+    private int dumpHourly(LocalDate date) {
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries("sales:hourly:" + date);
+
+        if (entries.isEmpty()) {
+            return 0;
+        }
+
+        List<DailyHourlySales> entities = entries.entrySet().stream()
+                .map(e -> DailyHourlySales.builder()
+                        .aggregateDate(date)
+                        .hour(Integer.parseInt((String) e.getKey()))
+                        .amount(Long.parseLong((String) e.getValue()))
+                        .build())
+                .toList();
+
+        dailyHourlySalesRepository.saveAll(entities);
+
+        return entities.size();
+    }
+
+    private int dumpCategory(LocalDate date) {
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries("sales:category:" + date);
+
+        if (entries.isEmpty()) {
+            return 0;
+        }
+
+        List<DailyCategorySales> entities = entries.entrySet().stream()
+                .map(e -> DailyCategorySales.builder()
+                        .aggregateDate(date)
+                        .categoryName((String) e.getKey())
+                        .amount(Long.parseLong((String) e.getValue()))
+                        .build())
+                .toList();
+
+        dailyCategorySalesRepository.saveAll(entities);
+
+        return entities.size();
+    }
+
+    private int dumpPayment(LocalDate date) {
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries("sales:payment:" + date);
+
+        if (entries.isEmpty()) {
+            return 0;
+        }
+
+        List<DailyPaymentSales> entities = entries.entrySet().stream()
+                .map(e -> DailyPaymentSales.builder()
+                        .aggregateDate(date)
+                        .paymentMethod((String) e.getKey())
+                        .amount(Long.parseLong((String) e.getValue()))
+                        .build())
+                .toList();
+
+        dailyPaymentSalesRepository.saveAll(entities);
+
+        return entities.size();
+    }
+
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyDumpLogRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyDumpLogRepository.java
@@ -1,0 +1,48 @@
+package com.example.statistics.domain.daily;
+
+import com.example.statistics.domain.daily.model.DailyDumpLog;
+import com.example.statistics.domain.daily.model.DumpStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+/**
+ * 일별 dump 이력 관리 저장소.
+ * 매일 새벽 5시 스케줄러 또는 수동 트리거가 dump 를 수행한 결과를 기록.
+ * 운영 도구로서 누락 복구 + 모니터링 + 디버깅 용도.
+ */
+public interface DailyDumpLogRepository extends JpaRepository<DailyDumpLog, Long> {
+
+    /**
+     * 특정 날짜의 dump 이력을 조회.
+     * 재시도/멱등성 판단, 운영 디버깅에 사용.
+     *
+     * @param aggregateDate 조회할 집계 날짜
+     * @return 해당 날짜의 dump 이력 (수행되지 않았으면 Optional.empty())
+     */
+    Optional<DailyDumpLog> findByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 특정 날짜에 특정 상태(SUCCESS/FAILED)의 dump 이력이 있는지 확인.
+     * 예: "이 날짜 SUCCESS 됐나?" 빠른 체크 — 스케줄러 재실행 시 SUCCESS 인 날짜는 skip.
+     *
+     * @param aggregateDate 확인할 집계 날짜
+     * @param status        확인할 dump 상태 (SUCCESS / FAILED)
+     * @return 해당 상태로 기록되어 있으면 true, 아니면 false
+     */
+    boolean existsByAggregateDateAndDumpStatus(LocalDate aggregateDate, DumpStatus status);
+
+    /**
+     * 마지막으로 SUCCESS 처리된 dump 날짜를 조회.
+     * 누락 복구 로직의 기준점 — 스케줄러는 이 날짜 + 1 ~ 어제 까지 catch-up 처리.
+     *
+     * 예시) 마지막 성공일이 2026-05-19, 오늘이 2026-05-22 라면
+     *      → 2026-05-20, 2026-05-21 두 날짜를 추가로 dump 수행
+     *
+     * @return 마지막 성공 dump 날짜 (한 번도 SUCCESS 없으면 Optional.empty())
+     */
+    @Query("SELECT MAX(d.aggregateDate) FROM DailyDumpLog d WHERE d.dumpStatus = 'SUCCESS'")
+    Optional<LocalDate> findLastSuccessfulDumpDate();
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyDumpService.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyDumpService.java
@@ -1,0 +1,44 @@
+package com.example.statistics.domain.daily;
+
+import com.example.statistics.domain.daily.dto.DumpResult;
+import com.example.statistics.domain.daily.model.DumpStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DailyDumpService {
+
+    private final DailyDumpInternalService internalService;
+    private final DailyDumpLogRepository dailyDumpLogRepository;
+
+    /**
+     * 특정 날짜의 Redis 일별 집계를 MariaDB 에 dump.
+     * 이미 SUCCESS 로 dump 됐으면 skip (멱등성).
+     */
+    public DumpResult dump(LocalDate targetDate) {
+        long start = System.currentTimeMillis();
+
+        // 1. 멱등성 체크
+        if(dailyDumpLogRepository.existsByAggregateDateAndDumpStatus(targetDate, DumpStatus.SUCCESS)) {
+            log.info("[DailyDump] already done, skip: {}", targetDate);
+            return DumpResult.skipped(targetDate);
+        }
+
+        try {
+            // 2. 트랜잭션 안에서 Redis 읽기 + MariaDB INSERT + SUCCESS 로그
+            return internalService.doDump(targetDate, start);
+        } catch (Exception e) {
+            // 3. 실패 시 별도 트랜잭션으로 FAILED 로그
+            long elapsed = System.currentTimeMillis() - start;
+            internalService.recordFailure(targetDate, e.getMessage());
+            log.error("[DailyDump] failed: {}", targetDate, e);
+            return DumpResult.failed(targetDate, e.getMessage(), elapsed);
+        }
+    }
+
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyHourlySalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyHourlySalesRepository.java
@@ -1,0 +1,33 @@
+package com.example.statistics.domain.daily;
+
+import com.example.statistics.domain.daily.model.DailyHourlySales;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 일별 시간대별 매출 영구 저장소.
+ * Redis 키 `sales:hourly:DATE` (Hash) 의 시간대별 집계를 MariaDB 에 dump 한 결과를 관리.
+ * 한 날짜에 0~23시 중 결제가 발생한 시간만큼 row 가 존재 (aggregate_date + hour 복합 UNIQUE).
+ */
+public interface DailyHourlySalesRepository extends JpaRepository<DailyHourlySales, Long> {
+
+    /**
+     * 특정 날짜의 시간대별 매출을 조회.
+     * 결제 발생 시간 수만큼 row 가 반환되므로 List 형태.
+     *
+     * @param aggregateDate 조회할 집계 날짜
+     * @return 해당 날짜의 시간대별 매출 목록 (없으면 빈 List)
+     */
+    List<DailyHourlySales> findByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 특정 날짜의 dump 가 이미 수행되었는지 확인.
+     * 스케줄러/수동 트리거 의 멱등성 체크에 사용.
+     *
+     * @param aggregateDate 확인할 집계 날짜
+     * @return 이미 dump 되었으면 true, 아니면 false
+     */
+    boolean existsByAggregateDate(LocalDate aggregateDate);
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyMenuSalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyMenuSalesRepository.java
@@ -1,0 +1,33 @@
+package com.example.statistics.domain.daily;
+
+import com.example.statistics.domain.daily.model.DailyMenuSales;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 일별 메뉴별 판매량 영구 저장소.
+ * Redis 키 `sales:menu:ranking:DATE` (ZSet) 의 메뉴별 집계를 MariaDB 에 dump 한 결과를 관리.
+ * 한 날짜에 판매된 메뉴 수만큼 row 가 존재 (aggregate_date + menu_idx 복합 UNIQUE).
+ */
+public interface DailyMenuSalesRepository extends JpaRepository<DailyMenuSales, Long> {
+
+    /**
+     * 특정 날짜의 모든 메뉴 판매량을 조회.
+     * 판매된 메뉴 수만큼 row 가 반환되므로 List 형태.
+     *
+     * @param aggregateDate 조회할 집계 날짜
+     * @return 해당 날짜의 메뉴별 판매량 목록 (없으면 빈 List)
+     */
+    List<DailyMenuSales> findByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 특정 날짜의 dump 가 이미 수행되었는지 확인.
+     * 스케줄러/수동 트리거 의 멱등성 체크에 사용.
+     *
+     * @param aggregateDate 확인할 집계 날짜
+     * @return 이미 dump 되었으면 true, 아니면 false
+     */
+    boolean existsByAggregateDate(LocalDate aggregateDate);
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyPaymentSalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyPaymentSalesRepository.java
@@ -1,0 +1,33 @@
+package com.example.statistics.domain.daily;
+
+import com.example.statistics.domain.daily.model.DailyPaymentSales;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 일별 결제수단별 매출 영구 저장소.
+ * Redis 키 `sales:payment:DATE` (Hash) 의 결제수단별 집계를 MariaDB 에 dump 한 결과를 관리.
+ * 한 날짜에 사용된 결제수단 수만큼 row 가 존재 (aggregate_date + payment_method 복합 UNIQUE).
+ */
+public interface DailyPaymentSalesRepository extends JpaRepository<DailyPaymentSales, Long> {
+
+    /**
+     * 특정 날짜의 결제수단별 매출을 조회.
+     * 사용된 결제수단 수만큼 row 가 반환되므로 List 형태.
+     *
+     * @param aggregateDate 조회할 집계 날짜
+     * @return 해당 날짜의 결제수단별 매출 목록 (없으면 빈 List)
+     */
+    List<DailyPaymentSales> findByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 특정 날짜의 dump 가 이미 수행되었는지 확인.
+     * 스케줄러/수동 트리거 의 멱등성 체크에 사용.
+     *
+     * @param aggregateDate 확인할 집계 날짜
+     * @return 이미 dump 되었으면 true, 아니면 false
+     */
+    boolean existsByAggregateDate(LocalDate aggregateDate);
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyStoreSalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyStoreSalesRepository.java
@@ -1,0 +1,33 @@
+package com.example.statistics.domain.daily;
+
+import com.example.statistics.domain.daily.model.DailyStoreSales;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 일별 매장별 매출 영구 저장소.
+ * Redis 키 `sales:store:ranking:DATE` (ZSet) 의 매장별 집계를 MariaDB 에 dump 한 결과를 관리.
+ * 한 날짜에 매장 수만큼 row 가 존재 (aggregate_date + store_idx 복합 UNIQUE).
+ */
+public interface DailyStoreSalesRepository extends JpaRepository<DailyStoreSales, Long> {
+
+    /**
+     * 특정 날짜의 모든 매장 매출을 조회.
+     * 매장 수만큼 row 가 반환되므로 List 형태.
+     *
+     * @param aggregateDate 조회할 집계 날짜
+     * @return 해당 날짜의 매장별 매출 목록 (없으면 빈 List)
+     */
+    List<DailyStoreSales> findByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 특정 날짜의 dump 가 이미 수행되었는지 확인.
+     * 스케줄러/수동 트리거 의 멱등성 체크에 사용.
+     *
+     * @param aggregateDate 확인할 집계 날짜
+     * @return 이미 dump 되었으면 true, 아니면 false
+     */
+    boolean existsByAggregateDate(LocalDate aggregateDate);
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyTotalSalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyTotalSalesRepository.java
@@ -1,0 +1,32 @@
+package com.example.statistics.domain.daily;
+
+import com.example.statistics.domain.daily.model.DailyTotalSales;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+/**
+ * 일별 총 매출 영구 저장소.
+ * Redis 키 `sales:today:DATE` 의 일별 집계를 MariaDB 에 dump 한 결과를 관리.
+ * 한 날짜당 1 row 만 존재 (aggregate_date UNIQUE).
+ */
+public interface DailyTotalSalesRepository extends JpaRepository<DailyTotalSales, Long> {
+
+    /**
+     * 특정 날짜의 총 매출을 조회.
+     *
+     * @param aggregateDate 조회할 집계 날짜
+     * @return 해당 날짜의 총 매출 (없으면 Optional.empty())
+     */
+    Optional<DailyTotalSales> findByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 특정 날짜의 dump 가 이미 수행되었는지 확인.
+     * 스케줄러/수동 트리거 의 멱등성 체크에 사용.
+     *
+     * @param aggregateDate 확인할 집계 날짜
+     * @return 이미 dump 되었으면 true, 아니면 false
+     */
+    boolean existsByAggregateDate(LocalDate aggregateDate);
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/dto/DumpResult.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/dto/DumpResult.java
@@ -1,0 +1,72 @@
+package com.example.statistics.domain.daily.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * Dump 작업 결과.
+ * 수동 트리거 API 응답 + 스케줄러 결과 로그 용도.
+ */
+@Getter
+@Builder
+public class DumpResult {
+
+    /** SUCCESS / FAILED / SKIPPED */
+    private final ResultStatus status;
+    /** 처리한 집계 날짜 */
+    private final LocalDate aggregateDate;
+    /** 처리된 row 수 (테이블별) — 실패/skipped 시 0 */
+    private final int totalSalesCount;
+    private final int storeSalesCount;
+    private final int menuSalesCount;
+    private final int hourlySalesCount;
+    private final int categorySalesCount;
+    private final int paymentSalesCount;
+    /** 소요 시간 (ms) */
+    private final long spendTime;
+    /** 실패 시 메시지 */
+    private final String errorMessage;
+    /** 완료 시각 */
+    private final LocalDateTime completedAt;
+
+    /** 결과 enum */
+    public enum ResultStatus {
+        SUCCESS, FAILED, SKIPPED
+    }
+
+    public static DumpResult success(LocalDate date, int total, int store, int menu, int hourly, int category, int payment, long elapsed) {
+        return DumpResult.builder()
+                .status(ResultStatus.SUCCESS)
+                .aggregateDate(date)
+                .totalSalesCount(total)
+                .storeSalesCount(store)
+                .menuSalesCount(menu)
+                .hourlySalesCount(hourly)
+                .categorySalesCount(category)
+                .paymentSalesCount(payment)
+                .spendTime(elapsed)
+                .completedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static DumpResult failed(LocalDate date, String error, long elapsed) {
+        return DumpResult.builder()
+                .status(ResultStatus.FAILED)
+                .aggregateDate(date)
+                .errorMessage(error)
+                .spendTime(elapsed)
+                .completedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static DumpResult skipped(LocalDate date) {
+        return DumpResult.builder()
+                .status(ResultStatus.SKIPPED)
+                .aggregateDate(date)
+                .completedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyCategorySales.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyCategorySales.java
@@ -1,0 +1,42 @@
+package com.example.statistics.domain.daily.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "daily_category_sales",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_daily_category",
+                columnNames = {"aggregate_date", "category_name"}
+        )
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyCategorySales {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "idx")
+    private Long idx;
+
+    @Column(name = "aggregate_date", nullable = false)
+    private LocalDate aggregateDate;
+
+    @Column(name = "category_name", nullable = false, length = 100)
+    private String categoryName;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyDumpLog.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyDumpLog.java
@@ -1,0 +1,40 @@
+package com.example.statistics.domain.daily.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "daily_dump_log")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyDumpLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "idx")
+    private Long idx;
+
+    @Column(name = "aggregate_date", nullable = false, unique = true)
+    private LocalDate aggregateDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dump_status", nullable = false, length = 20)
+    private DumpStatus dumpStatus;
+
+    @Column(name = "record_count", nullable = false)
+    private Integer recordCount;
+
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @CreationTimestamp
+    @Column(name = "dumped_at", nullable = false, updatable = false)
+    private LocalDateTime dumpedAt;
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyHourlySales.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyHourlySales.java
@@ -1,0 +1,42 @@
+package com.example.statistics.domain.daily.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "daily_hourly_sales",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_daily_hourly",
+                columnNames = {"aggregate_date", "hour"}
+        )
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyHourlySales {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "idx")
+    private Long idx;
+
+    @Column(name = "aggregate_date", nullable = false)
+    private LocalDate aggregateDate;
+
+    @Column(name = "hour", nullable = false)
+    private Integer hour;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyMenuSales.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyMenuSales.java
@@ -1,0 +1,45 @@
+package com.example.statistics.domain.daily.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "daily_menu_sales",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_daily_menu",
+                columnNames = {"aggregate_date", "menu_idx"}
+        )
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyMenuSales {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "idx")
+    private Long idx;
+
+    @Column(name = "aggregate_date", nullable = false)
+    private LocalDate aggregateDate;
+
+    @Column(name = "menu_idx", nullable = false)
+    private Long menuIdx;
+
+    @Column(name = "menu_name", nullable = false, length = 200)
+    private String menuName;
+
+    @Column(name = "quantity", nullable = false)
+    private Long quantity;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyPaymentSales.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyPaymentSales.java
@@ -1,0 +1,42 @@
+package com.example.statistics.domain.daily.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "daily_payment_sales",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_daily_payment",
+                columnNames = {"aggregate_date", "payment_method"}
+        )
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyPaymentSales {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "idx")
+    private Long idx;
+
+    @Column(name = "aggregate_date", nullable = false)
+    private LocalDate aggregateDate;
+
+    @Column(name = "payment_method", nullable = false, length = 50)
+    private String paymentMethod;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyStoreSales.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyStoreSales.java
@@ -1,0 +1,45 @@
+package com.example.statistics.domain.daily.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "daily_store_sales",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_daily_store",
+                columnNames = {"aggregate_date", "store_idx"}
+        )
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyStoreSales {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "idx")
+    private Long idx;
+
+    @Column(name = "aggregate_date", nullable = false)
+    private LocalDate aggregateDate;
+
+    @Column(name = "store_idx", nullable = false)
+    private Long storeIdx;
+
+    @Column(name = "store_name", nullable = false, length = 100)
+    private String storeName;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyTotalSales.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DailyTotalSales.java
@@ -1,0 +1,34 @@
+package com.example.statistics.domain.daily.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.checkerframework.common.aliasing.qual.Unique;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "daily_total_sales")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyTotalSales {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "idx")
+    private Long idx;
+
+    @Column(name = "aggregate_date", nullable = false, unique = true)
+    private LocalDate aggregateDate;
+
+    @Column(name = "total_amount", nullable = false)
+    private Long totalAmount;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DumpStatus.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/model/DumpStatus.java
@@ -1,0 +1,6 @@
+package com.example.statistics.domain.daily.model;
+
+public enum DumpStatus {
+    SUCCESS,
+    FAILED
+}


### PR DESCRIPTION
## Summary
- 통계 MSA Redis 일별 집계를 MariaDB 에 영구 저장하는 `DailyDumpService` 구현
- 수동 트리거 API (`POST /internal/statistics/dailyDump`) — 운영 도구 + 개발 검증 겸용
- Spring AOP self-invocation 함정 회피를 위해 진입점/내부 서비스 두 클래스로 분리
- 6개 Redis 키 → MariaDB 7개 테이블 매핑
- ⚠️ 자동 스케줄러 (`@Scheduled` + ShedLock) 는 분량/리뷰 용이성을 위해 **다음 이슈로 분리**

## 변경 파일
- `domain/daily/model/` — Entity 7개 + DumpStatus enum
- `domain/daily/` — Repository 7개
- `domain/daily/DailyDumpService.java` — 진입점 (멱등성 + 예외 처리)
- `domain/daily/DailyDumpInternalService.java` — 트랜잭션 로직
- `domain/daily/dto/DumpResult.java` — 응답 DTO
- `InternalStatisticsController.java` — 수동 트리거 API

## 주요 변경 사항
- daily 도메인 신설 — Entity 7개 (daily_total/store/menu/hourly/category/payment_sales + daily_dump_log)
- 단일 UNIQUE 는 `@Column(unique=true)`, 복합 UNIQUE 는 `@Table(uniqueConstraints=...)` 패턴 일관 적용
- `DumpStatus` enum (SUCCESS / FAILED) — DB 저장용
- `ResultStatus` enum (SUCCESS / FAILED / **SKIPPED**) — API 응답용 (이미 처리됨 표현)
- **self-invocation 함정 회피**: `DailyDumpService` (진입점) 와 `DailyDumpInternalService` (트랜잭션 로직) 두 클래스 분리
- `doDump` 는 `@Transactional` 로 6개 테이블 INSERT 묶음, `recordFailure` 는 `@Transactional(REQUIRES_NEW)` 로 메인 롤백 시에도 FAILED 로그 보존
- 멱등성: `daily_dump_log` 에 SUCCESS 있으면 SKIPPED 반환 (불필요한 작업 방지)
- `POST /internal/statistics/dailyDump?date=YYYY-MM-DD` 수동 트리거 (생략 시 어제 기본값)
- `ddl-auto=update` 로 hibernate 가 daily_* 7개 테이블 자동 생성

## 트레이드오프
- 자동 스케줄러는 별도 이슈로 분리 — 운영 시 매일 새벽 5시 자동 dump 필수
- 운영 환경의 `/internal/*` 경로는 K8s NetworkPolicy 또는 Spring Security 로 차단 필수
- Redis 만료(7일) 후 누락 발견 시 모놀리식 DB raw 에서 재집계 필요

## Test Plan
- [x] gradle 빌드 통과
- [x] K8s rollout 정상 (3 pod Running)
- [x] daily_* 7개 테이블 자동 생성 확인
- [x] 수동 트리거 SUCCESS 응답 + 5-way 정합성 검증
- [x] 멱등성 재호출 SKIPPED 응답
- [x] daily_dump_log 정확 기록

## Issue
- Refs #874