### PR TITLE
[Fix] findByPayedMonth 메서드 추가

### DIFF
--- a/backend/billing-batch/src/main/java/org/example/spring/billingbatch/repository/FailedPaymentRepository.java
+++ b/backend/billing-batch/src/main/java/org/example/spring/billingbatch/repository/FailedPaymentRepository.java
@@ -11,5 +11,6 @@ import java.util.List;
 @Repository
 public interface FailedPaymentRepository extends JpaRepository<FailedPayment, Long> {
     Page<FailedPayment> findByPayedMonth(String payedMonth, Pageable pageable);
+    List<FailedPayment> findByPayedMonth(String payedMonth);
     boolean existsByStoreIdxAndPayedMonth(Long storeIdx, String payedMonth);
 }

--- a/backend/billing-batch/src/main/resources/application.yaml
+++ b/backend/billing-batch/src/main/resources/application.yaml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: billing-batch
+  batch:
+    job:
+      enabled: false
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
FailedPaymentRepository에 인자가 하나인 findByPayedMonth 메서드가 누락되어 발생한 컴파일 에러를 해결.