### PR TITLE
[Feat] #889 - 일별 dump 자동 스케줄러 (@Scheduled + ShedLock + catch-up)

### DIFF
--- a/backend/statistics/build.gradle
+++ b/backend/statistics/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     // --- Redis ---
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // --- ShedLock (Multi-replica 환경에서 @Scheduled 분산 락) ---
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.13.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.13.0'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/backend/statistics/src/main/java/com/example/statistics/config/SchedulerConfig.java
+++ b/backend/statistics/src/main/java/com/example/statistics/config/SchedulerConfig.java
@@ -1,0 +1,42 @@
+package com.example.statistics.config;
+
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import net.javacrumbs.shedlock.support.LockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import javax.sql.DataSource;
+
+/**
+ * 스케줄러 + ShedLock 설정.
+ *
+ * <ul>
+ *   <li>{@link EnableScheduling} — Spring 의 {@code @Scheduled} 활성화</li>
+ *   <li>{@link EnableSchedulerLock} — ShedLock 활성화 (분산 락)</li>
+ *   <li>{@link LockProvider} — 락 저장소 = JDBC (DB 의 shedlock 테이블 사용)</li>
+ * </ul>
+ *
+ * <p>shedlock 테이블은 {@code resources/schema.sql} 에서 IF NOT EXISTS 로 생성.
+ * (ShedLock 라이브러리가 자동 마이그레이션을 제공하지 않으므로 수동 DDL 필요)
+ *
+ * <p>{@code usingDbTime()} — 각 pod 의 OS 시각 차이(clock skew) 무관하게
+ * DB 서버 시각을 기준으로 락 유효 시간 계산.
+ */
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+public class SchedulerConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build()
+        );
+    }
+}

--- a/backend/statistics/src/main/java/com/example/statistics/config/SchedulerConfig.java
+++ b/backend/statistics/src/main/java/com/example/statistics/config/SchedulerConfig.java
@@ -2,7 +2,7 @@ package com.example.statistics.config;
 
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
-import net.javacrumbs.shedlock.support.LockProvider;
+import net.javacrumbs.shedlock.core.LockProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;

--- a/backend/statistics/src/main/java/com/example/statistics/scheduler/DailyDumpScheduler.java
+++ b/backend/statistics/src/main/java/com/example/statistics/scheduler/DailyDumpScheduler.java
@@ -1,0 +1,106 @@
+package com.example.statistics.scheduler;
+
+import com.example.statistics.domain.daily.DailyDumpLogRepository;
+import com.example.statistics.domain.daily.DailyDumpService;
+import com.example.statistics.domain.daily.dto.DumpResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+/**
+ * 일별 dump 자동 스케줄러.
+ * 매일 새벽 5시 (KST) 어제 데이터를 dump.
+ * Multi-replica 환경에서 ShedLock 으로 한 인스턴스만 실행.
+ *
+ * <p>누락 복구 (catch-up) 로직:
+ * <ul>
+ *   <li>마지막 SUCCESS dump 날짜 조회</li>
+ *   <li>(마지막 SUCCESS + 1) ~ 어제 까지 순차적으로 dump 호출</li>
+ *   <li>실패한 날짜는 다음 cron 에서 재시도 (Redis TTL 7일 안이면 복구 가능)</li>
+ *   <li>처음 한 번도 SUCCESS 없으면 어제만 dump</li>
+ * </ul>
+ *
+ * <p>각 호출은 {@link DailyDumpService#dump(LocalDate)} 가 자체 멱등성 가드를 가지므로
+ * 같은 날짜에 두 번 호출돼도 두 번째는 SKIPPED 반환.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyDumpScheduler {
+
+    private final DailyDumpService dailyDumpService;
+    private final DailyDumpLogRepository dumpLogRepository;
+
+    /**
+     * 매일 새벽 5시 (KST) 자동 트리거.
+     * cron 형식: "초 분 시 일 월 요일" (Spring 6자리)
+     *
+     * <p>ShedLock 으로 multi-replica 환경에서 한 pod 만 실행.
+     * - lockAtMostFor = 10m : 락 자동 해제 (deadlock 방지)
+     * - lockAtLeastFor = 5m : 너무 빨리 끝나도 5분간 락 유지 (중복 실행 방지)
+     */
+    @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
+    @SchedulerLock(
+            name = "dailyAggregateDump",
+            lockAtMostFor = "10m",
+            lockAtLeastFor = "5m"
+    )
+    public void runDailyDump() {
+        log.info("[DailyDumpScheduler] start");
+
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+
+        // 1) catch-up 시작점: 마지막 SUCCESS + 1, 없으면 어제부터
+        LocalDate startDate = dumpLogRepository.findLastSuccessfulDumpDate()
+                .map(last -> last.plusDays(1))
+                .orElse(yesterday);
+
+        // 2) 이미 어제까지 처리됐으면 skip
+        if (startDate.isAfter(yesterday)) {
+            log.info("[DailyDumpScheduler] 이미 어제까지 dump 완료, skip (startDate={})", startDate);
+            return;
+        }
+
+        int totalDays = (int) (yesterday.toEpochDay() - startDate.toEpochDay()) + 1;
+        log.info("[DailyDumpScheduler] catch-up 범위: {} ~ {} ({}일)",
+                startDate, yesterday, totalDays);
+
+        // 3) 누락분 catch-up
+        int successCount = 0;
+        int failedCount = 0;
+        int skippedCount = 0;
+
+        for (LocalDate date = startDate; !date.isAfter(yesterday); date = date.plusDays(1)) {
+            try {
+                DumpResult result = dailyDumpService.dump(date);
+                int recordCount = result.getTotalSalesCount()
+                        + result.getStoreSalesCount()
+                        + result.getMenuSalesCount()
+                        + result.getHourlySalesCount()
+                        + result.getCategorySalesCount()
+                        + result.getPaymentSalesCount();
+
+                log.info("[DailyDumpScheduler] {} → {} (records={}, elapsed={}ms)",
+                        date, result.getStatus(), recordCount, result.getSpendTime());
+
+                switch (result.getStatus()) {
+                    case SUCCESS -> successCount++;
+                    case SKIPPED -> skippedCount++;
+                    case FAILED -> failedCount++;
+                }
+            } catch (Exception e) {
+                // dailyDumpService 가 자체 예외 처리 (recordFailure REQUIRES_NEW) 하지만,
+                // 혹시 그 외 예외 발생 시에도 다른 날짜 처리 계속 진행하도록 안전망.
+                failedCount++;
+                log.error("[DailyDumpScheduler] {} 처리 중 예외 - 다음 날짜 계속 진행", date, e);
+            }
+        }
+
+        log.info("[DailyDumpScheduler] complete (success={}, skipped={}, failed={})",
+                successCount, skippedCount, failedCount);
+    }
+}

--- a/backend/statistics/src/main/resources/schema.sql
+++ b/backend/statistics/src/main/resources/schema.sql
@@ -1,0 +1,14 @@
+-- ============================================================
+-- ShedLock 분산 락 테이블
+-- ShedLock 라이브러리가 자동 마이그레이션 제공하지 않으므로 수동 DDL.
+-- application 시작 시 spring.sql.init.mode=always 로 항상 실행됨.
+-- IF NOT EXISTS 라 중복 실행해도 안전.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS shedlock (
+    name VARCHAR(64) NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL,
+    locked_by VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);


### PR DESCRIPTION
## Summary
- `@Scheduled` + ShedLock 으로 **multi-replica 환경 분산 락**
- **누락 복구 (catch-up)** 로직 포함 — N일 누락돼도 자동 복구
- 수동 트리거 API 와 같은 `DailyDumpService.dump()` 재사용 → 코드 중복 없음

## 변경 파일
- `build.gradle` — ShedLock 의존성 (shedlock-spring + shedlock-provider-jdbc-template 5.13.0)
- `config/SchedulerConfig.java` (신규) — `@EnableScheduling` + `@EnableSchedulerLock` + `JdbcTemplateLockProvider`
- `resources/schema.sql` (신규) — `shedlock` 테이블 DDL (IF NOT EXISTS)
- `scheduler/DailyDumpScheduler.java` (신규) — `@Scheduled` + `@SchedulerLock` + catch-up 로직

## 주요 변경 사항

### ShedLock 설정 (SchedulerConfig)
- `@EnableSchedulerLock(defaultLockAtMostFor = "10m")` — deadlock 방지
- `JdbcTemplateLockProvider` — DB 의 `shedlock` 테이블 사용
- `.usingDbTime()` — 각 pod 의 clock skew 무관, DB 서버 시각 기준 락 유효성 계산

### `shedlock` 테이블
- `name` VARCHAR(64) PK + `lock_until`/`locked_at`/`locked_by` TIMESTAMP/VARCHAR
- ShedLock 라이브러리가 자동 마이그레이션 제공 안 함 → schema.sql 수동 DDL
- `spring.sql.init.mode=always` 로 시작 시 자동 실행, `IF NOT EXISTS` 안전 처리

### DailyDumpScheduler
- `@Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")` — Spring 6자리 cron + 한국 시각
- `@SchedulerLock(lockAtMostFor="10m", lockAtLeastFor="5m")` — 적절한 락 범위
- **catch-up 로직**:
  - `findLastSuccessfulDumpDate()` 로 마지막 SUCCESS 조회
  - (마지막 SUCCESS + 1) ~ 어제 까지 루프
  - 첫 실행 시 어제만 dump
  - 한 날짜 예외 발생해도 다음 날짜 진행
- 결과 통계 로깅 (success/skipped/failed count)

## Test Plan
- [x] gradle 빌드 통과
- [x] 코드 리뷰 가능 (의사결정 + 한 줄 한 줄 설명 문서 첨부)
