### PR TITLE
[Refactor] #920 - Ingress 제거 + Frontend Nginx 가 진입점 (LoadBalancer + SSL + API 분기)

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -2,4 +2,5 @@ FROM nginx:alpine
 COPY dist /usr/share/nginx/html
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
+EXPOSE 443
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -1,15 +1,118 @@
+# ============================================================
+# Nexus Frontend Nginx — 외부 진입점 (Ingress 제거 후 Nginx 가 진입점)
+# ============================================================
+# - 80 (HTTP) → 443 (HTTPS) 강제 리다이렉트
+# - TLS termination (ZeroSSL cert, K8s Secret `nexus-tls` 마운트)
+# - SPA 서빙 (Vue Router history mode)
+# - API 분기:
+#   /api/auth/*           → 모놀리식 직접 (Gateway 우회, 로그인)
+#   /api/(stat|pos)/*     → Gateway → Eureka → MSA
+#   /api/notification/subscribe → 모놀리식 SSE (buffering off)
+#   /api/*                → 모놀리식 (대시보드/알림/발주)
+# - 정적 파일 캐싱 (js/css/image)
+# ============================================================
+
+
+# HTTP → HTTPS 강제 리다이렉트
 server {
     listen 80;
-    server_name _;
+    server_name www.nexusscm.kro.kr;
+    return 301 https://$host$request_uri;
+}
+
+
+# 메인 HTTPS 서버
+server {
+    listen 443 ssl;
+    server_name www.nexusscm.kro.kr;
+
+    # TLS 설정 (ZeroSSL cert, K8s Secret 마운트)
+    ssl_certificate     /etc/nginx/ssl/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 10m;
+
     root /usr/share/nginx/html;
     index index.html;
 
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
+    # 큰 파일 업로드 허용 (PDF 보고서 등)
+    client_max_body_size 15M;
 
+
+    # --- 정적 자원 캐싱 (Vue dist 의 js/css/image) ---
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+
+    # --- 로그인 (Gateway 우회, 모놀리식 직접) ---
+    # 기존 인증 코드 변경 0 — 모놀리식이 JWT 발급
+    location /api/auth/ {
+        proxy_pass http://nexus-backend-service:8080/auth/;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+
+    # --- 통계 / POS MSA (Gateway 거침, Eureka 로 라우팅) ---
+    # Gateway 가 JWT 검증 + X-User-* 헤더 주입 → MSA 호출
+    location ~ ^/api/(statistics|pos)/ {
+        proxy_pass http://nexus-gateway-service:8088;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+
+    # --- SSE (알림 실시간 푸시) ---
+    # buffering / cache 끄기 + 장기 timeout (한 번 연결 후 server 가 계속 push)
+    location /api/notification/subscribe {
+        proxy_pass http://nexus-backend-service:8080/notification/subscribe;
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 24h;
+    }
+    # 가맹점 SSE
+    location /api/store/notification/subscribe {
+        proxy_pass http://nexus-backend-service:8080/store/notification/subscribe;
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 24h;
+    }
+
+
+    # --- 그 외 /api/* (대시보드, 알림, 발주, AI 등) — 모놀리식 직접 ---
+    location /api/ {
+        proxy_pass http://nexus-backend-service:8080/;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+
+    # --- SPA fallback (Vue Router history mode) ---
+    # 위 location 들에 안 잡힌 모든 경로 → index.html 로 fallback
+    location / {
+        try_files $uri $uri/ /index.html;
     }
 }

--- a/k8s/frontend/deployment-blue.yaml
+++ b/k8s/frontend/deployment-blue.yaml
@@ -1,5 +1,7 @@
 # Blue/Green 배포 - Blue 슬롯
 # Service의 selector.slot 값을 blue/green으로 전환하여 트래픽을 제어합니다.
+#
+# Frontend Nginx 가 TLS termination (nexus-tls Secret 의 ZeroSSL cert 사용)
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,3 +26,17 @@ spec:
           image: deatytim/nexusfront:latest
           ports:
             - containerPort: 80
+            - containerPort: 443
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/nginx/ssl
+              readOnly: true
+      volumes:
+        - name: ssl-certs
+          secret:
+            secretName: nexus-tls          # ZeroSSL cert (kubectl-create 등록됨)
+            items:
+              - key: tls.crt
+                path: fullchain.pem        # Pod 안 /etc/nginx/ssl/fullchain.pem
+              - key: tls.key
+                path: privkey.pem          # Pod 안 /etc/nginx/ssl/privkey.pem

--- a/k8s/frontend/deployment-green.yaml
+++ b/k8s/frontend/deployment-green.yaml
@@ -1,5 +1,7 @@
 # Blue/Green 배포 - Green 슬롯
 # Service의 selector.slot 값을 blue/green으로 전환하여 트래픽을 제어합니다.
+#
+# Frontend Nginx 가 TLS termination (nexus-tls Secret 의 ZeroSSL cert 사용)
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,3 +26,17 @@ spec:
           image: deatytim/nexusfront:latest
           ports:
             - containerPort: 80
+            - containerPort: 443
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/nginx/ssl
+              readOnly: true
+      volumes:
+        - name: ssl-certs
+          secret:
+            secretName: nexus-tls          # ZeroSSL cert (kubectl-create 등록됨)
+            items:
+              - key: tls.crt
+                path: fullchain.pem        # Pod 안 /etc/nginx/ssl/fullchain.pem
+              - key: tls.key
+                path: privkey.pem          # Pod 안 /etc/nginx/ssl/privkey.pem

--- a/k8s/frontend/service.yaml
+++ b/k8s/frontend/service.yaml
@@ -1,15 +1,27 @@
-# Blue/Green 배포용 Service
-# slot 값을 Jenkins 파이프라인에서 blue <-> green으로 patch하여 트래픽을 전환합니다.
+# Frontend Service — 외부 진입점 (LoadBalancer, MetalLB 가 IP 할당)
+# Blue/Green 배포: slot 값을 Jenkins 파이프라인에서 blue <-> green 으로 patch 하여 트래픽 전환
+#
+# Ingress 제거 후 Nginx 가 진입점 + TLS termination + API 분기:
+#   /                      → SPA (Vue dist)
+#   /api/auth/*           → 모놀리식 직접 (Gateway 우회)
+#   /api/(stat|pos)/*     → Gateway → Eureka → MSA
+#   /api/*                → 모놀리식 (대시보드/알림/발주)
+
 apiVersion: v1
 kind: Service
 metadata:
   name: nexus-frontend-service
 spec:
+  type: LoadBalancer    # ← MetalLB 가 IP 풀에서 External IP 자동 할당
   selector:
     app: nexus-frontend
-    slot: blue              # Jenkins에서 kubectl patch로 blue <-> green 전환
+    slot: blue          # Jenkins 에서 kubectl patch 로 blue <-> green 전환
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 80
       targetPort: 80
-  type: ClusterIP
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443


### PR DESCRIPTION
## Summary

- **K8s Ingress 제거** + **Frontend Nginx 가 외부 진입점**
- Frontend Service **LoadBalancer** 로 전환 (MetalLB 가 External IP 할당)
- Nginx 가 **TLS termination** (\`nexus-tls\` Secret 의 ZeroSSL cert 활용)
- Nginx 가 **API 분기** (\`/api/auth/*\` → 모놀리식, \`/api/(stat|pos)/*\` → Gateway)

## 변경 파일 (5개)

### Docker
- \`docker/frontend/Dockerfile\` — \`EXPOSE 443\` 추가

### Nginx 설정
- \`frontend/nginx/default.conf\` — SSL termination + API 분기 (+111줄)

### K8s yaml
- \`k8s/frontend/service.yaml\` — ClusterIP → **LoadBalancer** + 443 포트 추가
- \`k8s/frontend/deployment-blue.yaml\` — containerPort 443 + \`nexus-tls\` Secret 마운트
- \`k8s/frontend/deployment-green.yaml\` — 동일 (Blue/Green 일관성)

## 데이터 흐름 (변경 후)

\`\`\`
사용자 → DNS (www.nexusscm.kro.kr → 새 External IP)
         → Frontend Service (LoadBalancer, MetalLB)
         → Frontend Pod (Nginx, TLS termination)
              ├─ /                                → SPA 서빙 (Vue dist)
              ├─ /api/auth/*                     → nexus-backend-service (모놀리식, Gateway 우회)
              ├─ /api/(statistics|pos)/*         → nexus-gateway-service (Gateway → Eureka → MSA)
              ├─ /api/notification/subscribe     → 모놀리식 SSE (buffering off, 24h)
              ├─ /api/store/notification/subscribe → 동일
              └─ /api/*                          → 모놀리식 (대시보드/알림/발주)
\`\`\`

## 주요 변경 사항

### 1. Nginx default.conf (frontend/nginx/default.conf)

- **HTTP (80) → HTTPS (443) 301 리다이렉트**
- **TLS termination**: TLSv1.2/1.3, HIGH ciphers, session cache
- **SPA fallback**: Vue Router history mode (try_files)
- **정적 자원 캐싱**: js/css/image 1y immutable
- **client_max_body_size 15M**: PDF 보고서 업로드
- **SSE 전용 location**: buffering off, cache off, 24h read timeout

### 2. K8s yaml

- Service \`type: LoadBalancer\` → MetalLB 가 IP 풀에서 자동 할당
- Service 443 노출 (name: https)
- Deployment 의 \`nexus-tls\` Secret 마운트:
  - \`tls.crt\` → \`/etc/nginx/ssl/fullchain.pem\`
  - \`tls.key\` → \`/etc/nginx/ssl/privkey.pem\`

### 3. Docker

- \`EXPOSE 443\` 추가 (기존 80 만, documentation 목적)

## Issue
- Closes #920  