### PR TITLE
[Feat] #846 - POS 연동 기능 정상화

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuService.java
@@ -250,7 +250,6 @@ public class MenuService {
                 MenuItem newItem = itemReq.toEntity(menu, product);
                 menu.getMenuItemList().add(newItem);
             }
-            menuItemRepository.saveAllAndFlush(menu.getMenuItemList());
 
             //  저장 결과를 새로운 리스트(savedItems)로 반드시 받아옵니다!
             List<MenuItem> savedItems = menuItemRepository.saveAllAndFlush(menu.getMenuItemList());

--- a/backend/monolith/src/main/java/com/example/nexus/domain/pos/PosController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/pos/PosController.java
@@ -86,7 +86,7 @@ public class PosController {
         }
 
         PosCloseDto.CloseRes res = posService.deductOnClose(userDetails.getIdx());
-
+        autoOrderService.generateAutoOrder(userDetails.getIdx());
         PosCloseDto.CloseRes body = PosCloseDto.CloseRes.builder()
                 .storeIdx(res.getStoreIdx())
                 .processedPayCount(res.getProcessedPayCount())


### PR DESCRIPTION
## Summary
- POS 관련 기능(결제, 마감 등) 연동을 정상화하기 위해 Controller와 MenuService의 로직을 복구 및 수정

## 변경 파일
- `backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuService.java`
- `backend/monolith/src/main/java/com/example/nexus/domain/pos/PosController.java`

## 주요 변경 사항
- [x] POS 연동 기능(pos 다시 살리기)을 위한 `PosController` 로직 정상화
- [x] `MenuService` 관련 동기화 또는 비즈니스 로직 에러 파악 및 복구
- [x] 이전 카프카 MSA 리팩토링 브랜치(`refactor/back/pos/msa/kafka`) 내용 병합


## Issue
- Closes #846