### PR TITLE
[Feat] #904 - 가맹점 결제 수단 관리 등록된 카드사, 카드번호 가져오기

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/common/enums/CardCompany.java
+++ b/backend/monolith/src/main/java/com/example/nexus/common/enums/CardCompany.java
@@ -1,0 +1,34 @@
+package com.example.nexus.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum CardCompany {
+    BC("31", "비씨카드"),
+    KOOKMIN("11", "국민카드"),
+    SAMSUNG("51", "삼성카드"),
+    HYUNDAI("61", "현대카드"),
+    SHINHAN("41", "신한카드"),
+    HANA("21", "하나카드"),
+    LOTTE("71", "롯데카드"),
+    NH("91", "농협카드"),
+    CITY("36", "씨티카드"),
+    WOORI("33", "우리카드"),
+    WOORI_CULTURE("W1", "우리컬쳐"),
+    UNKNOWN("", "기타카드");
+
+    private final String code;
+    private final String korName;
+
+    public static String getKorNameByCode(String code) {
+        return Arrays.stream(CardCompany.values())
+                .filter(c -> c.code.equals(code))
+                .findFirst()
+                .map(CardCompany::getKorName)
+                .orElse(UNKNOWN.korName + (code != null && !code.isEmpty() ? "(" + code + ")" : ""));
+    }
+}

--- a/backend/monolith/src/main/java/com/example/nexus/domain/billing/BillingService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/billing/BillingService.java
@@ -2,6 +2,7 @@ package com.example.nexus.domain.billing;
 
 import com.example.nexus.common.exception.BaseException;
 import com.example.nexus.common.model.BaseResponseStatus;
+import com.example.nexus.common.enums.CardCompany;
 import com.example.nexus.domain.billing.model.Billing;
 import com.example.nexus.domain.billing.model.BillingDto;
 import lombok.RequiredArgsConstructor;
@@ -68,7 +69,7 @@ public class BillingService {
                 // issuerCode로 카드사 이름 찾기
                 Object issuerCodeObj = cardInfo.get("issuerCode");
                 String issuerCode = (issuerCodeObj != null) ? issuerCodeObj.toString() : "";
-                cardCompany = getCardCompanyName(issuerCode);
+                cardCompany = CardCompany.getKorNameByCode(issuerCode);
                 
                 // 카드 번호 (토스가 마스킹해서 줌)
                 Object numberObj = cardInfo.get("number");
@@ -107,25 +108,6 @@ public class BillingService {
     private String getSafeString(Map<?, ?> map, String key) {
         Object val = map.get(key);
         return (val != null) ? val.toString() : "";
-    }
-
-    // 카드사 코드 매핑 (Toss Payments 표준 코드)
-    private String getCardCompanyName(String code) {
-        if (code == null || code.isEmpty()) return "알 수 없는 카드";
-        return switch (code) {
-            case "31" -> "비씨카드";
-            case "11" -> "국민카드";
-            case "51" -> "삼성카드";
-            case "61" -> "현대카드";
-            case "41" -> "신한카드";
-            case "21" -> "하나카드";
-            case "71" -> "롯데카드";
-            case "91" -> "농협카드";
-            case "36" -> "씨티카드";
-            case "33" -> "우리카드";
-            case "W1" -> "우리컬쳐";
-            default -> "기타카드(" + code + ")";
-        };
     }
 
     @Transactional(readOnly = true)

--- a/frontend/src/views/store/PaymentView.vue
+++ b/frontend/src/views/store/PaymentView.vue
@@ -19,7 +19,6 @@
               <span class="method-name">{{ billing.cardCompany || billing.method }}</span>
             </div>
             <div class="card-details">
-              <p><strong>가맹점 번호:</strong> {{ billing.storeIdx }}</p>
               <p v-if="billing.cardNumber"><strong>카드번호:</strong> {{ billing.cardNumber }}</p>
               <p><strong>등록일:</strong> {{ formatDate(billing.authenticatedAt) }}</p>
             </div>


### PR DESCRIPTION
## 📋 Summary
- 가맹점 결제 수단 관리 등록된 카드사, 카드번호 가져오기

## 📂 변경 파일
- 'backend/monolith/src/main/java/com/example/nexus/common/enums/CardCompany.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/billing/BillingService.java'
- 'frontend/src/views/store/PaymentView.vue'

## ✨ 주요 변경 사항
- 빌링키 발급 시 카드사 명칭 및 마스킹된 카드번호 저장/조회 기능 구현
- CardCompany Enum을 통한 카드사 코드 관리 체계화
- 가맹점주 결제 관리 UI 간소화 및 시각적 정보 개선

Closes #904 