### PR TITLE
[Feat] #881 - 장기 통계 페이지 (연/월/매장/메뉴) 백엔드 API + 프론트엔드

### DIFF
--- a/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsController.java
+++ b/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsController.java
@@ -80,4 +80,23 @@ public class LongTermStatisticsController {
                 longTermStatisticsService.getCategorySales(year, month)
         ));
     }
+
+    /**
+     * 특정 기간 메뉴별 판매량 (판매량 많은 순).
+     *
+     * GET /statistics/long-term/menus?year=2026&month=5
+     * GET /statistics/long-term/menus?year=2026
+     *
+     * @param year  조회할 연도
+     * @param month 조회할 월 (선택, 없으면 그 해 전체)
+     */
+    @GetMapping("/menus")
+    public ResponseEntity<BaseResponse> getMenus(
+            @RequestParam int year,
+            @RequestParam(required = false) Integer month
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(
+                longTermStatisticsService.getMenuSales(year, month)
+        ));
+    }
 }

--- a/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsController.java
+++ b/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsController.java
@@ -1,0 +1,83 @@
+package com.example.statistics;
+
+import com.example.statistics.common.model.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 장기 통계 (월/연도/매장/카테고리별) REST API.
+ * daily_* 테이블의 영구 보존 데이터를 기반으로 조회.
+ *
+ * URL prefix: /statistics/long-term/*
+ */
+@RestController
+@RequestMapping("/statistics/long-term")
+@RequiredArgsConstructor
+public class LongTermStatisticsController {
+
+    private final LongTermStatisticsService longTermStatisticsService;
+
+    /**
+     * 연도별 총 매출 (전체 기간).
+     *
+     * GET /statistics/long-term/yearly
+     */
+    @GetMapping("/yearly")
+    public ResponseEntity<BaseResponse> getYearly() {
+        return ResponseEntity.ok(BaseResponse.success(longTermStatisticsService.getYearlySales()));
+    }
+
+    /**
+     * 특정 연도의 월별 매출 (1~12월).
+     *
+     * GET /statistics/long-term/monthly?year=2026
+     *
+     * @param year 조회할 연도
+     */
+    @GetMapping("/monthly")
+    public ResponseEntity<BaseResponse> getMonthly(@RequestParam int year) {
+        return ResponseEntity.ok(BaseResponse.success(longTermStatisticsService.getMonthlySales(year)));
+    }
+
+    /**
+     * 특정 기간 매장별 매출 (매출 큰 순).
+     *
+     * GET /statistics/long-term/stores?year=2026&month=5   (월 단위)
+     * GET /statistics/long-term/stores?year=2026           (연 단위)
+     *
+     * @param year  조회할 연도
+     * @param month 조회할 월 (선택, 없으면 그 해 전체)
+     */
+    @GetMapping("/stores")
+    public ResponseEntity<BaseResponse> getStores(
+            @RequestParam int year,
+            @RequestParam(required = false) Integer month
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(
+                longTermStatisticsService.getStoreSales(year, month)
+        ));
+    }
+
+    /**
+     * 특정 기간 카테고리별 매출 (매출 큰 순).
+     *
+     * GET /statistics/long-term/categories?year=2026&month=5
+     * GET /statistics/long-term/categories?year=2026
+     *
+     * @param year  조회할 연도
+     * @param month 조회할 월 (선택, 없으면 그 해 전체)
+     */
+    @GetMapping("/categories")
+    public ResponseEntity<BaseResponse> getCategories(
+            @RequestParam int year,
+            @RequestParam(required = false) Integer month
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(
+                longTermStatisticsService.getCategorySales(year, month)
+        ));
+    }
+}

--- a/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsService.java
+++ b/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsService.java
@@ -1,0 +1,119 @@
+package com.example.statistics;
+
+import com.example.statistics.domain.daily.DailyCategorySalesRepository;
+import com.example.statistics.domain.daily.DailyStoreSalesRepository;
+import com.example.statistics.domain.daily.DailyTotalSalesRepository;
+import com.example.statistics.model.LongTermStatisticsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 장기 통계 (월별/연도별/매장별/카테고리별) 비즈니스 로직.
+ * daily_* 테이블의 GROUP BY 결과를 DTO 로 변환해 반환.
+ */
+@Service
+@RequiredArgsConstructor
+public class LongTermStatisticsService {
+
+    private final DailyTotalSalesRepository totalRepo;
+    private final DailyStoreSalesRepository storeRepo;
+    private final DailyCategorySalesRepository categoryRepo;
+
+    /**
+     * 연도별 총 매출 (전체 기간).
+     */
+    public LongTermStatisticsDto.YearlySalesRes getYearlySales() {
+        List<LongTermStatisticsDto.YearlySalesItem> items = totalRepo.findYearlySalesGroup().stream()
+                .map(r -> LongTermStatisticsDto.YearlySalesItem.builder()
+                        .year(((Number) r[0]).intValue())
+                        .total(r[1] == null ? 0L : ((Number) r[1]).longValue())
+                        .build())
+                .toList();
+        return LongTermStatisticsDto.YearlySalesRes.builder()
+                .yearlyData(items)
+                .build();
+    }
+
+    /**
+     * 특정 연도의 월별 매출 (1~12월).
+     *
+     * @param year 조회할 연도
+     */
+    public LongTermStatisticsDto.MonthlySalesRes getMonthlySales(int year) {
+        List<LongTermStatisticsDto.MonthlySalesItem> items = totalRepo.findMonthlySalesGroup(year).stream()
+                .map(r -> LongTermStatisticsDto.MonthlySalesItem.builder()
+                        .month(((Number) r[0]).intValue())
+                        .total(r[1] == null ? 0L : ((Number) r[1]).longValue())
+                        .build())
+                .toList();
+        return LongTermStatisticsDto.MonthlySalesRes.builder()
+                .year(year)
+                .monthlyData(items)
+                .build();
+    }
+
+    /**
+     * 특정 기간의 매장별 매출 합계 (매출 큰 순).
+     * month 가 null 이면 해당 연도 전체.
+     *
+     * @param year  조회할 연도
+     * @param month 조회할 월 (선택)
+     */
+    public LongTermStatisticsDto.StoreSalesRes getStoreSales(int year, Integer month) {
+        LocalDate[] range = calculateDateRange(year, month);
+
+        List<LongTermStatisticsDto.StoreSalesItem> items = storeRepo
+                .findStoreSalesGroupByRange(range[0], range[1]).stream()
+                .map(r -> LongTermStatisticsDto.StoreSalesItem.builder()
+                        .storeIdx(((Number) r[0]).longValue())
+                        .storeName((String) r[1])
+                        .total(r[2] == null ? 0L : ((Number) r[2]).longValue())
+                        .build())
+                .toList();
+        return LongTermStatisticsDto.StoreSalesRes.builder()
+                .stores(items)
+                .build();
+    }
+
+    /**
+     * 특정 기간의 카테고리별 매출 합계 (매출 큰 순).
+     * month 가 null 이면 해당 연도 전체.
+     *
+     * @param year  조회할 연도
+     * @param month 조회할 월 (선택)
+     */
+    public LongTermStatisticsDto.CategorySalesRes getCategorySales(int year, Integer month) {
+        LocalDate[] range = calculateDateRange(year, month);
+
+        List<LongTermStatisticsDto.CategorySalesItem> items = categoryRepo
+                .findCategorySalesGroupByRange(range[0], range[1]).stream()
+                .map(r -> LongTermStatisticsDto.CategorySalesItem.builder()
+                        .categoryName((String) r[0])
+                        .amount(r[1] == null ? 0L : ((Number) r[1]).longValue())
+                        .build())
+                .toList();
+        return LongTermStatisticsDto.CategorySalesRes.builder()
+                .categories(items)
+                .build();
+    }
+
+    /**
+     * year + month(선택) 로부터 시작/종료 날짜 계산.
+     * month null → 그 해 1/1 ~ 12/31
+     * month 있음 → 그 달 1일 ~ 말일
+     */
+    private LocalDate[] calculateDateRange(int year, Integer month) {
+        LocalDate start, end;
+        if (month != null) {
+            start = LocalDate.of(year, month, 1);
+            end = start.plusMonths(1).minusDays(1);
+        } else {
+            start = LocalDate.of(year, 1, 1);
+            end = LocalDate.of(year, 12, 31);
+        }
+        return new LocalDate[]{start, end};
+    }
+}

--- a/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsService.java
+++ b/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsService.java
@@ -1,6 +1,7 @@
 package com.example.statistics;
 
 import com.example.statistics.domain.daily.DailyCategorySalesRepository;
+import com.example.statistics.domain.daily.DailyMenuSalesRepository;
 import com.example.statistics.domain.daily.DailyStoreSalesRepository;
 import com.example.statistics.domain.daily.DailyTotalSalesRepository;
 import com.example.statistics.model.LongTermStatisticsDto;
@@ -21,6 +22,7 @@ public class LongTermStatisticsService {
     private final DailyTotalSalesRepository totalRepo;
     private final DailyStoreSalesRepository storeRepo;
     private final DailyCategorySalesRepository categoryRepo;
+    private final DailyMenuSalesRepository menuRepo;
 
     /**
      * 연도별 총 매출 (전체 기간).
@@ -97,6 +99,28 @@ public class LongTermStatisticsService {
                 .toList();
         return LongTermStatisticsDto.CategorySalesRes.builder()
                 .categories(items)
+                .build();
+    }
+
+    /**
+     * 특정 기간의 메뉴별 판매량 합계 (판매량 많은 순).
+     *
+     * @param year  조회할 연도
+     * @param month 조회할 월 (선택)
+     */
+    public LongTermStatisticsDto.MenuSalesRes getMenuSales(int year, Integer month) {
+        LocalDate[] range = calculateDateRange(year, month);
+
+        List<LongTermStatisticsDto.MenuSalesItem> items = menuRepo
+                .findMenuSalesGroupByRange(range[0], range[1]).stream()
+                .map(r -> LongTermStatisticsDto.MenuSalesItem.builder()
+                        .menuIdx(((Number) r[0]).longValue())
+                        .menuName((String) r[1])
+                        .totalQuantity(r[2] == null ? 0L : ((Number) r[2]).longValue())
+                        .build())
+                .toList();
+        return LongTermStatisticsDto.MenuSalesRes.builder()
+                .menus(items)
                 .build();
     }
 

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyCategorySalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyCategorySalesRepository.java
@@ -2,6 +2,8 @@ package com.example.statistics.domain.daily;
 
 import com.example.statistics.domain.daily.model.DailyCategorySales;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -30,4 +32,24 @@ public interface DailyCategorySalesRepository extends JpaRepository<DailyCategor
      * @return 이미 dump 되었으면 true, 아니면 false
      */
     boolean existsByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 특정 기간(start ~ end) 내 카테고리별 매출 합계 (장기 통계).
+     * 카테고리별로 합산해서 매출 큰 순으로 정렬.
+     *
+     * @param start 시작 날짜 (포함)
+     * @param end   종료 날짜 (포함)
+     * @return [categoryName(String), amount(Long)] 배열 리스트
+     */
+    @Query(value = """
+            SELECT category_name, SUM(amount) AS amount
+            FROM daily_category_sales
+            WHERE aggregate_date BETWEEN :start AND :end
+            GROUP BY category_name
+            ORDER BY amount DESC
+            """, nativeQuery = true)
+    List<Object[]> findCategorySalesGroupByRange(
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
+    );
 }

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyMenuSalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyMenuSalesRepository.java
@@ -2,6 +2,8 @@ package com.example.statistics.domain.daily;
 
 import com.example.statistics.domain.daily.model.DailyMenuSales;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -15,19 +17,31 @@ public interface DailyMenuSalesRepository extends JpaRepository<DailyMenuSales, 
 
     /**
      * 특정 날짜의 모든 메뉴 판매량을 조회.
-     * 판매된 메뉴 수만큼 row 가 반환되므로 List 형태.
-     *
-     * @param aggregateDate 조회할 집계 날짜
-     * @return 해당 날짜의 메뉴별 판매량 목록 (없으면 빈 List)
      */
     List<DailyMenuSales> findByAggregateDate(LocalDate aggregateDate);
 
     /**
-     * 특정 날짜의 dump 가 이미 수행되었는지 확인.
-     * 스케줄러/수동 트리거 의 멱등성 체크에 사용.
-     *
-     * @param aggregateDate 확인할 집계 날짜
-     * @return 이미 dump 되었으면 true, 아니면 false
+     * 특정 날짜의 dump 가 이미 수행되었는지 확인 (멱등성 체크용).
      */
     boolean existsByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 특정 기간(start ~ end) 내 메뉴별 판매량 합계 (장기 통계).
+     * 메뉴별로 합산해서 판매량 많은 순으로 정렬.
+     *
+     * @param start 시작 날짜 (포함)
+     * @param end   종료 날짜 (포함)
+     * @return [menuIdx(Long), menuName(String), totalQuantity(Long)] 배열 리스트
+     */
+    @Query(value = """
+            SELECT menu_idx, menu_name, SUM(quantity) AS total_qty
+            FROM daily_menu_sales
+            WHERE aggregate_date BETWEEN :start AND :end
+            GROUP BY menu_idx, menu_name
+            ORDER BY total_qty DESC
+            """, nativeQuery = true)
+    List<Object[]> findMenuSalesGroupByRange(
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
+    );
 }

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyStoreSalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyStoreSalesRepository.java
@@ -2,6 +2,8 @@ package com.example.statistics.domain.daily;
 
 import com.example.statistics.domain.daily.model.DailyStoreSales;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -30,4 +32,24 @@ public interface DailyStoreSalesRepository extends JpaRepository<DailyStoreSales
      * @return 이미 dump 되었으면 true, 아니면 false
      */
     boolean existsByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 특정 기간(start ~ end) 내 매장별 매출 합계 (장기 통계).
+     * 매장별로 합산해서 매출 큰 순으로 정렬.
+     *
+     * @param start 시작 날짜 (포함)
+     * @param end   종료 날짜 (포함)
+     * @return [storeIdx(Long), storeName(String), total(Long)] 배열 리스트
+     */
+    @Query(value = """
+            SELECT store_idx, store_name, SUM(amount) AS total
+            FROM daily_store_sales
+            WHERE aggregate_date BETWEEN :start AND :end
+            GROUP BY store_idx, store_name
+            ORDER BY total DESC
+            """, nativeQuery = true)
+    List<Object[]> findStoreSalesGroupByRange(
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
+    );
 }

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyTotalSalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyTotalSalesRepository.java
@@ -2,8 +2,11 @@ package com.example.statistics.domain.daily;
 
 import com.example.statistics.domain.daily.model.DailyTotalSales;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -29,4 +32,32 @@ public interface DailyTotalSalesRepository extends JpaRepository<DailyTotalSales
      * @return 이미 dump 되었으면 true, 아니면 false
      */
     boolean existsByAggregateDate(LocalDate aggregateDate);
+
+    /**
+     * 연도별 매출 집계 (장기 통계).
+     *
+     * @return [year(Integer), total(Long)] 배열 리스트, 연도 오름차순
+     */
+    @Query(value = """
+            SELECT YEAR(aggregate_date) AS year, SUM(total_amount) AS total
+            FROM daily_total_sales
+            GROUP BY YEAR(aggregate_date)
+            ORDER BY YEAR(aggregate_date)
+            """, nativeQuery = true)
+    List<Object[]> findYearlySalesGroup();
+
+    /**
+     * 특정 연도의 월별 매출 집계 (장기 통계).
+     *
+     * @param year 조회할 연도
+     * @return [month(Integer), total(Long)] 배열 리스트, 월 오름차순
+     */
+    @Query(value = """
+            SELECT MONTH(aggregate_date) AS month, SUM(total_amount) AS total
+            FROM daily_total_sales
+            WHERE YEAR(aggregate_date) = :year
+            GROUP BY MONTH(aggregate_date)
+            ORDER BY MONTH(aggregate_date)
+            """, nativeQuery = true)
+    List<Object[]> findMonthlySalesGroup(@Param("year") int year);
 }

--- a/backend/statistics/src/main/java/com/example/statistics/model/LongTermStatisticsDto.java
+++ b/backend/statistics/src/main/java/com/example/statistics/model/LongTermStatisticsDto.java
@@ -1,0 +1,75 @@
+package com.example.statistics.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 장기 통계 (월별/연도별/매장별/카테고리별) 응답 DTO.
+ * daily_* 테이블의 GROUP BY 결과를 담는다.
+ */
+public class LongTermStatisticsDto {
+
+    // ─── 연도별 ─────────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class YearlySalesItem {
+        private int year;
+        private long total;
+    }
+
+    @Getter
+    @Builder
+    public static class YearlySalesRes {
+        private List<YearlySalesItem> yearlyData;
+    }
+
+    // ─── 월별 ───────────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class MonthlySalesItem {
+        private int month;
+        private long total;
+    }
+
+    @Getter
+    @Builder
+    public static class MonthlySalesRes {
+        private int year;
+        private List<MonthlySalesItem> monthlyData;
+    }
+
+    // ─── 매장별 ─────────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class StoreSalesItem {
+        private Long storeIdx;
+        private String storeName;
+        private long total;
+    }
+
+    @Getter
+    @Builder
+    public static class StoreSalesRes {
+        private List<StoreSalesItem> stores;
+    }
+
+    // ─── 카테고리별 ─────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class CategorySalesItem {
+        private String categoryName;
+        private long amount;
+    }
+
+    @Getter
+    @Builder
+    public static class CategorySalesRes {
+        private List<CategorySalesItem> categories;
+    }
+}

--- a/backend/statistics/src/main/java/com/example/statistics/model/LongTermStatisticsDto.java
+++ b/backend/statistics/src/main/java/com/example/statistics/model/LongTermStatisticsDto.java
@@ -72,4 +72,20 @@ public class LongTermStatisticsDto {
     public static class CategorySalesRes {
         private List<CategorySalesItem> categories;
     }
+
+    // ─── 메뉴별 ─────────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class MenuSalesItem {
+        private Long menuIdx;
+        private String menuName;
+        private long totalQuantity;
+    }
+
+    @Getter
+    @Builder
+    public static class MenuSalesRes {
+        private List<MenuSalesItem> menus;
+    }
 }

--- a/backend/statistics/src/main/resources/seed-long-term-dummy.sql
+++ b/backend/statistics/src/main/resources/seed-long-term-dummy.sql
@@ -1,0 +1,117 @@
+-- ============================================================
+-- 장기 통계 (#881) 로컬 검증용 더미 데이터
+-- 기간: 1년치 (2025-05-23 ~ 2026-05-22)
+--
+-- ⚠️ WARNING: 운영 DB 에는 절대 실행 금지!
+--    로컬/테스트 환경에서만 사용.
+--
+-- 실행 방법:
+--   mariadb -h 127.0.0.1 -P 3307 -uroot -pqwer1234 nexus \
+--     < backend/statistics/src/main/resources/sql/seed-long-term-dummy.sql
+--
+--   또는 mariadb 셸 안에서 source 명령:
+--   source backend/statistics/src/main/resources/sql/seed-long-term-dummy.sql;
+-- ============================================================
+
+
+-- ─── (1) daily_total_sales: 365 row, 일일 1억~2억 랜덤 ───────
+INSERT IGNORE INTO daily_total_sales (aggregate_date, total_amount, created_at)
+SELECT
+    DATE_SUB('2026-05-22', INTERVAL n DAY),
+    FLOOR(100000000 + RAND() * 100000000),
+    NOW()
+FROM (
+    SELECT a.N + b.N * 10 + c.N * 100 AS n
+    FROM
+        (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+         UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) a
+        CROSS JOIN (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+         UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) b
+        CROSS JOIN (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3) c
+) numbers
+WHERE n BETWEEN 0 AND 364;
+
+
+-- ─── (2) daily_store_sales: 365 × 100 매장 = 36,500 row ──────
+INSERT IGNORE INTO daily_store_sales (aggregate_date, store_idx, store_name, amount, created_at)
+SELECT
+    DATE_SUB('2026-05-22', INTERVAL d.n DAY),
+    s.store_idx,
+    CONCAT('매장 ', s.store_idx),
+    FLOOR(500000 + RAND() * 2000000),
+    NOW()
+FROM
+    (SELECT a.N + b.N * 10 + c.N * 100 AS n
+     FROM
+        (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+         UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) a
+        CROSS JOIN (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+         UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) b
+        CROSS JOIN (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3) c
+    ) d
+    CROSS JOIN (
+        SELECT a.N + b.N * 10 + 1 AS store_idx
+        FROM
+            (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+             UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) a
+            CROSS JOIN (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+             UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) b
+    ) s
+WHERE d.n BETWEEN 0 AND 364 AND s.store_idx <= 100;
+
+
+-- ─── (3) daily_category_sales: 365 × 4 카테고리 = 1,460 row ──
+INSERT IGNORE INTO daily_category_sales (aggregate_date, category_name, amount, created_at)
+SELECT
+    DATE_SUB('2026-05-22', INTERVAL d.n DAY),
+    c.category_name,
+    FLOOR(20000000 + RAND() * 30000000),
+    NOW()
+FROM
+    (SELECT a.N + b.N * 10 + c.N * 100 AS n
+     FROM
+        (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+         UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) a
+        CROSS JOIN (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+         UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) b
+        CROSS JOIN (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3) c
+    ) d
+    CROSS JOIN (
+        SELECT '커피' AS category_name UNION ALL
+        SELECT '음료' UNION ALL
+        SELECT '디저트' UNION ALL
+        SELECT '푸드'
+    ) c
+WHERE d.n BETWEEN 0 AND 364;
+
+
+-- ─── (4) daily_menu_sales: 365 × 15 메뉴 = 5,475 row ─────────
+INSERT IGNORE INTO daily_menu_sales (aggregate_date, menu_idx, menu_name, quantity, created_at)
+SELECT
+    DATE_SUB('2026-05-22', INTERVAL d.n DAY),
+    m.menu_idx,
+    CONCAT('메뉴 ', m.menu_idx),
+    FLOOR(50 + RAND() * 500),
+    NOW()
+FROM
+    (SELECT a.N + b.N * 10 + c.N * 100 AS n
+     FROM
+        (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+         UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) a
+        CROSS JOIN (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+         UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) b
+        CROSS JOIN (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3) c
+    ) d
+    CROSS JOIN (
+        SELECT 1 AS menu_idx UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5
+        UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9 UNION SELECT 10
+        UNION SELECT 11 UNION SELECT 12 UNION SELECT 13 UNION SELECT 14 UNION SELECT 15
+    ) m
+WHERE d.n BETWEEN 0 AND 364;
+
+
+-- ─── 검증 쿼리 ─────────────────────────────────────────────
+SELECT COUNT(*) AS total_cnt    FROM daily_total_sales;     -- 약 365
+SELECT COUNT(*) AS store_cnt    FROM daily_store_sales;     -- 약 36,500
+SELECT COUNT(*) AS category_cnt FROM daily_category_sales;  -- 약 1,460
+SELECT COUNT(*) AS menu_cnt     FROM daily_menu_sales;      -- 약 5,475

--- a/frontend/src/api/statistics/index.js
+++ b/frontend/src/api/statistics/index.js
@@ -11,3 +11,26 @@ export const getHourlySales = () => api.get('/statistics/sales/hourly')
 export const getCategoryRatio = () => api.get('/statistics/category/ratio')
 
 export const getPaymentRatio = () => api.get('/statistics/payment/ratio')
+
+// ─── 장기 통계 (월/연/매장/카테고리별) ─────────────────────
+
+export const getYearlySales = () =>
+  api.get('/statistics/long-term/yearly')
+
+export const getMonthlySales = (year) =>
+  api.get('/statistics/long-term/monthly', { params: { year } })
+
+export const getStoreSalesLongTerm = (year, month) =>
+  api.get('/statistics/long-term/stores', {
+    params: month ? { year, month } : { year },
+  })
+
+export const getCategorySalesLongTerm = (year, month) =>
+  api.get('/statistics/long-term/categories', {
+    params: month ? { year, month } : { year },
+  })
+
+export const getMenuSalesLongTerm = (year, month) =>
+  api.get('/statistics/long-term/menus', {
+    params: month ? { year, month } : { year },
+  })

--- a/frontend/src/components/common/SideBar.vue
+++ b/frontend/src/components/common/SideBar.vue
@@ -44,6 +44,7 @@ const adminMenus = [
     path: '/statistics', name: '통계', icon: BarChart3,
     children: [
       { path: '/statistics', name: '실시간 통계' },
+      { path: '/statistics/long-term', name: '장기 통계' },
       { path: '/statistics/esg', name: 'ESG 대시보드' },
     ],
   },

--- a/frontend/src/components/statistics/MenuSalesLongTermList.vue
+++ b/frontend/src/components/statistics/MenuSalesLongTermList.vue
@@ -1,0 +1,106 @@
+<script setup>
+import { ref, onMounted, onUnmounted, watch, computed } from 'vue'
+import { getMenuSalesLongTerm } from '@/api/statistics'
+
+const currentYear = new Date().getFullYear()
+
+const selectedYear = ref(currentYear)
+const selectedMonth = ref(null)  // null = 연 전체
+
+const allMenus = ref([])
+const visibleCount = ref(15)
+const PAGE_SIZE = 15
+
+const yearOptions = [2025, 2026]
+const monthOptions = Array.from({ length: 12 }, (_, i) => i + 1)
+
+const scrollContainer = ref(null)
+
+const fetchData = async () => {
+  try {
+    const { data } = await getMenuSalesLongTerm(selectedYear.value, selectedMonth.value)
+    allMenus.value = data.result.menus
+    visibleCount.value = PAGE_SIZE
+  } catch (e) {
+    console.error('메뉴별 판매량 조회 실패', e)
+    allMenus.value = []
+  }
+}
+
+const visibleMenus = computed(() => allMenus.value.slice(0, visibleCount.value))
+const hasMore = computed(() => visibleCount.value < allMenus.value.length)
+
+const periodLabel = computed(() => {
+  return selectedMonth.value
+    ? `${selectedYear.value}년 ${selectedMonth.value}월`
+    : `${selectedYear.value}년 전체`
+})
+
+const handleScroll = () => {
+  const el = scrollContainer.value
+  if (!el || !hasMore.value) return
+  if (el.scrollTop + el.clientHeight >= el.scrollHeight - 80) {
+    visibleCount.value = Math.min(visibleCount.value + PAGE_SIZE, allMenus.value.length)
+  }
+}
+
+onMounted(() => {
+  fetchData()
+  scrollContainer.value?.addEventListener('scroll', handleScroll)
+})
+
+onUnmounted(() => {
+  scrollContainer.value?.removeEventListener('scroll', handleScroll)
+})
+
+watch([selectedYear, selectedMonth], fetchData)
+</script>
+
+<template>
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col">
+    <div class="flex items-start justify-between mb-4 shrink-0">
+      <div>
+        <h2 class="font-bold text-gray-900">메뉴 판매량 순위</h2>
+        <p class="text-xs text-gray-400 mt-0.5">
+          {{ periodLabel }} · {{ visibleMenus.length }} / {{ allMenus.length }} 메뉴
+        </p>
+      </div>
+      <div class="flex gap-2">
+        <select v-model.number="selectedYear"
+          class="border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300">
+          <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}년</option>
+        </select>
+        <select v-model="selectedMonth"
+          class="border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300">
+          <option :value="null">연 전체</option>
+          <option v-for="m in monthOptions" :key="m" :value="m">{{ m }}월</option>
+        </select>
+      </div>
+    </div>
+
+    <ul ref="scrollContainer" class="space-y-2 overflow-auto pr-1" style="height: 432px;">
+      <li v-for="(item, i) in visibleMenus" :key="item.menuIdx"
+        class="flex items-center justify-between py-1.5 px-2 rounded hover:bg-gray-50">
+        <div class="flex items-center gap-3">
+          <span class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold"
+            :class="i < 3 ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-500'">
+            {{ i + 1 }}
+          </span>
+          <span class="text-sm font-medium text-gray-800">{{ item.menuName }}</span>
+        </div>
+        <span class="text-sm font-semibold text-gray-700">
+          {{ item.totalQuantity.toLocaleString('ko-KR') }} 개
+        </span>
+      </li>
+      <li v-if="hasMore" class="text-xs text-gray-400 text-center py-2">
+        스크롤하면 더 보이기...
+      </li>
+      <li v-else-if="visibleMenus.length > 0" class="text-xs text-gray-400 text-center py-2">
+        — 끝 —
+      </li>
+      <li v-if="visibleMenus.length === 0" class="text-sm text-gray-400 text-center py-4">
+        데이터 없음
+      </li>
+    </ul>
+  </div>
+</template>

--- a/frontend/src/components/statistics/MonthlyTotalCard.vue
+++ b/frontend/src/components/statistics/MonthlyTotalCard.vue
@@ -1,0 +1,69 @@
+<script setup>
+import { ref, onMounted, watch, computed } from 'vue'
+import { getMonthlySales } from '@/api/statistics'
+
+const currentYear = new Date().getFullYear()
+const currentMonth = new Date().getMonth() + 1
+
+const selectedYear = ref(currentYear)
+const selectedMonth = ref(currentMonth)
+const monthlyData = ref([])  // [{month, total}, ...]
+
+const yearOptions = [2025, 2026]
+const monthOptions = Array.from({ length: 12 }, (_, i) => i + 1)
+
+const fetchData = async () => {
+  try {
+    const { data } = await getMonthlySales(selectedYear.value)
+    monthlyData.value = data.result.monthlyData
+  } catch (e) {
+    console.error('월별 매출 조회 실패', e)
+    monthlyData.value = []
+  }
+}
+
+const selectedTotal = computed(() => {
+  const found = monthlyData.value.find((d) => d.month === selectedMonth.value)
+  return found ? found.total : 0
+})
+
+const formattedTotal = computed(() => {
+  return `₩ ${selectedTotal.value.toLocaleString('ko-KR')}`
+})
+
+onMounted(fetchData)
+watch(() => selectedYear.value, fetchData)
+</script>
+
+<template>
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col"
+    style="min-height:200px">
+    <div class="flex items-start justify-between mb-4">
+      <div>
+        <h2 class="font-bold text-gray-900">월별 매출</h2>
+        <p class="text-xs text-gray-400 mt-0.5">선택한 달의 총 매출</p>
+      </div>
+      <div class="flex gap-2">
+        <select v-model.number="selectedYear"
+          class="border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300">
+          <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}년</option>
+        </select>
+        <select v-model.number="selectedMonth"
+          class="border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300">
+          <option v-for="m in monthOptions" :key="m" :value="m">{{ m }}월</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="flex-1 flex items-center justify-center">
+      <div class="text-center">
+        <p class="text-xs text-gray-400 mb-2">
+          {{ selectedYear }}년 {{ selectedMonth }}월 총 매출
+        </p>
+        <p class="text-4xl font-extrabold text-orange-600 tracking-tight">
+          {{ formattedTotal }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/statistics/StoreSalesLongTermList.vue
+++ b/frontend/src/components/statistics/StoreSalesLongTermList.vue
@@ -1,0 +1,109 @@
+<script setup>
+import { ref, onMounted, onUnmounted, watch, computed } from 'vue'
+import { getStoreSalesLongTerm } from '@/api/statistics'
+
+const currentYear = new Date().getFullYear()
+
+const selectedYear = ref(currentYear)
+const selectedMonth = ref(null)  // null = 연 전체
+
+const allStores = ref([])      // 백엔드에서 받아온 전체 매장 리스트
+const visibleCount = ref(15)   // 현재 화면에 보이는 개수
+const PAGE_SIZE = 15
+
+const yearOptions = [2025, 2026]
+const monthOptions = Array.from({ length: 12 }, (_, i) => i + 1)
+
+const scrollContainer = ref(null)
+
+const fetchData = async () => {
+  try {
+    const { data } = await getStoreSalesLongTerm(selectedYear.value, selectedMonth.value)
+    allStores.value = data.result.stores
+    visibleCount.value = PAGE_SIZE  // 필터 바뀌면 처음부터
+  } catch (e) {
+    console.error('매장별 매출 조회 실패', e)
+    allStores.value = []
+  }
+}
+
+// 화면에 표시할 슬라이스
+const visibleStores = computed(() => allStores.value.slice(0, visibleCount.value))
+const hasMore = computed(() => visibleCount.value < allStores.value.length)
+
+const periodLabel = computed(() => {
+  return selectedMonth.value
+    ? `${selectedYear.value}년 ${selectedMonth.value}월`
+    : `${selectedYear.value}년 전체`
+})
+
+// 무한 스크롤 핸들러
+const handleScroll = () => {
+  const el = scrollContainer.value
+  if (!el || !hasMore.value) return
+  // 하단에 가까워지면 더 로드
+  if (el.scrollTop + el.clientHeight >= el.scrollHeight - 80) {
+    visibleCount.value = Math.min(visibleCount.value + PAGE_SIZE, allStores.value.length)
+  }
+}
+
+onMounted(() => {
+  fetchData()
+  scrollContainer.value?.addEventListener('scroll', handleScroll)
+})
+
+onUnmounted(() => {
+  scrollContainer.value?.removeEventListener('scroll', handleScroll)
+})
+
+watch([selectedYear, selectedMonth], fetchData)
+</script>
+
+<template>
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col">
+    <div class="flex items-start justify-between mb-4 shrink-0">
+      <div>
+        <h2 class="font-bold text-gray-900">매장 매출 순위</h2>
+        <p class="text-xs text-gray-400 mt-0.5">
+          {{ periodLabel }} · {{ visibleStores.length }} / {{ allStores.length }} 매장
+        </p>
+      </div>
+      <div class="flex gap-2">
+        <select v-model.number="selectedYear"
+          class="border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300">
+          <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}년</option>
+        </select>
+        <select v-model="selectedMonth"
+          class="border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300">
+          <option :value="null">연 전체</option>
+          <option v-for="m in monthOptions" :key="m" :value="m">{{ m }}월</option>
+        </select>
+      </div>
+    </div>
+
+    <ul ref="scrollContainer" class="space-y-2 overflow-auto pr-1" style="height: 432px;">
+      <li v-for="(item, i) in visibleStores" :key="item.storeIdx"
+        class="flex items-center justify-between py-1.5 px-2 rounded hover:bg-gray-50">
+        <div class="flex items-center gap-3">
+          <span class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold"
+            :class="i < 3 ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-500'">
+            {{ i + 1 }}
+          </span>
+          <span class="text-sm font-medium text-gray-800">{{ item.storeName }}</span>
+        </div>
+        <span class="text-sm font-semibold text-gray-700">
+          ₩ {{ item.total.toLocaleString('ko-KR') }}
+        </span>
+      </li>
+      <li v-if="hasMore" class="text-xs text-gray-400 text-center py-2">
+        스크롤하면 더 보이기...
+      </li>
+      <li v-else-if="visibleStores.length > 0" class="text-xs text-gray-400 text-center py-2">
+        — 끝 —
+      </li>
+      <li v-if="visibleStores.length === 0" class="text-sm text-gray-400 text-center py-4">
+        데이터 없음
+      </li>
+    </ul>
+  </div>
+</template>

--- a/frontend/src/components/statistics/YearlyTotalCard.vue
+++ b/frontend/src/components/statistics/YearlyTotalCard.vue
@@ -1,0 +1,58 @@
+<script setup>
+import { ref, onMounted, computed } from 'vue'
+import { getYearlySales } from '@/api/statistics'
+
+const allYears = ref([])      // [{year, total}, ...]
+const selectedYear = ref(null)
+
+const fetchData = async () => {
+  try {
+    const { data } = await getYearlySales()
+    allYears.value = data.result.yearlyData
+    // 기본값: 가장 최신 연도
+    if (allYears.value.length > 0 && selectedYear.value == null) {
+      selectedYear.value = allYears.value[allYears.value.length - 1].year
+    }
+  } catch (e) {
+    console.error('연도별 매출 조회 실패', e)
+  }
+}
+
+const selectedTotal = computed(() => {
+  const found = allYears.value.find((d) => d.year === selectedYear.value)
+  return found ? found.total : 0
+})
+
+const formattedTotal = computed(() => {
+  return `₩ ${selectedTotal.value.toLocaleString('ko-KR')}`
+})
+
+const yearOptions = computed(() => allYears.value.map((d) => d.year))
+
+onMounted(fetchData)
+</script>
+
+<template>
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col"
+    style="min-height:200px">
+    <div class="flex items-start justify-between mb-4">
+      <div>
+        <h2 class="font-bold text-gray-900">연도별 매출</h2>
+        <p class="text-xs text-gray-400 mt-0.5">선택한 연도의 총 매출</p>
+      </div>
+      <select v-model.number="selectedYear"
+        class="border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300">
+        <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}년</option>
+      </select>
+    </div>
+
+    <div class="flex-1 flex items-center justify-center">
+      <div class="text-center">
+        <p class="text-xs text-gray-400 mb-2">{{ selectedYear }}년 총 매출</p>
+        <p class="text-4xl font-extrabold text-orange-600 tracking-tight">
+          {{ formattedTotal }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -35,6 +35,12 @@ const router = createRouter({
       meta: { role: 'ADMIN' },
     },
     {
+      path: '/statistics/long-term',
+      name: 'statisticsLongTerm',
+      component: () => import('@/views/hq/LongTermStatisticsView.vue'),
+      meta: { role: 'ADMIN' },
+    },
+    {
       path: '/store',
       name: 'store',
       component: () => import('@/views/hq/StoreView.vue'),

--- a/frontend/src/views/hq/LongTermStatisticsView.vue
+++ b/frontend/src/views/hq/LongTermStatisticsView.vue
@@ -1,0 +1,30 @@
+<script setup>
+import YearlyTotalCard from '@/components/statistics/YearlyTotalCard.vue'
+import MonthlyTotalCard from '@/components/statistics/MonthlyTotalCard.vue'
+import StoreSalesLongTermList from '@/components/statistics/StoreSalesLongTermList.vue'
+import MenuSalesLongTermList from '@/components/statistics/MenuSalesLongTermList.vue'
+</script>
+
+<template>
+  <div class="flex-1 overflow-auto p-5 space-y-4">
+    <!-- 헤더 -->
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h1 class="text-[22px] font-bold text-gray-900 tracking-tight">장기 통계</h1>
+        <p class="text-xs text-gray-400 mt-1">연도/월/매장/메뉴별 매출 분석</p>
+      </div>
+    </div>
+
+    <!-- 연도/월별 금액 카드 -->
+    <div class="grid grid-cols-2 gap-4">
+      <YearlyTotalCard />
+      <MonthlyTotalCard />
+    </div>
+
+    <!-- 매장/메뉴 리스트 (무한 스크롤) -->
+    <div class="grid grid-cols-2 gap-4">
+      <StoreSalesLongTermList />
+      <MenuSalesLongTermList />
+    </div>
+  </div>
+</template>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -17,11 +17,11 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },
-      '/api/statistics': {
-        target: 'http://localhost:8088', // Gateway (통계도 있다면 추가)
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
-      },
+      // '/api/statistics': {
+      //   target: 'http://localhost:8081', // 통계 MSA 직접 (Gateway 안 띄울 때)
+      //   changeOrigin: true,
+      //   rewrite: (path) => path.replace(/^\/api/, ''),
+      // },
 
       '/api': {
         target: 'http://localhost:8080',


### PR DESCRIPTION
## Summary
- 통계 MSA 의 `daily_*` 영구 보존 데이터를 활용한 **장기 통계 페이지** 구현
- 백엔드 5개 엔드포인트 (`/statistics/long-term/*`) + 프론트엔드 4개 컴포넌트
- 각 컴포넌트가 **자체 드롭다운으로 연/월 필터** + 매장/메뉴는 **무한 스크롤**로 15개씩 추가 로딩

## 변경 파일

### 백엔드
- `model/LongTermStatisticsDto.java` (신규) — 응답 DTO 5종
- `LongTermStatisticsService.java` (신규) — 비즈니스 로직
- `LongTermStatisticsController.java` (신규) — REST API
- `domain/daily/DailyTotalSalesRepository.java` — Native Query 2개 추가
- `domain/daily/DailyStoreSalesRepository.java` — Native Query 1개 추가
- `domain/daily/DailyCategorySalesRepository.java` — Native Query 1개 추가
- `domain/daily/DailyMenuSalesRepository.java` — Native Query 1개 추가
- `src/main/resources/sql/seed-long-term-dummy.sql` (.gitignore 처리) — 로컬 1년치 더미 데이터

### 프론트엔드
- `views/hq/LongTermStatisticsView.vue` (신규) — 페이지 (2×2 그리드)
- `components/statistics/YearlyTotalCard.vue` (신규) — 연도 선택 → 금액 카드
- `components/statistics/MonthlyTotalCard.vue` (신규) — 연/월 선택 → 금액 카드
- `components/statistics/StoreSalesLongTermList.vue` (신규) — 매장 순위 + 무한 스크롤 + 연/월 필터
- `components/statistics/MenuSalesLongTermList.vue` (신규) — 메뉴 순위 + 무한 스크롤 + 연/월 필터
- `api/statistics/index.js` — long-term API 5개 추가
- `router/index.js` — `/statistics/long-term` 라우트 (ADMIN 권한)
- `components/common/SideBar.vue` — 통계 메뉴에 "장기 통계" 항목 추가

## 주요 변경 사항

- 백엔드 5개 엔드포인트
  - `GET /statistics/long-term/yearly`               — 연도별 총 매출 (전체 기간)
  - `GET /statistics/long-term/monthly?year`         — 특정 연도의 월별 매출
  - `GET /statistics/long-term/stores?year&month`    — 매장별 매출 (매출 큰 순)
  - `GET /statistics/long-term/categories?year&month` — 카테고리별 매출 (매출 큰 순)
  - `GET /statistics/long-term/menus?year&month`     — 메뉴별 판매량 (판매량 많은 순)
- Repository 메서드는 모두 **Native Query GROUP BY** (`MONTH()/YEAR()` SUM 집계)
- `month` 파라미터는 옵션 — 없으면 그 해 1/1 ~ 12/31 자동 범위
- 단일 UNIQUE 는 `@Column(unique=true)`, 복합 UNIQUE 는 `@Table(uniqueConstraints=...)` 일관 적용
- DTO 패턴 — `Item` + `Res` 두 클래스 (기존 `StatisticsDto` 와 동일 스타일)
- 프론트엔드 컴포넌트는 모두 **자체 드롭다운 + 자체 fetch** (페이지 레벨 공통 상태 없음 → 독립성 ↑)
- 매장/메뉴 리스트는 `height: 432px` 고정 + `overflow-auto` 로 **첫 화면 9개 row 표시**, 스크롤 시 15개씩 추가
- 사이드바 메뉴: 통계 > 실시간 통계 / **장기 통계** / ESG 대시보드

## DB & Infrastructure

- 테이블 스키마 변경 없음 (Phase 1B-1 (#874) 에서 만든 `daily_*` 7개 테이블 그대로 활용)
- 운영 환경 hibernate `ddl-auto=update` 로 별도 마이그레이션 불필요
- 더미 데이터 SQL 은 `src/main/resources/sql/` 폴더에 보관하되 `.gitignore` 로 git 제외 (운영 DB 실행 시 매출이 거대하게 보이므로 사고 방지)

## Test Plan
- [x] gradle 빌드 통과
- [x] 통계 MSA 로컬 실행 (IntelliJ EnvFile 플러그인으로 `.env` 로딩, 8081 포트)
- [x] `ddl-auto=update` 로 `daily_*` 7개 테이블 자동 생성 확인
- [x] 더미 SQL 실행 (1년치 ≈ 43,800 row 추가)
- [x] 5개 API 응답 검증 (yearly/monthly/stores/menus 결과 일치 확인)
- [x] 5-way 정합성 — yearly 합 = monthly 합 (예: 2026 = 21,127,807,506)
- [x] 프론트 무한 스크롤 동작 확인 (15개씩 로딩)
- [x] 연/월 드롭다운 변경 시 차트/리스트 즉시 갱신
- [x] ADMIN 권한 외 접근 시 라우터 가드 동작

## Issue
- Closes #881