### PR TITLE
[Fix] #894 - 본사, 가맹점 배송 관리 페이지 하단 페이징 버튼 수정, 가시성 고도화

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java
@@ -37,8 +37,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
     // 본사 배송 관리 - 필터 조회
     @Query("SELECT d FROM Delivery d " +
-            "JOIN FETCH d.orders o " +
-            "JOIN FETCH o.store s " +
+            "JOIN d.orders o " +
+            "JOIN o.store s " +
             "WHERE (:storeName IS NULL OR s.storeName LIKE %:storeName%) " +
             "AND (:status IS NULL OR d.deliveryStatus = :status) " +
             "AND (:year IS NULL OR FUNCTION('YEAR', d.departureDate) = :year) " +
@@ -55,8 +55,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
     // 가맹점 배송 현황 - 전체 조회
     @Query("SELECT d FROM Delivery d " +
-            "JOIN FETCH d.orders o " +
-            "JOIN FETCH o.store s " +
+            "JOIN d.orders o " +
+            "JOIN o.store s " +
             "WHERE s.idx = :storeIdx")
     List<Delivery> findAllByOrdersStoreIdx(
             @Param("storeIdx") Long storeIdx
@@ -64,8 +64,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
     // 가맹점 배송 현황 - 필터 및 발주번호 검색 조회
     @Query("SELECT d FROM Delivery d " +
-            "JOIN FETCH d.orders o " +
-            "JOIN FETCH o.store s " +
+            "JOIN d.orders o " +
+            "JOIN o.store s " +
             "WHERE s.idx = :storeIdx " +
             "AND (:orderIdx IS NULL OR o.idx = :orderIdx) " +
             "AND (:status IS NULL OR d.deliveryStatus = :status) " +
@@ -95,7 +95,7 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     );
 
     // 본사 대시보드 - 지연 배송 목록 무한스크롤 페이징
-    @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o JOIN FETCH o.store s " +
+    @Query("SELECT d FROM Delivery d JOIN d.orders o JOIN o.store s " +
             "WHERE d.deliveryStatus = :status")
     Slice<Delivery> findByDeliveryStatus(
             @Param("status") DeliveryStatus status,
@@ -103,7 +103,7 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     );
 
     // 점주 대시보드 - 배송완료 제외 최신순
-    @Query("SELECT d FROM Delivery d JOIN FETCH d.orders o " +
+    @Query("SELECT d FROM Delivery d JOIN d.orders o " +
             "WHERE o.store.idx = :storeIdx AND d.deliveryStatus <> :excludeStatus " +
             "ORDER BY d.departureDate DESC")
     List<Delivery> findByOrders_Store_IdxAndDeliveryStatusNotOrderByDepartureDateDesc(

--- a/backend/monolith/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java
@@ -1,5 +1,6 @@
 package com.example.nexus.domain.delivery.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import org.springframework.data.domain.Page;
 
@@ -12,14 +13,35 @@ import java.util.List;
 @AllArgsConstructor
 public class DeliveryDto {
 
+    @JsonProperty("deliveryIdx")
     private Long deliveryIdx;
+
+    @JsonProperty("orderIdx")
     private Long orderIdx;
+
+    @JsonProperty("storeName")
     private String storeName;
+
+    @JsonProperty("deliveryStatus")
     private String deliveryStatus;
+
+    @JsonProperty("delayReason")
     private String delayReason;
+
+    @JsonProperty("departureDate")
     private LocalDateTime departureDate;
+
+    @JsonProperty("estimatedArrivalAt")
     private LocalDateTime estimatedArrivalAt;
+
+    @JsonProperty("deliveredDate")
     private LocalDateTime deliveredDate;
+
+    @JsonProperty("orderPrice")
+    private Long orderPrice;
+
+    @JsonProperty("itemCount")
+    private Integer itemCount;
 
     public static DeliveryDto from(Delivery delivery) {
 
@@ -32,6 +54,8 @@ public class DeliveryDto {
                 .departureDate(delivery.getDepartureDate())
                 .estimatedArrivalAt(delivery.getEstimatedArrivalAt())
                 .deliveredDate(delivery.getDeliveredDate())
+                .orderPrice(delivery.getOrders().getPrice())
+                .itemCount(delivery.getOrders().getOrdersItemList() != null ? delivery.getOrders().getOrdersItemList().size() : 0)
                 .build();
     }
 

--- a/backend/monolith/src/main/resources/application-dev.yaml
+++ b/backend/monolith/src/main/resources/application-dev.yaml
@@ -11,6 +11,9 @@ spring:
       ddl-auto: update
     show-sql: false
     defer-datasource-initialization: true
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
     producer:

--- a/frontend/src/views/hq/DeliveryView.vue
+++ b/frontend/src/views/hq/DeliveryView.vue
@@ -102,11 +102,19 @@
             <span class="text-xs font-mono text-gray-400"># {{ d.orderIdx }}</span>
             <span class="font-bold text-gray-900 text-sm">{{ d.storeName }}</span>
           </div>
-          <span
-            class="text-xs font-bold px-2 py-0.5 rounded whitespace-nowrap"
-            :class="statusClass(d.statusEnum)">
-            {{ d.statusLabel }}
-          </span>
+          <div class="flex items-center gap-3">
+            <span v-if="d.orderPrice != null" class="text-[11px] font-medium text-gray-500 bg-white/80 px-2 py-0.5 rounded-full border border-gray-100 shadow-sm">
+              {{ formatPrice(d.orderPrice) }} ({{ d.itemCount }}건)
+            </span>
+            <span
+              class="text-xs font-bold px-2 py-0.5 rounded whitespace-nowrap"
+              :class="statusClass(d.statusEnum)">
+              {{ d.statusLabel }}
+              <span v-if="d.statusEnum === 'DELIVERED' && d.deliveredTime" class="ml-1 opacity-80 font-medium">
+                ({{ d.deliveredTime }})
+              </span>
+            </span>
+          </div>
         </div>
 
         <div class="px-5 py-4 flex items-start overflow-x-auto hide-scrollbar">
@@ -166,16 +174,26 @@
     </div>
 
     <div v-if="totalPages > 1" class="flex justify-center items-center gap-2 mt-6">
+      <!-- 이전 10페이지 그룹 -->
+      <button
+        @click="goToPage(Math.max(0, currentPage - 10))"
+        :disabled="currentPage < 10"
+        class="p-2 border rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M11 19l-7-7 7-7m8 14l-7-7 7-7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+
+      <!-- 이전 페이지 -->
       <button
         @click="goToPage(currentPage - 1)"
         :disabled="currentPage === 0"
         class="p-2 border rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M15 19l-7-7 7-7" stroke-width="2"/></svg>
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M15 19l-7-7 7-7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
 
+      <!-- 페이지 번호 (최대 10개) -->
       <div class="flex gap-1">
         <button
-          v-for="p in totalPages"
+          v-for="p in visiblePages"
           :key="p"
           @click="goToPage(p - 1)"
           class="w-9 h-9 text-sm font-semibold rounded-lg transition-colors"
@@ -186,11 +204,20 @@
         </button>
       </div>
 
+      <!-- 다음 페이지 -->
       <button
         @click="goToPage(currentPage + 1)"
         :disabled="currentPage === totalPages - 1"
         class="p-2 border rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7" stroke-width="2"/></svg>
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+
+      <!-- 다음 10페이지 그룹 -->
+      <button
+        @click="goToPage(Math.min(totalPages - 1, currentPage + 10))"
+        :disabled="currentPage >= Math.floor((totalPages - 1) / 10) * 10"
+        class="p-2 border rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M13 5l7 7-7 7M5 5l7 7-7 7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
     </div>
 
@@ -299,9 +326,36 @@ const yearOptions = computed(() => {
   return [cur, cur - 1, cur - 2]
 })
 
+const visiblePages = computed(() => {
+  const range = 10
+  const startPage = Math.floor(currentPage.value / range) * range + 1
+  const endPage = Math.min(startPage + range - 1, totalPages.value)
+
+  const pages = []
+  for (let i = startPage; i <= endPage; i++) {
+    pages.push(i)
+  }
+  return pages
+})
+
 function formatDatetime(val) {
   if (!val) return null
   return String(val).replace('T', ' ').substring(0, 16)
+}
+
+function formatShortTime(val) {
+  if (!val) return null
+  const date = new Date(val)
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  const h = String(date.getHours()).padStart(2, '0')
+  const i = String(date.getMinutes()).padStart(2, '0')
+  return `${m}.${d} ${h}:${i}`
+}
+
+function formatPrice(value) {
+  if (value === null || value === undefined) return '0원'
+  return new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(value)
 }
 
 // DTO 맵핑 로직 (기존과 동일)
@@ -311,6 +365,7 @@ function mapDelivery(dto) {
   const departureFormatted = formatDatetime(dto.departureDate)
   const estimatedFormatted = formatDatetime(dto.estimatedArrivalAt)
   const deliveredFormatted = formatDatetime(dto.deliveredDate)
+  const deliveredTimeShort = formatShortTime(dto.deliveredDate)
 
   const ORDER = ['READY', 'START', 'DELIVERYING', 'DELIVERED']
   const currentIdx = statusEnum === 'DELAY' ? 2 : ORDER.indexOf(statusEnum)
@@ -329,6 +384,9 @@ function mapDelivery(dto) {
     statusEnum,
     statusLabel,
     delayReason:  dto.delayReason || '',
+    orderPrice:   dto.orderPrice,
+    itemCount:    dto.itemCount,
+    deliveredTime: deliveredTimeShort,
     timeline,
   }
 }
@@ -352,6 +410,10 @@ async function fetchDeliveries() {
     const res = await getAllDeliveries(params)
     // 백엔드 응답 구조: res.data.result (DeliveryPageRes)
     const result = res.data.result
+
+    if (result.deliveryList && result.deliveryList.length > 0) {
+      console.log('[DeliveryView] 첫 번째 배송 데이터 샘플:', result.deliveryList[0])
+    }
 
     deliveries.value = (result.deliveryList || []).map(mapDelivery)
     totalPages.value = result.totalPage

--- a/frontend/src/views/store/StoreDeliveryView.vue
+++ b/frontend/src/views/store/StoreDeliveryView.vue
@@ -113,11 +113,19 @@
             </div>
             <span class="font-bold text-gray-900 text-sm">{{ d.storeName }}</span>
           </div>
-          <span
-            class="text-xs font-bold px-2 py-0.5 rounded whitespace-nowrap"
-            :class="statusClass(d.statusEnum)">
-            {{ d.statusLabel }}
-          </span>
+          <div class="flex items-center gap-3">
+            <span v-if="d.orderPrice != null" class="text-[11px] font-medium text-gray-500 bg-white/80 px-2 py-0.5 rounded-full border border-gray-100 shadow-sm">
+              {{ formatPrice(d.orderPrice) }} ({{ d.itemCount }}건)
+            </span>
+            <span
+              class="text-xs font-bold px-2 py-0.5 rounded whitespace-nowrap"
+              :class="statusClass(d.statusEnum)">
+              {{ d.statusLabel }}
+              <span v-if="d.statusEnum === 'DELIVERED' && d.deliveredTime" class="ml-1 opacity-80 font-medium text-[10px]">
+                ({{ d.deliveredTime }})
+              </span>
+            </span>
+          </div>
         </div>
 
         <!-- 타임라인 -->
@@ -172,6 +180,15 @@
 
     <!-- 페이지네이션 -->
     <div v-if="totalPages > 1" class="flex justify-center items-center gap-2 mt-6">
+      <!-- 이전 10페이지 그룹 -->
+      <button
+        @click="fetchDeliveries(Math.max(0, currentPage - 10))"
+        :disabled="currentPage < 10"
+        class="p-2 border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M11 19l-7-7 7-7m8 14l-7-7 7-7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+
+      <!-- 이전 페이지 -->
       <button
         @click="fetchDeliveries(currentPage - 1)"
         :disabled="currentPage === 0"
@@ -181,19 +198,21 @@
         </svg>
       </button>
 
+      <!-- 페이지 번호 (최대 10개) -->
       <div class="flex gap-1">
         <button
-          v-for="p in totalPages"
+          v-for="p in visiblePages"
           :key="p"
           @click="fetchDeliveries(p - 1)"
           class="w-9 h-9 text-sm font-semibold rounded-lg transition-colors cursor-pointer"
           :class="currentPage === p - 1
-        ? 'bg-blue-500 text-white'
-        : 'bg-white border border-gray-200 text-gray-600 hover:bg-gray-50'">
+            ? 'bg-blue-500 text-white'
+            : 'bg-white border border-gray-200 text-gray-600 hover:bg-gray-50'">
           {{ p }}
         </button>
       </div>
 
+      <!-- 다음 페이지 -->
       <button
         @click="fetchDeliveries(currentPage + 1)"
         :disabled="currentPage === totalPages - 1"
@@ -201,6 +220,14 @@
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path d="M9 5l7 7-7 7" stroke-width="2"/>
         </svg>
+      </button>
+
+      <!-- 다음 10페이지 그룹 -->
+      <button
+        @click="fetchDeliveries(Math.min(totalPages - 1, currentPage + 10))"
+        :disabled="currentPage >= Math.floor((totalPages - 1) / 10) * 10"
+        class="p-2 border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M13 5l7 7-7 7M5 5l7 7-7 7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
     </div>
 
@@ -310,10 +337,37 @@ function formatDatetime(val) {
   return String(val).replace('T', ' ').substring(0, 16)
 }
 
+function formatShortTime(val) {
+  if (!val) return null
+  const date = new Date(val)
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  const h = String(date.getHours()).padStart(2, '0')
+  const i = String(date.getMinutes()).padStart(2, '0')
+  return `${m}.${d} ${h}:${i}`
+}
+
+function formatPrice(value) {
+  if (value === null || value === undefined) return '0원'
+  return new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(value)
+}
+
 function extractDate(val) {
   if (!val) return null
   return String(val).substring(0, 10) // "YYYY-MM-DD"
 }
+
+const visiblePages = computed(() => {
+  const range = 10
+  const startPage = Math.floor(currentPage.value / range) * range + 1
+  const endPage = Math.min(startPage + range - 1, totalPages.value)
+
+  const pages = []
+  for (let i = startPage; i <= endPage; i++) {
+    pages.push(i)
+  }
+  return pages
+})
 
 // DeliveryDto -> 프론트엔드 포맷 매핑
 // DeliveryStatus enum 순서 기반 타임라인 구성
@@ -325,6 +379,7 @@ function mapDelivery(dto) {
   const estimatedFormatted = formatDatetime(dto.estimatedArrivalAt)
   const deliveredFormatted = formatDatetime(dto.deliveredDate)
   const dateStr            = extractDate(dto.departureDate)
+  const deliveredTimeShort = formatShortTime(dto.deliveredDate)
 
   // READY -> START -> DELIVERYING -> DELIVERED
   // DELAY 는 DELIVERYING 단계에서 발생
@@ -376,6 +431,9 @@ function mapDelivery(dto) {
     statusEnum,
     statusLabel,
     delayReason:  dto.delayReason  || '',
+    orderPrice:   dto.orderPrice,
+    itemCount:    dto.itemCount,
+    deliveredTime: deliveredTimeShort,
     timeline,
   }
 }


### PR DESCRIPTION
## 📋 Summary
[백엔드 개선]
- JPA 페이징 버그 수정: Pageable 사용 시 JOIN FETCH로 인한 인 메모리 페이징 문제 해결 (일반 JOIN으로 변경)
- N+1 문제 방어: application.yml에 hibernate.default_batch_fetch_size: 100 설정 추가
- DeliveryDto 확장: 발주 금액(orderPrice) 및 품목 수(itemCount) 필드 추가 및 JSON 직렬화 명시(@JsonProperty)
[프론트엔드 개선]
- 슬라이딩 윈도우 페이징 구현: 하단 페이지 버튼을 최대 10개로 제한하고 그룹 이동(<<, >>) 기능 추가 (본사/가맹점 공통)
- 배송 정보 가시성 강화: 각 배송 카드에 연관된 발주 총액 및 품목 수 요약 표시
- 배지 UI 개선: '입고완료' 상태 배지 내부에 실제 완료 시간(MM.DD HH:mm) 표시
- 유틸리티 추가: 금액 포맷팅(formatPrice) 및 짧은 시간 포맷(formatShortTime) 함수 적용

## 📂 변경 파일
- 'backend/monolith/src/main/java/com/example/nexus/domain/delivery/DeliveryRepository.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java'
- 'backend/monolith/src/main/resources/application-dev.yaml'
- 'frontend/src/views/hq/DeliveryView.vue'
- 'frontend/src/views/store/StoreDeliveryView.vue'

## ✨ 주요 변경 사항
- 페이징 처리 하단 버튼 10개로 제한 후 클릭해서 이동할 수 있게 수정
- 입고완료 옆에 입고완료 시간 및 발주에 대한 금액 보여주게 수정

Closes #894  