### PR TITLE
[Refactor] #885 - 장기 통계 페이지 UX 개선 (단위/카드/통합차트/검색/애니메이션)

### DIFF
--- a/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsController.java
+++ b/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsController.java
@@ -44,6 +44,18 @@ public class LongTermStatisticsController {
     }
 
     /**
+     * 특정 연도의 분기별 매출 (1~4분기).
+     *
+     * GET /statistics/long-term/quarterly?year=2026
+     *
+     * @param year 조회할 연도
+     */
+    @GetMapping("/quarterly")
+    public ResponseEntity<BaseResponse> getQuarterly(@RequestParam int year) {
+        return ResponseEntity.ok(BaseResponse.success(longTermStatisticsService.getQuarterlySales(year)));
+    }
+
+    /**
      * 특정 기간 매장별 매출 (매출 큰 순).
      *
      * GET /statistics/long-term/stores?year=2026&month=5   (월 단위)

--- a/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsService.java
+++ b/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsService.java
@@ -58,6 +58,24 @@ public class LongTermStatisticsService {
     }
 
     /**
+     * 특정 연도의 분기별 매출 (1~4분기).
+     *
+     * @param year 조회할 연도
+     */
+    public LongTermStatisticsDto.QuarterlySalesRes getQuarterlySales(int year) {
+        List<LongTermStatisticsDto.QuarterlySalesItem> items = totalRepo.findQuarterlySalesGroup(year).stream()
+                .map(r -> LongTermStatisticsDto.QuarterlySalesItem.builder()
+                        .quarter(((Number) r[0]).intValue())
+                        .total(r[1] == null ? 0L : ((Number) r[1]).longValue())
+                        .build())
+                .toList();
+        return LongTermStatisticsDto.QuarterlySalesRes.builder()
+                .year(year)
+                .quarterlyData(items)
+                .build();
+    }
+
+    /**
      * 특정 기간의 매장별 매출 합계 (매출 큰 순).
      * month 가 null 이면 해당 연도 전체.
      *

--- a/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyTotalSalesRepository.java
+++ b/backend/statistics/src/main/java/com/example/statistics/domain/daily/DailyTotalSalesRepository.java
@@ -60,4 +60,19 @@ public interface DailyTotalSalesRepository extends JpaRepository<DailyTotalSales
             ORDER BY MONTH(aggregate_date)
             """, nativeQuery = true)
     List<Object[]> findMonthlySalesGroup(@Param("year") int year);
+
+    /**
+     * 특정 연도의 분기별 매출 집계 (장기 통계).
+     *
+     * @param year 조회할 연도
+     * @return [quarter(1~4), total(Long)] 배열 리스트, 분기 오름차순
+     */
+    @Query(value = """
+            SELECT QUARTER(aggregate_date) AS quarter, SUM(total_amount) AS total
+            FROM daily_total_sales
+            WHERE YEAR(aggregate_date) = :year
+            GROUP BY QUARTER(aggregate_date)
+            ORDER BY QUARTER(aggregate_date)
+            """, nativeQuery = true)
+    List<Object[]> findQuarterlySalesGroup(@Param("year") int year);
 }

--- a/backend/statistics/src/main/java/com/example/statistics/model/LongTermStatisticsDto.java
+++ b/backend/statistics/src/main/java/com/example/statistics/model/LongTermStatisticsDto.java
@@ -42,6 +42,22 @@ public class LongTermStatisticsDto {
         private List<MonthlySalesItem> monthlyData;
     }
 
+    // ─── 분기별 ─────────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class QuarterlySalesItem {
+        private int quarter;   // 1~4
+        private long total;
+    }
+
+    @Getter
+    @Builder
+    public static class QuarterlySalesRes {
+        private int year;
+        private List<QuarterlySalesItem> quarterlyData;
+    }
+
     // ─── 매장별 ─────────────────────────────────────
 
     @Getter

--- a/frontend/src/api/statistics/index.js
+++ b/frontend/src/api/statistics/index.js
@@ -20,6 +20,9 @@ export const getYearlySales = () =>
 export const getMonthlySales = (year) =>
   api.get('/statistics/long-term/monthly', { params: { year } })
 
+export const getQuarterlySales = (year) =>
+  api.get('/statistics/long-term/quarterly', { params: { year } })
+
 export const getStoreSalesLongTerm = (year, month) =>
   api.get('/statistics/long-term/stores', {
     params: month ? { year, month } : { year },

--- a/frontend/src/components/statistics/MenuSalesLongTermList.vue
+++ b/frontend/src/components/statistics/MenuSalesLongTermList.vue
@@ -1,34 +1,33 @@
 <script setup>
-import { ref, onMounted, onUnmounted, watch, computed } from 'vue'
+import { ref, onMounted, watch, computed } from 'vue'
 import { getMenuSalesLongTerm } from '@/api/statistics'
 
 const currentYear = new Date().getFullYear()
 
 const selectedYear = ref(currentYear)
-const selectedMonth = ref(null)  // null = 연 전체
+const selectedMonth = ref(null)
+const searchKeyword = ref('')
 
 const allMenus = ref([])
-const visibleCount = ref(15)
-const PAGE_SIZE = 15
 
 const yearOptions = [2025, 2026]
 const monthOptions = Array.from({ length: 12 }, (_, i) => i + 1)
-
-const scrollContainer = ref(null)
 
 const fetchData = async () => {
   try {
     const { data } = await getMenuSalesLongTerm(selectedYear.value, selectedMonth.value)
     allMenus.value = data.result.menus
-    visibleCount.value = PAGE_SIZE
   } catch (e) {
     console.error('메뉴별 판매량 조회 실패', e)
     allMenus.value = []
   }
 }
 
-const visibleMenus = computed(() => allMenus.value.slice(0, visibleCount.value))
-const hasMore = computed(() => visibleCount.value < allMenus.value.length)
+const filteredMenus = computed(() => {
+  if (!searchKeyword.value.trim()) return allMenus.value
+  const kw = searchKeyword.value.toLowerCase()
+  return allMenus.value.filter((m) => m.menuName.toLowerCase().includes(kw))
+})
 
 const periodLabel = computed(() => {
   return selectedMonth.value
@@ -36,33 +35,24 @@ const periodLabel = computed(() => {
     : `${selectedYear.value}년 전체`
 })
 
-const handleScroll = () => {
-  const el = scrollContainer.value
-  if (!el || !hasMore.value) return
-  if (el.scrollTop + el.clientHeight >= el.scrollHeight - 80) {
-    visibleCount.value = Math.min(visibleCount.value + PAGE_SIZE, allMenus.value.length)
-  }
+const getOriginalRank = (menu) => {
+  return allMenus.value.findIndex((m) => m.menuIdx === menu.menuIdx) + 1
 }
 
-onMounted(() => {
-  fetchData()
-  scrollContainer.value?.addEventListener('scroll', handleScroll)
-})
-
-onUnmounted(() => {
-  scrollContainer.value?.removeEventListener('scroll', handleScroll)
-})
-
+onMounted(fetchData)
 watch([selectedYear, selectedMonth], fetchData)
 </script>
 
 <template>
   <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col">
-    <div class="flex items-start justify-between mb-4 shrink-0">
+    <!-- 헤더 -->
+    <div class="flex items-start justify-between mb-3 shrink-0">
       <div>
         <h2 class="font-bold text-gray-900">메뉴 판매량 순위</h2>
         <p class="text-xs text-gray-400 mt-0.5">
-          {{ periodLabel }} · {{ visibleMenus.length }} / {{ allMenus.length }} 메뉴
+          {{ periodLabel }} ·
+          <span v-if="searchKeyword">{{ filteredMenus.length }} / {{ allMenus.length }} 메뉴</span>
+          <span v-else>총 {{ allMenus.length }} 메뉴</span>
         </p>
       </div>
       <div class="flex gap-2">
@@ -78,13 +68,20 @@ watch([selectedYear, selectedMonth], fetchData)
       </div>
     </div>
 
-    <ul ref="scrollContainer" class="space-y-2 overflow-auto pr-1" style="height: 432px;">
-      <li v-for="(item, i) in visibleMenus" :key="item.menuIdx"
+    <!-- 검색 -->
+    <div class="mb-3 shrink-0">
+      <input v-model="searchKeyword" type="text" placeholder="메뉴명 검색..."
+        class="w-full border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300" />
+    </div>
+
+    <!-- 리스트 (스크롤) -->
+    <ul class="space-y-2 overflow-auto pr-1" style="height: 432px;">
+      <li v-for="item in filteredMenus" :key="item.menuIdx"
         class="flex items-center justify-between py-1.5 px-2 rounded hover:bg-gray-50">
         <div class="flex items-center gap-3">
           <span class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold"
-            :class="i < 3 ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-500'">
-            {{ i + 1 }}
+            :class="getOriginalRank(item) <= 3 ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-500'">
+            {{ getOriginalRank(item) }}
           </span>
           <span class="text-sm font-medium text-gray-800">{{ item.menuName }}</span>
         </div>
@@ -92,14 +89,8 @@ watch([selectedYear, selectedMonth], fetchData)
           {{ item.totalQuantity.toLocaleString('ko-KR') }} 개
         </span>
       </li>
-      <li v-if="hasMore" class="text-xs text-gray-400 text-center py-2">
-        스크롤하면 더 보이기...
-      </li>
-      <li v-else-if="visibleMenus.length > 0" class="text-xs text-gray-400 text-center py-2">
-        — 끝 —
-      </li>
-      <li v-if="visibleMenus.length === 0" class="text-sm text-gray-400 text-center py-4">
-        데이터 없음
+      <li v-if="filteredMenus.length === 0" class="text-sm text-gray-400 text-center py-4">
+        {{ searchKeyword ? '검색 결과 없음' : '데이터 없음' }}
       </li>
     </ul>
   </div>

--- a/frontend/src/components/statistics/MonthlyTotalCard.vue
+++ b/frontend/src/components/statistics/MonthlyTotalCard.vue
@@ -1,23 +1,21 @@
 <script setup>
-import { ref, onMounted, watch, computed, onUnmounted, nextTick } from 'vue'
-import { Chart } from 'chart.js/auto'
+import { ref, onMounted, watch, computed } from 'vue'
 import { getMonthlySales } from '@/api/statistics'
 import { formatCurrency, calculateChange } from '@/utils/formatCurrency'
+import { useAnimatedNumber } from '@/composables/useAnimatedNumber'
 
 const currentYear = new Date().getFullYear()
 const currentMonth = new Date().getMonth() + 1
 
 const selectedYear = ref(currentYear)
 const selectedMonth = ref(currentMonth)
+const isMounted = ref(false)
 
-const currentYearData = ref([])    // 선택 연도 monthly
-const previousYearData = ref([])   // 작년 monthly (YoY 계산용)
+const currentYearData = ref([])
+const previousYearData = ref([])
 
 const yearOptions = [2025, 2026]
 const monthOptions = Array.from({ length: 12 }, (_, i) => i + 1)
-
-const sparklineCanvas = ref(null)
-let chartInstance = null
 
 const fetchData = async () => {
   try {
@@ -27,96 +25,55 @@ const fetchData = async () => {
     ])
     currentYearData.value = curr.data.result.monthlyData
     previousYearData.value = prev.data.result.monthlyData
-    await nextTick()
-    renderSparkline()
   } catch (e) {
     console.error('월별 매출 조회 실패', e)
   }
 }
 
 const selectedTotal = computed(() => {
-  const found = currentYearData.value.find((d) => d.month === selectedMonth.value)
-  return found ? found.total : 0
+  const f = currentYearData.value.find((d) => d.month === selectedMonth.value)
+  return f ? f.total : 0
 })
 
-// YoY (작년 동월 대비)
+const previousTotal = computed(() => {
+  const f = previousYearData.value.find((d) => d.month === selectedMonth.value)
+  return f ? f.total : null
+})
+
 const yoy = computed(() => {
-  const prev = previousYearData.value.find((d) => d.month === selectedMonth.value)?.total
-  if (prev == null) return null
-  return calculateChange(selectedTotal.value, prev)
+  if (previousTotal.value == null) return null
+  return calculateChange(selectedTotal.value, previousTotal.value)
 })
 
-const formattedTotal = computed(() => formatCurrency(selectedTotal.value))
+// 카운트업
+const animatedTotal = useAnimatedNumber(selectedTotal)
+const formattedTotal = computed(() => formatCurrency(animatedTotal.value))
 
-const renderSparkline = () => {
-  if (!sparklineCanvas.value) return
+// 프로그레스 바
+const maxValue = computed(() => Math.max(selectedTotal.value, previousTotal.value || 0))
+const currentBarWidth = computed(() => {
+  if (!isMounted.value || maxValue.value === 0) return '0%'
+  return (selectedTotal.value / maxValue.value) * 100 + '%'
+})
+const previousBarWidth = computed(() => {
+  if (!isMounted.value || maxValue.value === 0 || previousTotal.value == null) return '0%'
+  return (previousTotal.value / maxValue.value) * 100 + '%'
+})
 
-  const labels = monthOptions.map((m) => `${m}월`)
-  const totals = new Array(12).fill(0)
-  currentYearData.value.forEach((d) => {
-    totals[d.month - 1] = d.total
-  })
-
-  // 선택 월 포인트만 강조
-  const pointRadii = monthOptions.map((m) => (m === selectedMonth.value ? 5 : 0))
-  const pointColors = monthOptions.map((m) =>
-    m === selectedMonth.value ? '#f97316' : 'rgba(0,0,0,0)',
-  )
-
-  if (chartInstance) chartInstance.destroy()
-
-  chartInstance = new Chart(sparklineCanvas.value, {
-    type: 'line',
-    data: {
-      labels,
-      datasets: [{
-        data: totals,
-        borderColor: '#f97316',
-        backgroundColor: 'rgba(249,115,22,0.15)',
-        fill: true,
-        tension: 0.3,
-        pointRadius: pointRadii,
-        pointBackgroundColor: pointColors,
-        pointBorderColor: pointColors,
-        borderWidth: 2,
-      }],
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      plugins: {
-        legend: { display: false },
-        tooltip: {
-          backgroundColor: '#1f2937',
-          titleColor: '#f9fafb',
-          bodyColor: '#d1d5db',
-          padding: 8,
-          cornerRadius: 8,
-          callbacks: { label: (ctx) => ` ${formatCurrency(ctx.parsed.y)}` },
-        },
-      },
-      scales: {
-        x: { display: false },
-        y: { display: false, beginAtZero: true },
-      },
-    },
-  })
-}
-
-onMounted(fetchData)
+onMounted(async () => {
+  await fetchData()
+  setTimeout(() => { isMounted.value = true }, 100)
+})
 watch(() => selectedYear.value, fetchData)
-watch(() => selectedMonth.value, () => renderSparkline())
-onUnmounted(() => {
-  if (chartInstance) chartInstance.destroy()
-})
 </script>
 
 <template>
-  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col" style="min-height:200px">
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col">
+    <!-- 헤더 -->
     <div class="flex items-start justify-between mb-4">
       <div>
         <h2 class="font-bold text-gray-900">월별 매출</h2>
-        <p class="text-xs text-gray-400 mt-0.5">선택 달의 총 매출</p>
+        <p class="text-xs text-gray-400 mt-0.5">{{ selectedYear }}년 {{ selectedMonth }}월 총 매출</p>
       </div>
       <div class="flex gap-2">
         <select v-model.number="selectedYear"
@@ -130,23 +87,40 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <div class="flex-1 flex items-center gap-6">
-      <!-- 큰 숫자 + YoY -->
-      <div class="flex-shrink-0 min-w-[140px]">
-        <p class="text-3xl font-extrabold text-orange-600 tracking-tight">
-          {{ formattedTotal }}
-        </p>
-        <p v-if="yoy" class="text-xs mt-1.5 font-semibold"
-          :class="yoy.isPositive ? 'text-emerald-600' : 'text-red-500'">
-          {{ yoy.text }}
-          <span class="text-gray-400 font-normal">vs 작년 동월</span>
-        </p>
-        <p v-else class="text-xs mt-1.5 text-gray-400">작년 동월 데이터 없음</p>
-      </div>
+    <!-- 큰 숫자 (카운트업) -->
+    <p class="text-4xl font-extrabold text-orange-600 tracking-tight">
+      {{ formattedTotal }}
+    </p>
 
-      <!-- Sparkline (선택 월 강조) -->
-      <div class="flex-1 relative" style="height: 70px; min-width: 100px;">
-        <canvas ref="sparklineCanvas" style="display:block; width:100%; height:100%;"></canvas>
+    <!-- YoY 배지 -->
+    <p v-if="yoy" class="text-sm mt-2 font-semibold"
+      :class="yoy.isPositive ? 'text-emerald-600' : 'text-red-500'">
+      {{ yoy.isPositive ? '▲' : '▼' }} {{ yoy.text }}
+      <span class="text-gray-400 font-normal ml-1">vs 작년 동월</span>
+    </p>
+    <p v-else class="text-sm mt-2 text-gray-400">작년 동월 데이터 없음</p>
+
+    <!-- 프로그레스 바 -->
+    <div class="mt-5 space-y-2.5">
+      <div>
+        <div class="flex justify-between text-xs text-gray-500 mb-1">
+          <span>작년 {{ selectedMonth }}월</span>
+          <span>{{ previousTotal != null ? formatCurrency(previousTotal) : '-' }}</span>
+        </div>
+        <div class="bg-gray-100 rounded-full h-2 overflow-hidden">
+          <div class="h-full bg-gray-300 rounded-full transition-all duration-1000 ease-out"
+            :style="{ width: previousBarWidth }"></div>
+        </div>
+      </div>
+      <div>
+        <div class="flex justify-between text-xs mb-1">
+          <span class="text-gray-700 font-semibold">올해 {{ selectedMonth }}월</span>
+          <span class="text-gray-700 font-semibold">{{ formatCurrency(selectedTotal) }}</span>
+        </div>
+        <div class="bg-gray-100 rounded-full h-2 overflow-hidden">
+          <div class="h-full bg-orange-500 rounded-full transition-all duration-1000 ease-out"
+            :style="{ width: currentBarWidth }"></div>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/components/statistics/MonthlyTotalCard.vue
+++ b/frontend/src/components/statistics/MonthlyTotalCard.vue
@@ -1,47 +1,122 @@
 <script setup>
-import { ref, onMounted, watch, computed } from 'vue'
+import { ref, onMounted, watch, computed, onUnmounted, nextTick } from 'vue'
+import { Chart } from 'chart.js/auto'
 import { getMonthlySales } from '@/api/statistics'
+import { formatCurrency, calculateChange } from '@/utils/formatCurrency'
 
 const currentYear = new Date().getFullYear()
 const currentMonth = new Date().getMonth() + 1
 
 const selectedYear = ref(currentYear)
 const selectedMonth = ref(currentMonth)
-const monthlyData = ref([])  // [{month, total}, ...]
+
+const currentYearData = ref([])    // 선택 연도 monthly
+const previousYearData = ref([])   // 작년 monthly (YoY 계산용)
 
 const yearOptions = [2025, 2026]
 const monthOptions = Array.from({ length: 12 }, (_, i) => i + 1)
 
+const sparklineCanvas = ref(null)
+let chartInstance = null
+
 const fetchData = async () => {
   try {
-    const { data } = await getMonthlySales(selectedYear.value)
-    monthlyData.value = data.result.monthlyData
+    const [curr, prev] = await Promise.all([
+      getMonthlySales(selectedYear.value),
+      getMonthlySales(selectedYear.value - 1),
+    ])
+    currentYearData.value = curr.data.result.monthlyData
+    previousYearData.value = prev.data.result.monthlyData
+    await nextTick()
+    renderSparkline()
   } catch (e) {
     console.error('월별 매출 조회 실패', e)
-    monthlyData.value = []
   }
 }
 
 const selectedTotal = computed(() => {
-  const found = monthlyData.value.find((d) => d.month === selectedMonth.value)
+  const found = currentYearData.value.find((d) => d.month === selectedMonth.value)
   return found ? found.total : 0
 })
 
-const formattedTotal = computed(() => {
-  return `₩ ${selectedTotal.value.toLocaleString('ko-KR')}`
+// YoY (작년 동월 대비)
+const yoy = computed(() => {
+  const prev = previousYearData.value.find((d) => d.month === selectedMonth.value)?.total
+  if (prev == null) return null
+  return calculateChange(selectedTotal.value, prev)
 })
+
+const formattedTotal = computed(() => formatCurrency(selectedTotal.value))
+
+const renderSparkline = () => {
+  if (!sparklineCanvas.value) return
+
+  const labels = monthOptions.map((m) => `${m}월`)
+  const totals = new Array(12).fill(0)
+  currentYearData.value.forEach((d) => {
+    totals[d.month - 1] = d.total
+  })
+
+  // 선택 월 포인트만 강조
+  const pointRadii = monthOptions.map((m) => (m === selectedMonth.value ? 5 : 0))
+  const pointColors = monthOptions.map((m) =>
+    m === selectedMonth.value ? '#f97316' : 'rgba(0,0,0,0)',
+  )
+
+  if (chartInstance) chartInstance.destroy()
+
+  chartInstance = new Chart(sparklineCanvas.value, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{
+        data: totals,
+        borderColor: '#f97316',
+        backgroundColor: 'rgba(249,115,22,0.15)',
+        fill: true,
+        tension: 0.3,
+        pointRadius: pointRadii,
+        pointBackgroundColor: pointColors,
+        pointBorderColor: pointColors,
+        borderWidth: 2,
+      }],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: '#1f2937',
+          titleColor: '#f9fafb',
+          bodyColor: '#d1d5db',
+          padding: 8,
+          cornerRadius: 8,
+          callbacks: { label: (ctx) => ` ${formatCurrency(ctx.parsed.y)}` },
+        },
+      },
+      scales: {
+        x: { display: false },
+        y: { display: false, beginAtZero: true },
+      },
+    },
+  })
+}
 
 onMounted(fetchData)
 watch(() => selectedYear.value, fetchData)
+watch(() => selectedMonth.value, () => renderSparkline())
+onUnmounted(() => {
+  if (chartInstance) chartInstance.destroy()
+})
 </script>
 
 <template>
-  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col"
-    style="min-height:200px">
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col" style="min-height:200px">
     <div class="flex items-start justify-between mb-4">
       <div>
         <h2 class="font-bold text-gray-900">월별 매출</h2>
-        <p class="text-xs text-gray-400 mt-0.5">선택한 달의 총 매출</p>
+        <p class="text-xs text-gray-400 mt-0.5">선택 달의 총 매출</p>
       </div>
       <div class="flex gap-2">
         <select v-model.number="selectedYear"
@@ -55,14 +130,23 @@ watch(() => selectedYear.value, fetchData)
       </div>
     </div>
 
-    <div class="flex-1 flex items-center justify-center">
-      <div class="text-center">
-        <p class="text-xs text-gray-400 mb-2">
-          {{ selectedYear }}년 {{ selectedMonth }}월 총 매출
-        </p>
-        <p class="text-4xl font-extrabold text-orange-600 tracking-tight">
+    <div class="flex-1 flex items-center gap-6">
+      <!-- 큰 숫자 + YoY -->
+      <div class="flex-shrink-0 min-w-[140px]">
+        <p class="text-3xl font-extrabold text-orange-600 tracking-tight">
           {{ formattedTotal }}
         </p>
+        <p v-if="yoy" class="text-xs mt-1.5 font-semibold"
+          :class="yoy.isPositive ? 'text-emerald-600' : 'text-red-500'">
+          {{ yoy.text }}
+          <span class="text-gray-400 font-normal">vs 작년 동월</span>
+        </p>
+        <p v-else class="text-xs mt-1.5 text-gray-400">작년 동월 데이터 없음</p>
+      </div>
+
+      <!-- Sparkline (선택 월 강조) -->
+      <div class="flex-1 relative" style="height: 70px; min-width: 100px;">
+        <canvas ref="sparklineCanvas" style="display:block; width:100%; height:100%;"></canvas>
       </div>
     </div>
   </div>

--- a/frontend/src/components/statistics/SalesTrendChart.vue
+++ b/frontend/src/components/statistics/SalesTrendChart.vue
@@ -1,0 +1,184 @@
+<script setup>
+import { ref, onMounted, watch, computed, onUnmounted, nextTick } from 'vue'
+import { Chart } from 'chart.js/auto'
+import { getYearlySales, getQuarterlySales, getMonthlySales } from '@/api/statistics'
+import { formatCurrency, formatCurrencyShort } from '@/utils/formatCurrency'
+
+const currentYear = new Date().getFullYear()
+
+// 'yearly' | 'quarterly' | 'monthly'
+const viewMode = ref('monthly')
+const selectedYear = ref(currentYear)
+
+const chartData = ref({ labels: [], values: [] })
+
+const canvas = ref(null)
+let chartInstance = null
+
+const yearOptions = [2025, 2026]
+
+const VIEW_MODES = [
+  { key: 'yearly', label: '연도' },
+  { key: 'quarterly', label: '분기' },
+  { key: 'monthly', label: '월' },
+]
+
+const fetchData = async () => {
+  try {
+    if (viewMode.value === 'yearly') {
+      const { data } = await getYearlySales()
+      const sorted = [...data.result.yearlyData].sort((a, b) => a.year - b.year)
+      chartData.value = {
+        labels: sorted.map((d) => `${d.year}년`),
+        values: sorted.map((d) => d.total),
+      }
+    } else if (viewMode.value === 'quarterly') {
+      const { data } = await getQuarterlySales(selectedYear.value)
+      const items = data.result.quarterlyData
+      const values = new Array(4).fill(0)
+      items.forEach((d) => {
+        values[d.quarter - 1] = d.total
+      })
+      chartData.value = {
+        labels: ['1분기', '2분기', '3분기', '4분기'],
+        values,
+      }
+    } else {
+      // monthly
+      const { data } = await getMonthlySales(selectedYear.value)
+      const items = data.result.monthlyData
+      const values = new Array(12).fill(0)
+      items.forEach((d) => {
+        values[d.month - 1] = d.total
+      })
+      chartData.value = {
+        labels: Array.from({ length: 12 }, (_, i) => `${i + 1}월`),
+        values,
+      }
+    }
+    await nextTick()
+    renderChart()
+  } catch (e) {
+    console.error('매출 추이 조회 실패', e)
+  }
+}
+
+// 월별은 line, 연/분기는 bar
+const chartType = computed(() => (viewMode.value === 'monthly' ? 'line' : 'bar'))
+
+const renderChart = () => {
+  if (!canvas.value) return
+
+  if (chartInstance) chartInstance.destroy()
+
+  const isLine = chartType.value === 'line'
+
+  chartInstance = new Chart(canvas.value, {
+    type: chartType.value,
+    data: {
+      labels: chartData.value.labels,
+      datasets: [
+        {
+          label: '매출',
+          data: chartData.value.values,
+          backgroundColor: isLine ? 'rgba(249,115,22,0.15)' : 'rgba(249,115,22,0.7)',
+          borderColor: '#f97316',
+          borderWidth: 2,
+          fill: isLine,
+          tension: 0.3,
+          borderRadius: 4,
+          barPercentage: 0.55,
+          pointBackgroundColor: '#f97316',
+          pointRadius: 4,
+          pointHoverRadius: 6,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: '#1f2937',
+          titleColor: '#f9fafb',
+          bodyColor: '#d1d5db',
+          padding: 10,
+          cornerRadius: 10,
+          callbacks: { label: (ctx) => ` ${formatCurrency(ctx.parsed.y)}` },
+        },
+      },
+      scales: {
+        x: {
+          grid: { display: false },
+          ticks: { color: '#9ca3af', font: { size: 12 } },
+          border: { display: false },
+        },
+        y: {
+          min: 0,
+          grid: { color: '#f3f4f6' },
+          ticks: {
+            color: '#9ca3af',
+            font: { size: 11 },
+            callback: (v) => formatCurrencyShort(v),
+          },
+          border: { display: false },
+        },
+      },
+    },
+  })
+}
+
+const periodLabel = computed(() => {
+  if (viewMode.value === 'yearly') return '전체 기간'
+  return `${selectedYear.value}년`
+})
+
+const totalLabel = computed(() => {
+  const sum = chartData.value.values.reduce((a, b) => a + b, 0)
+  return formatCurrency(sum)
+})
+
+onMounted(fetchData)
+watch([viewMode, selectedYear], fetchData)
+onUnmounted(() => {
+  if (chartInstance) chartInstance.destroy()
+})
+</script>
+
+<template>
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col">
+    <div class="flex items-start justify-between mb-4 gap-4 flex-wrap">
+      <div>
+        <h2 class="font-bold text-gray-900">매출 추이</h2>
+        <p class="text-xs text-gray-400 mt-0.5">
+          {{ periodLabel }} · 합계 {{ totalLabel }}
+        </p>
+      </div>
+
+      <div class="flex gap-2 items-center">
+        <!-- 연도 selector (분기/월에만 표시) -->
+        <select v-if="viewMode !== 'yearly'" v-model.number="selectedYear"
+          class="border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300">
+          <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}년</option>
+        </select>
+
+        <!-- 토글: 연/분기/월 -->
+        <div class="inline-flex rounded-md border border-gray-200 bg-white overflow-hidden">
+          <button v-for="mode in VIEW_MODES" :key="mode.key"
+            @click="viewMode = mode.key"
+            class="px-3 py-1.5 text-sm transition-colors"
+            :class="viewMode === mode.key
+              ? 'bg-orange-500 text-white font-semibold'
+              : 'text-gray-600 hover:bg-gray-50'">
+            {{ mode.label }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="relative" style="height: 280px;">
+      <canvas ref="canvas" style="display:block; width:100%; height:100%;"></canvas>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/statistics/StoreSalesLongTermList.vue
+++ b/frontend/src/components/statistics/StoreSalesLongTermList.vue
@@ -1,35 +1,35 @@
 <script setup>
-import { ref, onMounted, onUnmounted, watch, computed } from 'vue'
+import { ref, onMounted, watch, computed } from 'vue'
 import { getStoreSalesLongTerm } from '@/api/statistics'
+import { formatCurrency } from '@/utils/formatCurrency'
 
 const currentYear = new Date().getFullYear()
 
 const selectedYear = ref(currentYear)
 const selectedMonth = ref(null)  // null = 연 전체
+const searchKeyword = ref('')
 
-const allStores = ref([])      // 백엔드에서 받아온 전체 매장 리스트
-const visibleCount = ref(15)   // 현재 화면에 보이는 개수
-const PAGE_SIZE = 15
+const allStores = ref([])
 
 const yearOptions = [2025, 2026]
 const monthOptions = Array.from({ length: 12 }, (_, i) => i + 1)
-
-const scrollContainer = ref(null)
 
 const fetchData = async () => {
   try {
     const { data } = await getStoreSalesLongTerm(selectedYear.value, selectedMonth.value)
     allStores.value = data.result.stores
-    visibleCount.value = PAGE_SIZE  // 필터 바뀌면 처음부터
   } catch (e) {
     console.error('매장별 매출 조회 실패', e)
     allStores.value = []
   }
 }
 
-// 화면에 표시할 슬라이스
-const visibleStores = computed(() => allStores.value.slice(0, visibleCount.value))
-const hasMore = computed(() => visibleCount.value < allStores.value.length)
+// 검색 필터링 (원본 순위는 유지)
+const filteredStores = computed(() => {
+  if (!searchKeyword.value.trim()) return allStores.value
+  const kw = searchKeyword.value.toLowerCase()
+  return allStores.value.filter((s) => s.storeName.toLowerCase().includes(kw))
+})
 
 const periodLabel = computed(() => {
   return selectedMonth.value
@@ -37,35 +37,25 @@ const periodLabel = computed(() => {
     : `${selectedYear.value}년 전체`
 })
 
-// 무한 스크롤 핸들러
-const handleScroll = () => {
-  const el = scrollContainer.value
-  if (!el || !hasMore.value) return
-  // 하단에 가까워지면 더 로드
-  if (el.scrollTop + el.clientHeight >= el.scrollHeight - 80) {
-    visibleCount.value = Math.min(visibleCount.value + PAGE_SIZE, allStores.value.length)
-  }
+// 검색해도 원본 전체 순위 유지
+const getOriginalRank = (store) => {
+  return allStores.value.findIndex((s) => s.storeIdx === store.storeIdx) + 1
 }
 
-onMounted(() => {
-  fetchData()
-  scrollContainer.value?.addEventListener('scroll', handleScroll)
-})
-
-onUnmounted(() => {
-  scrollContainer.value?.removeEventListener('scroll', handleScroll)
-})
-
+onMounted(fetchData)
 watch([selectedYear, selectedMonth], fetchData)
 </script>
 
 <template>
   <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col">
-    <div class="flex items-start justify-between mb-4 shrink-0">
+    <!-- 헤더 -->
+    <div class="flex items-start justify-between mb-3 shrink-0">
       <div>
         <h2 class="font-bold text-gray-900">매장 매출 순위</h2>
         <p class="text-xs text-gray-400 mt-0.5">
-          {{ periodLabel }} · {{ visibleStores.length }} / {{ allStores.length }} 매장
+          {{ periodLabel }} ·
+          <span v-if="searchKeyword">{{ filteredStores.length }} / {{ allStores.length }} 매장</span>
+          <span v-else>총 {{ allStores.length }} 매장</span>
         </p>
       </div>
       <div class="flex gap-2">
@@ -81,28 +71,27 @@ watch([selectedYear, selectedMonth], fetchData)
       </div>
     </div>
 
-    <ul ref="scrollContainer" class="space-y-2 overflow-auto pr-1" style="height: 432px;">
-      <li v-for="(item, i) in visibleStores" :key="item.storeIdx"
+    <!-- 검색 -->
+    <div class="mb-3 shrink-0">
+      <input v-model="searchKeyword" type="text" placeholder="매장명 검색..."
+        class="w-full border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300" />
+    </div>
+
+    <!-- 리스트 (스크롤) -->
+    <ul class="space-y-2 overflow-auto pr-1" style="height: 432px;">
+      <li v-for="item in filteredStores" :key="item.storeIdx"
         class="flex items-center justify-between py-1.5 px-2 rounded hover:bg-gray-50">
         <div class="flex items-center gap-3">
           <span class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold"
-            :class="i < 3 ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-500'">
-            {{ i + 1 }}
+            :class="getOriginalRank(item) <= 3 ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-500'">
+            {{ getOriginalRank(item) }}
           </span>
           <span class="text-sm font-medium text-gray-800">{{ item.storeName }}</span>
         </div>
-        <span class="text-sm font-semibold text-gray-700">
-          ₩ {{ item.total.toLocaleString('ko-KR') }}
-        </span>
+        <span class="text-sm font-semibold text-gray-700">{{ formatCurrency(item.total) }}</span>
       </li>
-      <li v-if="hasMore" class="text-xs text-gray-400 text-center py-2">
-        스크롤하면 더 보이기...
-      </li>
-      <li v-else-if="visibleStores.length > 0" class="text-xs text-gray-400 text-center py-2">
-        — 끝 —
-      </li>
-      <li v-if="visibleStores.length === 0" class="text-sm text-gray-400 text-center py-4">
-        데이터 없음
+      <li v-if="filteredStores.length === 0" class="text-sm text-gray-400 text-center py-4">
+        {{ searchKeyword ? '검색 결과 없음' : '데이터 없음' }}
       </li>
     </ul>
   </div>

--- a/frontend/src/components/statistics/YearlyTotalCard.vue
+++ b/frontend/src/components/statistics/YearlyTotalCard.vue
@@ -1,9 +1,13 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, computed, watch, onUnmounted, nextTick } from 'vue'
+import { Chart } from 'chart.js/auto'
 import { getYearlySales } from '@/api/statistics'
+import { formatCurrency, calculateChange } from '@/utils/formatCurrency'
 
 const allYears = ref([])      // [{year, total}, ...]
 const selectedYear = ref(null)
+const sparklineCanvas = ref(null)
+let chartInstance = null
 
 const fetchData = async () => {
   try {
@@ -13,32 +17,87 @@ const fetchData = async () => {
     if (allYears.value.length > 0 && selectedYear.value == null) {
       selectedYear.value = allYears.value[allYears.value.length - 1].year
     }
+    await nextTick()
+    renderSparkline()
   } catch (e) {
     console.error('연도별 매출 조회 실패', e)
   }
 }
+
+const sortedYears = computed(() =>
+  [...allYears.value].sort((a, b) => a.year - b.year),
+)
 
 const selectedTotal = computed(() => {
   const found = allYears.value.find((d) => d.year === selectedYear.value)
   return found ? found.total : 0
 })
 
-const formattedTotal = computed(() => {
-  return `₩ ${selectedTotal.value.toLocaleString('ko-KR')}`
+// YoY (전년 대비)
+const yoy = computed(() => {
+  const sorted = sortedYears.value
+  const idx = sorted.findIndex((d) => d.year === selectedYear.value)
+  if (idx <= 0) return null
+  return calculateChange(sorted[idx].total, sorted[idx - 1].total)
 })
 
-const yearOptions = computed(() => allYears.value.map((d) => d.year))
+const formattedTotal = computed(() => formatCurrency(selectedTotal.value))
+const yearOptions = computed(() => sortedYears.value.map((d) => d.year))
+
+const renderSparkline = () => {
+  if (!sparklineCanvas.value || sortedYears.value.length === 0) return
+
+  const labels = sortedYears.value.map((d) => `${d.year}`)
+  const totals = sortedYears.value.map((d) => d.total)
+
+  // 선택된 연도만 진하게, 나머지는 연하게
+  const backgroundColors = sortedYears.value.map((d) =>
+    d.year === selectedYear.value ? 'rgba(249,115,22,0.9)' : 'rgba(249,115,22,0.3)',
+  )
+
+  if (chartInstance) chartInstance.destroy()
+
+  chartInstance = new Chart(sparklineCanvas.value, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [{ data: totals, backgroundColor: backgroundColors, borderRadius: 3, barPercentage: 0.6 }],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: '#1f2937',
+          titleColor: '#f9fafb',
+          bodyColor: '#d1d5db',
+          padding: 8,
+          cornerRadius: 8,
+          callbacks: { label: (ctx) => ` ${formatCurrency(ctx.parsed.y)}` },
+        },
+      },
+      scales: {
+        x: { display: false },
+        y: { display: false, beginAtZero: true },
+      },
+    },
+  })
+}
 
 onMounted(fetchData)
+watch(selectedYear, () => renderSparkline())
+onUnmounted(() => {
+  if (chartInstance) chartInstance.destroy()
+})
 </script>
 
 <template>
-  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col"
-    style="min-height:200px">
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col" style="min-height:200px">
     <div class="flex items-start justify-between mb-4">
       <div>
         <h2 class="font-bold text-gray-900">연도별 매출</h2>
-        <p class="text-xs text-gray-400 mt-0.5">선택한 연도의 총 매출</p>
+        <p class="text-xs text-gray-400 mt-0.5">선택 연도의 총 매출</p>
       </div>
       <select v-model.number="selectedYear"
         class="border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300">
@@ -46,12 +105,23 @@ onMounted(fetchData)
       </select>
     </div>
 
-    <div class="flex-1 flex items-center justify-center">
-      <div class="text-center">
-        <p class="text-xs text-gray-400 mb-2">{{ selectedYear }}년 총 매출</p>
-        <p class="text-4xl font-extrabold text-orange-600 tracking-tight">
+    <div class="flex-1 flex items-center gap-6">
+      <!-- 큰 숫자 + YoY -->
+      <div class="flex-shrink-0 min-w-[140px]">
+        <p class="text-3xl font-extrabold text-orange-600 tracking-tight">
           {{ formattedTotal }}
         </p>
+        <p v-if="yoy" class="text-xs mt-1.5 font-semibold"
+          :class="yoy.isPositive ? 'text-emerald-600' : 'text-red-500'">
+          {{ yoy.text }}
+          <span class="text-gray-400 font-normal">vs 전년</span>
+        </p>
+        <p v-else class="text-xs mt-1.5 text-gray-400">전년 데이터 없음</p>
+      </div>
+
+      <!-- Sparkline (선택 연도 강조) -->
+      <div class="flex-1 relative" style="height: 70px; min-width: 100px;">
+        <canvas ref="sparklineCanvas" style="display:block; width:100%; height:100%;"></canvas>
       </div>
     </div>
   </div>

--- a/frontend/src/components/statistics/YearlyTotalCard.vue
+++ b/frontend/src/components/statistics/YearlyTotalCard.vue
@@ -1,24 +1,20 @@
 <script setup>
-import { ref, onMounted, computed, watch, onUnmounted, nextTick } from 'vue'
-import { Chart } from 'chart.js/auto'
+import { ref, onMounted, computed } from 'vue'
 import { getYearlySales } from '@/api/statistics'
 import { formatCurrency, calculateChange } from '@/utils/formatCurrency'
+import { useAnimatedNumber } from '@/composables/useAnimatedNumber'
 
-const allYears = ref([])      // [{year, total}, ...]
+const allYears = ref([])
 const selectedYear = ref(null)
-const sparklineCanvas = ref(null)
-let chartInstance = null
+const isMounted = ref(false)
 
 const fetchData = async () => {
   try {
     const { data } = await getYearlySales()
     allYears.value = data.result.yearlyData
-    // 기본값: 가장 최신 연도
     if (allYears.value.length > 0 && selectedYear.value == null) {
       selectedYear.value = allYears.value[allYears.value.length - 1].year
     }
-    await nextTick()
-    renderSparkline()
   } catch (e) {
     console.error('연도별 매출 조회 실패', e)
   }
@@ -29,75 +25,53 @@ const sortedYears = computed(() =>
 )
 
 const selectedTotal = computed(() => {
-  const found = allYears.value.find((d) => d.year === selectedYear.value)
-  return found ? found.total : 0
+  const f = allYears.value.find((d) => d.year === selectedYear.value)
+  return f ? f.total : 0
 })
 
-// YoY (전년 대비)
-const yoy = computed(() => {
+const previousTotal = computed(() => {
   const sorted = sortedYears.value
   const idx = sorted.findIndex((d) => d.year === selectedYear.value)
   if (idx <= 0) return null
-  return calculateChange(sorted[idx].total, sorted[idx - 1].total)
+  return sorted[idx - 1].total
 })
 
-const formattedTotal = computed(() => formatCurrency(selectedTotal.value))
+const yoy = computed(() => {
+  if (previousTotal.value == null) return null
+  return calculateChange(selectedTotal.value, previousTotal.value)
+})
+
 const yearOptions = computed(() => sortedYears.value.map((d) => d.year))
 
-const renderSparkline = () => {
-  if (!sparklineCanvas.value || sortedYears.value.length === 0) return
+// 카운트업 애니메이션
+const animatedTotal = useAnimatedNumber(selectedTotal)
+const formattedTotal = computed(() => formatCurrency(animatedTotal.value))
 
-  const labels = sortedYears.value.map((d) => `${d.year}`)
-  const totals = sortedYears.value.map((d) => d.total)
+// 프로그레스 바 (페이지 진입 시 0% → final 애니메이션 위해 isMounted 가드)
+const maxValue = computed(() => Math.max(selectedTotal.value, previousTotal.value || 0))
+const currentBarWidth = computed(() => {
+  if (!isMounted.value || maxValue.value === 0) return '0%'
+  return (selectedTotal.value / maxValue.value) * 100 + '%'
+})
+const previousBarWidth = computed(() => {
+  if (!isMounted.value || maxValue.value === 0 || previousTotal.value == null) return '0%'
+  return (previousTotal.value / maxValue.value) * 100 + '%'
+})
 
-  // 선택된 연도만 진하게, 나머지는 연하게
-  const backgroundColors = sortedYears.value.map((d) =>
-    d.year === selectedYear.value ? 'rgba(249,115,22,0.9)' : 'rgba(249,115,22,0.3)',
-  )
-
-  if (chartInstance) chartInstance.destroy()
-
-  chartInstance = new Chart(sparklineCanvas.value, {
-    type: 'bar',
-    data: {
-      labels,
-      datasets: [{ data: totals, backgroundColor: backgroundColors, borderRadius: 3, barPercentage: 0.6 }],
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      plugins: {
-        legend: { display: false },
-        tooltip: {
-          backgroundColor: '#1f2937',
-          titleColor: '#f9fafb',
-          bodyColor: '#d1d5db',
-          padding: 8,
-          cornerRadius: 8,
-          callbacks: { label: (ctx) => ` ${formatCurrency(ctx.parsed.y)}` },
-        },
-      },
-      scales: {
-        x: { display: false },
-        y: { display: false, beginAtZero: true },
-      },
-    },
-  })
-}
-
-onMounted(fetchData)
-watch(selectedYear, () => renderSparkline())
-onUnmounted(() => {
-  if (chartInstance) chartInstance.destroy()
+onMounted(async () => {
+  await fetchData()
+  // 다음 frame 후 mount flag → 0% → final 트랜지션 트리거
+  setTimeout(() => { isMounted.value = true }, 100)
 })
 </script>
 
 <template>
-  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col" style="min-height:200px">
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col">
+    <!-- 헤더 -->
     <div class="flex items-start justify-between mb-4">
       <div>
         <h2 class="font-bold text-gray-900">연도별 매출</h2>
-        <p class="text-xs text-gray-400 mt-0.5">선택 연도의 총 매출</p>
+        <p class="text-xs text-gray-400 mt-0.5">{{ selectedYear }}년 총 매출</p>
       </div>
       <select v-model.number="selectedYear"
         class="border border-gray-200 rounded-md px-3 py-1.5 text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-300">
@@ -105,23 +79,40 @@ onUnmounted(() => {
       </select>
     </div>
 
-    <div class="flex-1 flex items-center gap-6">
-      <!-- 큰 숫자 + YoY -->
-      <div class="flex-shrink-0 min-w-[140px]">
-        <p class="text-3xl font-extrabold text-orange-600 tracking-tight">
-          {{ formattedTotal }}
-        </p>
-        <p v-if="yoy" class="text-xs mt-1.5 font-semibold"
-          :class="yoy.isPositive ? 'text-emerald-600' : 'text-red-500'">
-          {{ yoy.text }}
-          <span class="text-gray-400 font-normal">vs 전년</span>
-        </p>
-        <p v-else class="text-xs mt-1.5 text-gray-400">전년 데이터 없음</p>
-      </div>
+    <!-- 큰 숫자 (카운트업) -->
+    <p class="text-4xl font-extrabold text-orange-600 tracking-tight">
+      {{ formattedTotal }}
+    </p>
 
-      <!-- Sparkline (선택 연도 강조) -->
-      <div class="flex-1 relative" style="height: 70px; min-width: 100px;">
-        <canvas ref="sparklineCanvas" style="display:block; width:100%; height:100%;"></canvas>
+    <!-- YoY 배지 -->
+    <p v-if="yoy" class="text-sm mt-2 font-semibold"
+      :class="yoy.isPositive ? 'text-emerald-600' : 'text-red-500'">
+      {{ yoy.isPositive ? '▲' : '▼' }} {{ yoy.text }}
+      <span class="text-gray-400 font-normal ml-1">vs 전년</span>
+    </p>
+    <p v-else class="text-sm mt-2 text-gray-400">전년 데이터 없음</p>
+
+    <!-- 프로그레스 바 (0% → final 애니메이션) -->
+    <div class="mt-5 space-y-2.5">
+      <div>
+        <div class="flex justify-between text-xs text-gray-500 mb-1">
+          <span>작년</span>
+          <span>{{ previousTotal != null ? formatCurrency(previousTotal) : '-' }}</span>
+        </div>
+        <div class="bg-gray-100 rounded-full h-2 overflow-hidden">
+          <div class="h-full bg-gray-300 rounded-full transition-all duration-1000 ease-out"
+            :style="{ width: previousBarWidth }"></div>
+        </div>
+      </div>
+      <div>
+        <div class="flex justify-between text-xs mb-1">
+          <span class="text-gray-700 font-semibold">올해</span>
+          <span class="text-gray-700 font-semibold">{{ formatCurrency(selectedTotal) }}</span>
+        </div>
+        <div class="bg-gray-100 rounded-full h-2 overflow-hidden">
+          <div class="h-full bg-orange-500 rounded-full transition-all duration-1000 ease-out"
+            :style="{ width: currentBarWidth }"></div>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/utils/formatCurrency.js
+++ b/frontend/src/utils/formatCurrency.js
@@ -1,0 +1,90 @@
+/**
+ * 금액을 한국식 단위(만/억/조)로 자동 변환.
+ * 금액이 클수록 큰 단위로, 작으면 그대로 표시.
+ *
+ * 예시:
+ *   5,000              → "₩ 5,000"
+ *   1,234,500          → "₩ 123.5만"
+ *   211,300,000        → "₩ 2.1억"
+ *   21,127,807,506     → "₩ 211.3억"
+ *   1,234,500,000,000  → "₩ 1.23조"
+ *
+ * @param {number} amount - 금액
+ * @param {object} opts
+ *   - withSymbol: ₩ 기호 표시 여부 (기본 true)
+ *   - decimals: 만/억 단위 소수점 자릿수 (기본 1)
+ * @returns {string} 포맷된 문자열
+ */
+export function formatCurrency(amount, opts = {}) {
+  const { withSymbol = true, decimals = 1 } = opts
+  const symbol = withSymbol ? '₩ ' : ''
+
+  if (amount == null) return `${symbol}0`
+
+  const num = Number(amount)
+  if (Number.isNaN(num)) return `${symbol}0`
+
+  const absAmount = Math.abs(num)
+  const sign = num < 0 ? '-' : ''
+
+  // 1조 이상
+  if (absAmount >= 1_000_000_000_000) {
+    return `${sign}${symbol}${(absAmount / 1_000_000_000_000).toFixed(2)}조`
+  }
+  // 1억 이상
+  if (absAmount >= 100_000_000) {
+    return `${sign}${symbol}${(absAmount / 100_000_000).toFixed(decimals)}억`
+  }
+  // 1만 이상
+  if (absAmount >= 10_000) {
+    return `${sign}${symbol}${(absAmount / 10_000).toFixed(decimals)}만`
+  }
+  // 1만 미만 — 그대로
+  return `${sign}${symbol}${absAmount.toLocaleString('ko-KR')}`
+}
+
+/**
+ * 차트 축/툴팁용 짧은 포맷 (₩ 기호 없음).
+ *
+ * @param {number} amount
+ * @returns {string}
+ */
+export function formatCurrencyShort(amount) {
+  return formatCurrency(amount, { withSymbol: false, decimals: 1 })
+}
+
+/**
+ * 툴팁용 (₩ 기호 + 단위 변환).
+ * 차트 tooltip 콜백에서 사용.
+ *
+ * @param {number} amount
+ * @returns {string}
+ */
+export function formatCurrencyTooltip(amount) {
+  return formatCurrency(amount, { withSymbol: true, decimals: 1 })
+}
+
+/**
+ * 전년/전월 대비 변동률 계산 (YoY / MoM).
+ * 양수면 증가, 음수면 감소.
+ *
+ * @param {number} current - 현재 값
+ * @param {number} previous - 비교 대상 값
+ * @returns {object|null}
+ *   - percent: 변동률 (소수점 1자리)
+ *   - isPositive: 증가 여부
+ *   - text: "+18.2%" 또는 "-5.4%"
+ *   - 데이터 부족 시 null
+ */
+export function calculateChange(current, previous) {
+  if (current == null || previous == null || previous === 0) return null
+
+  const percent = ((current - previous) / previous) * 100
+  const isPositive = percent >= 0
+  const sign = isPositive ? '+' : ''
+  return {
+    percent: Math.round(percent * 10) / 10,
+    isPositive,
+    text: `${sign}${percent.toFixed(1)}%`,
+  }
+}

--- a/frontend/src/views/hq/LongTermStatisticsView.vue
+++ b/frontend/src/views/hq/LongTermStatisticsView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import YearlyTotalCard from '@/components/statistics/YearlyTotalCard.vue'
 import MonthlyTotalCard from '@/components/statistics/MonthlyTotalCard.vue'
+import SalesTrendChart from '@/components/statistics/SalesTrendChart.vue'
 import StoreSalesLongTermList from '@/components/statistics/StoreSalesLongTermList.vue'
 import MenuSalesLongTermList from '@/components/statistics/MenuSalesLongTermList.vue'
 </script>
@@ -11,17 +12,22 @@ import MenuSalesLongTermList from '@/components/statistics/MenuSalesLongTermList
     <div class="flex items-start justify-between gap-4">
       <div>
         <h1 class="text-[22px] font-bold text-gray-900 tracking-tight">장기 통계</h1>
-        <p class="text-xs text-gray-400 mt-1">연도/월/매장/메뉴별 매출 분석</p>
+        <p class="text-xs text-gray-400 mt-1">연도/월/분기/매장/메뉴별 매출 분석</p>
       </div>
     </div>
 
-    <!-- 연도/월별 금액 카드 -->
+    <!-- KPI 카드 (연도/월 — 큰 숫자 + sparkline + YoY) -->
     <div class="grid grid-cols-2 gap-4">
       <YearlyTotalCard />
       <MonthlyTotalCard />
     </div>
 
-    <!-- 매장/메뉴 리스트 (무한 스크롤) -->
+    <!-- 매출 추이 (연/분기/월 토글, full width) -->
+    <div class="grid grid-cols-1">
+      <SalesTrendChart />
+    </div>
+
+    <!-- 매장/메뉴 순위 (스크롤 + 검색) -->
     <div class="grid grid-cols-2 gap-4">
       <StoreSalesLongTermList />
       <MenuSalesLongTermList />

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -17,12 +17,11 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },
-      // '/api/statistics': {
-      //   target: 'http://localhost:8081', // 통계 MSA 직접 (Gateway 안 띄울 때)
-      //   changeOrigin: true,
-      //   rewrite: (path) => path.replace(/^\/api/, ''),
-      // },
-
+      '/api/statistics': {
+        target: 'http://localhost:8081', // 통계 MSA 직접 (Gateway 안 띄울 때)
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
       '/api': {
         target: 'http://localhost:8080',
         changeOrigin: true,


### PR DESCRIPTION
## Summary
- 멘토 피드백 + 자체 검토를 바탕으로 장기 통계 페이지(#881) UX 전면 개선
- **단위 자동 변환** (만/억/조), **KPI 카드 + 프로그레스 비교**, **통합 차트 토글** (연/분기/월), **매장/메뉴 검색**, **카운트업 애니메이션**
- 분기 API 신규 추가 (백엔드)
- 못생긴 sparkline 제거 → 프로그레스 바로 작년 직접 비교

## 변경 파일

### 백엔드
- `domain/daily/DailyTotalSalesRepository.java` — `findQuarterlySalesGroup` 추가
- `LongTermStatisticsDto.java` — `QuarterlySalesItem` + `QuarterlySalesRes`
- `LongTermStatisticsService.java` — `getQuarterlySales(year)`
- `LongTermStatisticsController.java` — `GET /quarterly?year`

### 프론트엔드
- `utils/formatCurrency.js` (신규) — 만/억/조 자동 변환 + YoY 계산
- `components/statistics/YearlyTotalCard.vue` — 큰 숫자 카운트업 + 프로그레스 + YoY
- `components/statistics/MonthlyTotalCard.vue` — 동일 + 작년 동월 비교
- `components/statistics/SalesTrendChart.vue` (신규) — 연/분기/월 토글 차트
- `components/statistics/StoreSalesLongTermList.vue` — 검색 + 단순 스크롤
- `components/statistics/MenuSalesLongTermList.vue` — 검색 + 단순 스크롤
- `views/hq/LongTermStatisticsView.vue` — 3행 레이아웃
- `api/statistics/index.js` — `getQuarterlySales(year)` 추가

## 주요 변경 사항

### 백엔드 — 분기 API
- `QUARTER()` Native Query 로 1~4분기 GROUP BY
- 새 DTO + Service + Controller 1세트
- 테이블 변경 없음, 기존 `daily_total_sales` 재활용

### 프론트엔드 — 단위 자동 변환
- `formatCurrency` 함수: 1만 미만 그대로, 1만~ 만원, 1억~ 억원, 1조~ 조원 자동 전환
- `formatCurrencyShort`: 차트 Y축용 (₩ 없이)
- `calculateChange`: 전년/전월 변동률 계산 (양수/음수, % text 반환)
- 모든 카드/차트 Y축/툴팁에 일관 적용
  - 예: `21,127,807,506` → **`₩ 211.3억`**

### 프론트엔드 — KPI 카드 재구성
- sparkline 제거 → 못생긴 그래프 사라짐 (통합 차트와 역할 중복 제거)
- **큰 숫자**: `text-4xl` + 카운트업 애니메이션 (`useAnimatedNumber`, 600ms cubic)
- **YoY 배지**: `▲ +18.2%` (초록) / `▼ -5.4%` (빨강)
- **프로그레스 바 2개**: 작년(회색) vs 올해(오렌지), 큰 값 기준 100%, 1초 ease-out 트랜지션
- 페이지 진입 시 0% → final width 부드럽게 채워짐 (`isMounted` 가드)

### 프론트엔드 — 통합 트렌드 차트
- `SalesTrendChart.vue` 신규: 연/분기/월 토글 (`[연도] [분기] [월]` 버튼 그룹)
- 모드별 자동 차트 타입: 월별 → line, 연/분기 → bar
- 분기 모드: 1~4분기 막대 (없는 분기는 0 표시)
- 헤더에 선택 기간 합계 표시 (`2026년 · 합계 ₩ 211.3억`)
- 연도 selector 는 분기/월 모드에서만 노출 (연도 모드는 전체 기간)
- ⚠ 토글 시 차트 세로 길이 무한 늘어나던 버그 수정 (`flex-1` 제거 + height 고정)

### 프론트엔드 — 매장/메뉴 검색
- 무한 스크롤 → 단순 스크롤 + 검색 input (UX 단순화)
- 검색 시 결과 카운트 표시 (`23 / 100 매장`)
- 검색 결과에서도 **원본 전체 순위 유지** (강남점 검색해도 1위 표시)
- 매장: `formatCurrency` 적용, 메뉴: 수량 (개)

### 프론트엔드 — 애니메이션
- 카드 큰 숫자: `useAnimatedNumber` (600ms cubic easing)
- 프로그레스 바: CSS transition (1초 ease-out)
- 통합 차트: Chart.js 기본 애니메이션 (1초)
- 페이지 진입 시 + 드롭다운 변경 시 자연스러운 전환

## Test Plan
- [x] 백엔드 빌드 통과 + `/statistics/long-term/quarterly?year=2026` 응답 확인
- [x] 프론트엔드 dev 서버 hot reload 정상
- [x] 단위 자동 변환 (₩ 211.3억 등) 모든 카드/차트 확인
- [x] 카운트업 애니메이션 (페이지 진입 + 드롭다운 변경 시)
- [x] 프로그레스 바 0% → final 채워짐
- [x] SalesTrendChart 연/분기/월 토글 동작 + 높이 고정
- [x] 매장/메뉴 검색 즉시 동작, 검색 시에도 원본 순위 유지
- [x] 사이드바 → 통계 → 장기 통계 진입 정상

## Issue
- Closes #885