### PR TITLE
[Refactor] #926 - 발주/알림/대시보드 에러 코드 세분화 + Swagger Try it out examples + dev seed 보정

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
+++ b/backend/monolith/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
@@ -78,6 +78,9 @@ public enum BaseResponseStatus {
     ORDERS_ITEMS_EMPTY(false, 4209, "발주 항목이 비어 있습니다."),
     BATCH_SERVICE_UNAVAILABLE(false, 4210, "배치 서비스 호출에 실패했습니다."),
 
+    // 4300번대 ~ 알림 관련
+    NOT_FOUND_NOTIFICATION(false, 4301, "알림을 찾을 수 없습니다."),
+
     // 5000번대 실패
     FAIL(false, 5000, "요청 실패"),
     DATABASE_ERROR(false, 5001, "데이터베이스 연결 및 처리 오류");

--- a/backend/monolith/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
+++ b/backend/monolith/src/main/java/com/example/nexus/common/model/BaseResponseStatus.java
@@ -71,6 +71,12 @@ public enum BaseResponseStatus {
 
     // 4200번대 ~ 발주 관련
     ORDERS_APPROVE_INSUFFICIENT_STOCK(false, 4201, "본사 재고가 부족하여 발주를 승인할 수 없습니다."),
+    NOT_FOUND_ORDERS(false, 4202, "발주를 찾을 수 없습니다."),
+    NOT_FOUND_ORDERS_ITEM(false, 4203, "발주 항목을 찾을 수 없습니다."),
+    ORDERS_NOT_AUTHORIZED(false, 4204, "해당 발주에 대한 권한이 없습니다."),
+    ORDERS_INVALID_STATUS(false, 4205, "현재 발주 상태에서 처리할 수 없습니다."),
+    ORDERS_ITEMS_EMPTY(false, 4209, "발주 항목이 비어 있습니다."),
+    BATCH_SERVICE_UNAVAILABLE(false, 4210, "배치 서비스 호출에 실패했습니다."),
 
     // 5000번대 실패
     FAIL(false, 5000, "요청 실패"),

--- a/backend/monolith/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/dashboard/StoreDashboardService.java
@@ -42,7 +42,7 @@ public class StoreDashboardService {
     public StoreDashboardDto.SalesKpiRes getSalesKpi(Long userIdx) {
         // 점주의 매장 조회
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         // 금일/전일 기간 설정
         LocalDate today = LocalDate.now();
@@ -73,7 +73,7 @@ public class StoreDashboardService {
     public StoreDashboardDto.PendingOrderKpiRes getPendingOrderKpi(Long userIdx) {
         // 점주의 매장 조회
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         // 승인 대기 상태의 자동 발주 건수 조회
         long pendingCount = ordersRepository.countByStore_IdxAndOrdersStatusAndOrdersType(
@@ -91,7 +91,7 @@ public class StoreDashboardService {
     public StoreDashboardDto.InventoryRiskKpiRes getInventoryRiskKpi(Long userIdx) {
         // 점주의 매장 조회
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         // 상태별 위험 재고 건수 조회
         long lowCount = storeInventoryRepository.countByStore_IdxAndStatus(store.getIdx(), InventoryStatus.LOW);
@@ -112,7 +112,7 @@ public class StoreDashboardService {
     public StoreDashboardDto.SettlementKpiRes getSettlementKpi(Long userIdx) {
         // 점주의 매장 조회
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         // 현재/직전 반월 구간 계산
         LocalDate today = LocalDate.now();
@@ -166,7 +166,7 @@ public class StoreDashboardService {
     public StoreDashboardDto.DailySalesChartRes getDailySalesChart(Long userIdx) {
         // 점주의 매장 조회
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         // 이번 주 일요일 ~ 토요일 구간 계산
         LocalDate today = LocalDate.now();
@@ -208,7 +208,7 @@ public class StoreDashboardService {
     public List<StoreDashboardDto.PendingOrderItem> getPendingOrderList(Long userIdx) {
         // 점주의 매장 조회
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         // WAITING + AUTO 발주서 목록 조회
         return ordersRepository
@@ -223,7 +223,7 @@ public class StoreDashboardService {
     public List<StoreDashboardDto.MyDeliveryItem> getMyDeliveryList(Long userIdx) {
         // 점주의 매장 조회
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         // 배송완료(DELIVERED) 제외한 배송 목록 조회
         return deliveryRepository
@@ -238,7 +238,7 @@ public class StoreDashboardService {
     public List<StoreDashboardDto.InventoryWarningItem> getInventoryWarningList(Long userIdx) {
         // 점주의 매장 조회
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         // LOW/CRITICAL 상태 재고 목록 조회 (CRITICAL 우선 정렬)
         return storeInventoryRepository

--- a/backend/monolith/src/main/java/com/example/nexus/domain/notification/HeadNotificationController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/notification/HeadNotificationController.java
@@ -5,6 +5,7 @@ import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.domain.notification.model.HeadNotificationDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -72,7 +73,14 @@ public class HeadNotificationController {
     )
     @PutMapping("/{notificationIdx}/read")
     public ResponseEntity<BaseResponse> markAsRead(
-            @Parameter(description = "알림 고유 ID") @PathVariable Long notificationIdx
+            @Parameter(
+                    description = "알림 고유 ID",
+                    examples = {
+                            @ExampleObject(name = "정상 (존재하는 알림)", value = "1"),
+                            @ExampleObject(name = "NOT_FOUND_NOTIFICATION (없는 알림)", value = "99999")
+                    }
+            )
+            @PathVariable Long notificationIdx
     ) {
         headNotificationService.markAsRead(notificationIdx);
         return ResponseEntity.ok(BaseResponse.success("success"));

--- a/backend/monolith/src/main/java/com/example/nexus/domain/notification/HeadNotificationService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/notification/HeadNotificationService.java
@@ -1,6 +1,8 @@
 package com.example.nexus.domain.notification;
 
 import com.example.nexus.common.enums.NotificationType;
+import com.example.nexus.common.exception.BaseException;
+import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.domain.notification.model.HeadNotification;
 import com.example.nexus.domain.notification.model.HeadNotificationDto;
 import lombok.RequiredArgsConstructor;
@@ -57,7 +59,7 @@ public class HeadNotificationService {
     @Transactional
     public void markAsRead(Long notificationIdx) {
         HeadNotification notification = headNotificationRepository.findById(notificationIdx)
-                .orElseThrow(() -> new IllegalArgumentException("알림을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_NOTIFICATION));
         notification.markAsRead();
     }
 

--- a/backend/monolith/src/main/java/com/example/nexus/domain/notification/StoreNotificationController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/notification/StoreNotificationController.java
@@ -6,6 +6,7 @@ import com.example.nexus.domain.notification.model.StoreNotificationDto;
 import com.example.nexus.domain.user.model.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -74,7 +75,14 @@ public class StoreNotificationController {
     )
     @PutMapping("/{notificationIdx}/read")
     public ResponseEntity<BaseResponse> markAsRead(
-            @Parameter(description = "읽음 처리할 알림 고유 ID") @PathVariable Long notificationIdx
+            @Parameter(
+                    description = "읽음 처리할 알림 고유 ID",
+                    examples = {
+                            @ExampleObject(name = "정상 (본인 매장 알림)", value = "1"),
+                            @ExampleObject(name = "NOT_FOUND_NOTIFICATION (없는 알림)", value = "99999")
+                    }
+            )
+            @PathVariable Long notificationIdx
     ) {
         storeNotificationService.markAsRead(notificationIdx);
         return ResponseEntity.ok(BaseResponse.success("success"));

--- a/backend/monolith/src/main/java/com/example/nexus/domain/notification/StoreNotificationService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/notification/StoreNotificationService.java
@@ -31,7 +31,7 @@ public class StoreNotificationService {
      */
     public Slice<StoreNotificationDto.ListRes> getNotifications(AuthUserDetails authUserDetails, int page, int size) {
         Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
-                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                () -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
         return storeNotificationRepository.findAllByStore_IdxOrderByCreatedAtDesc(store.getIdx(), PageRequest.of(page, size))
                 .map(StoreNotificationDto.ListRes::from);
     }
@@ -41,7 +41,7 @@ public class StoreNotificationService {
      */
     public Slice<StoreNotificationDto.ListRes> getNotificationsByReadStatus(AuthUserDetails authUserDetails, boolean isRead, int page, int size) {
         Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
-                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                () -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
         return storeNotificationRepository.findAllByStore_IdxAndIsReadOrderByCreatedAtDesc(store.getIdx(), isRead, PageRequest.of(page, size))
                 .map(StoreNotificationDto.ListRes::from);
     }
@@ -51,7 +51,7 @@ public class StoreNotificationService {
      */
     public Slice<StoreNotificationDto.ListRes> getNotificationsByType(AuthUserDetails authUserDetails, NotificationType type, int page, int size) {
         Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
-                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                () -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
         return storeNotificationRepository.findAllByStore_IdxAndTypeOrderByCreatedAtDesc(store.getIdx(), type, PageRequest.of(page, size))
                 .map(StoreNotificationDto.ListRes::from);
     }
@@ -61,7 +61,7 @@ public class StoreNotificationService {
      */
     public StoreNotificationDto.UnreadCountRes getUnreadCount(AuthUserDetails authUserDetails) {
         Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
-                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                () -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
         long count = storeNotificationRepository.countByStore_IdxAndIsReadFalse(store.getIdx());
         return StoreNotificationDto.UnreadCountRes.builder().count(count).build();
     }
@@ -72,7 +72,7 @@ public class StoreNotificationService {
     @Transactional
     public void markAsRead(Long notificationIdx) {
         StoreNotification notification = storeNotificationRepository.findById(notificationIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_NOTIFICATION));
         notification.markAsRead();
     }
 
@@ -82,7 +82,7 @@ public class StoreNotificationService {
     @Transactional
     public void markAllAsRead(AuthUserDetails authUserDetails) {
         Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
-                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                () -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
         storeNotificationRepository.markAllAsReadByStoreIdx(store.getIdx());
     }
 
@@ -91,7 +91,7 @@ public class StoreNotificationService {
      */
     public SseEmitter subscribe(AuthUserDetails authUserDetails) {
         Store store = storeRepository.findByUserIdx(authUserDetails.getIdx()).orElseThrow(
-                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                () -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
         return storeSseEmitterService.subscribe(store.getIdx());
     }
 

--- a/backend/monolith/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -1,7 +1,9 @@
 package com.example.nexus.domain.orders;
 
 import com.example.nexus.common.enums.OrdersType;
+import com.example.nexus.common.exception.BaseException;
 import com.example.nexus.common.model.BaseResponse;
+import com.example.nexus.common.model.BaseResponseStatus;
 import com.example.nexus.common.model.PageResponse;
 import com.example.nexus.domain.orders.model.DangerDto;
 import com.example.nexus.domain.orders.model.OrdersDto;
@@ -9,6 +11,8 @@ import com.example.nexus.domain.orders.model.OrdersItemDto;
 import com.example.nexus.domain.user.model.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +23,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -53,7 +58,8 @@ public class OrdersController {
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size
     ) {
         Page<OrdersDto.OrderListRes> result = orderService.findAllAuto(
-                keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+                keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
 
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
@@ -72,7 +78,8 @@ public class OrdersController {
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size
     ) {
         Page<OrdersDto.OrderListRes> result = orderService.findAllConfirmed(
-                keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+                keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
 
@@ -85,10 +92,11 @@ public class OrdersController {
     )
     @PutMapping("/confirmed/approve")
     public ResponseEntity approveAll() {
-        restTemplate.postForEntity(
-            batchServiceUrl + "/batch/jobs/approve",
-            null, String.class
-        );
+        try {
+            restTemplate.postForEntity(batchServiceUrl + "/batch/jobs/approve", null, String.class);
+        } catch (RestClientException e) {
+            throw new BaseException(BaseResponseStatus.BATCH_SERVICE_UNAVAILABLE);
+        }
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
 
@@ -130,8 +138,9 @@ public class OrdersController {
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size
     ) {
         Page<DangerDto.DangerListRes> result = orderService.findDangerOrders(
-                startDate, endDate, keyword,
-                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+                startDate, endDate, keyword, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+
         return ResponseEntity.ok(BaseResponse.success(PageResponse.from(result)));
     }
 
@@ -144,7 +153,8 @@ public class OrdersController {
     )
     @GetMapping("/{ordersIdx}")
     public ResponseEntity ordersDetail(
-            @Parameter(description = "발주 고유 ID") @PathVariable Long ordersIdx
+            @Parameter(description = "발주 고유 ID", examples = {@ExampleObject(name = "정상 (존재하는 발주)", value = "1"), @ExampleObject(name = "NOT_FOUND_ORDERS (없는 발주)", value = "99999")})
+            @PathVariable Long ordersIdx
     ) {
         OrdersDto.OrdersRes result = orderService.findById(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success(result));
@@ -171,7 +181,15 @@ public class OrdersController {
             description = "본사가 이상 발주 판정 기준 변경. 변경 후 새 발주 부터 적용."
     )
     @PutMapping("/danger")
-    public ResponseEntity save(@RequestBody DangerDto.DangerReq req) {
+    public ResponseEntity save(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(examples = {
+                            @ExampleObject(name = "기본 (200% 초과 / 3개월 평균)", value = "{\"ratio\":200,\"period\":3}"),
+                            @ExampleObject(name = "엄격 (50% 초과 / 6개월 평균)", value = "{\"ratio\":50,\"period\":6}")}
+                    )
+            )
+            @RequestBody DangerDto.DangerReq req
+    ) {
         orderService.save(req);
         return ResponseEntity.ok(BaseResponse.success("update success"));
     }
@@ -181,11 +199,19 @@ public class OrdersController {
      */
     @Operation(
             summary = "발주 승인",
-            description = "본사가 특정 발주 단건 승인."
+            description = "본사가 특정 발주 단건 승인. CONFIRMED 상태인 발주만 승인 가능."
     )
     @PutMapping("/{ordersIdx}/approve")
     public ResponseEntity approve(
-            @Parameter(description = "승인할 발주 ID") @PathVariable Long ordersIdx
+            @Parameter(
+                    description = "승인할 발주 ID (CONFIRMED 상태인 발주만 승인 가능)",
+                    examples = {
+                            @ExampleObject(name = "정상 (CONFIRMED 발주)", value = "16"),
+                            @ExampleObject(name = "ORDERS_INVALID_STATUS (다른 상태)", value = "1"),
+                            @ExampleObject(name = "NOT_FOUND_ORDERS (없는 발주)", value = "99999")
+                    }
+            )
+            @PathVariable Long ordersIdx
     ) {
         orderService.approve(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
@@ -196,11 +222,19 @@ public class OrdersController {
      */
     @Operation(
             summary = "발주 반려",
-            description = "본사가 특정 발주 단건 반려."
+            description = "본사가 특정 발주 단건 반려. CONFIRMED 상태인 발주만 반려 가능."
     )
     @PutMapping("/{ordersIdx}/reject")
     public ResponseEntity reject(
-            @Parameter(description = "반려할 발주 ID") @PathVariable Long ordersIdx
+            @Parameter(
+                    description = "반려할 발주 ID (CONFIRMED 상태인 발주만 반려 가능)",
+                    examples = {
+                            @ExampleObject(name = "정상 (CONFIRMED 발주)", value = "16"),
+                            @ExampleObject(name = "ORDERS_INVALID_STATUS (다른 상태)", value = "1"),
+                            @ExampleObject(name = "NOT_FOUND_ORDERS (없는 발주)", value = "99999")
+                    }
+            )
+            @PathVariable Long ordersIdx
     ) {
         orderService.reject(ordersIdx);
         return ResponseEntity.ok(BaseResponse.success("update success"));
@@ -211,10 +245,25 @@ public class OrdersController {
      */
     @Operation(
             summary = "가맹점 수동 발주 생성",
-            description = "가맹점 사용자가 직접 발주 작성. 인증 필요 (401)."
+            description = "가맹점 사용자가 직접 발주 작성. 인증 필요."
     )
     @PostMapping("/store/reg/manual")
-    public ResponseEntity createStoreManualOrder(@AuthenticationPrincipal AuthUserDetails authUserDetails, @RequestBody OrdersDto.OrdersReq req) {
+    public ResponseEntity createStoreManualOrder(
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(name = "정상 (항목 3개)",
+                                            value = "{\"ordersItemList\":[{\"productIdx\":1,\"count\":10},{\"productIdx\":4,\"count\":5},{\"productIdx\":7,\"count\":3}]}"),
+                                    @ExampleObject(name = "ORDERS_ITEMS_EMPTY (빈 항목)",
+                                            value = "{\"ordersItemList\":[]}"),
+                                    @ExampleObject(name = "NOT_FOUND_PRODUCT (없는 상품)",
+                                            value = "{\"ordersItemList\":[{\"productIdx\":99999,\"count\":10}]}")
+                            }
+                    )
+            )
+            @RequestBody OrdersDto.OrdersReq req
+    ) {
         if (authUserDetails == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
         }
@@ -227,7 +276,7 @@ public class OrdersController {
      */
     @Operation(
             summary = "가맹점 제안 발주서 조회",
-            description = "현재 가맹점의 진행 중인 자동 발주 목록 (제안 상태). 인증 필요 (401)."
+            description = "현재 가맹점의 진행 중인 자동 발주 목록 (제안 상태). 인증 필요."
     )
     @GetMapping("/store/find")
     public ResponseEntity storeFind(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
@@ -243,12 +292,21 @@ public class OrdersController {
      */
     @Operation(
             summary = "가맹점 제안 발주서 확정",
-            description = "가맹점이 자동 발주 제안을 확정. 인증 필요 (401)."
+            description = "가맹점이 자동 발주 제안을 확정. WAITING 상태인 자신의 발주만 확정 가능."
     )
     @PutMapping("/store/{ordersIdx}/confirm")
     public ResponseEntity confirmStoreOrder(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
-            @Parameter(description = "확정할 발주 ID") @PathVariable Long ordersIdx
+            @Parameter(
+                    description = "확정할 발주 ID (WAITING 상태인 자신의 발주만 확정 가능)",
+                    examples = {
+                            @ExampleObject(name = "정상 (WAITING + 본인 매장)", value = "2"),
+                            @ExampleObject(name = "ORDERS_NOT_AUTHORIZED (다른 매장)", value = "100"),
+                            @ExampleObject(name = "ORDERS_INVALID_STATUS (WAITING 아님)", value = "1"),
+                            @ExampleObject(name = "NOT_FOUND_ORDERS (없는 발주)", value = "99999")
+                    }
+            )
+            @PathVariable Long ordersIdx
     ) {
         if (authUserDetails == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
@@ -262,12 +320,28 @@ public class OrdersController {
      */
     @Operation(
             summary = "가맹점 제안 발주서 항목 추가",
-            description = "가맹점이 자동 발주 제안에 항목 추가. 인증 필요 (401)."
+            description = "가맹점이 자동 발주 제안에 항목 추가. 자신의 발주만 수정 가능."
     )
     @PostMapping("/store/{ordersIdx}/items")
     public ResponseEntity addStoreItem(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
-            @Parameter(description = "항목 추가할 발주 ID") @PathVariable Long ordersIdx,
+            @Parameter(
+                    description = "항목 추가할 발주 ID",
+                    examples = {
+                            @ExampleObject(name = "정상 (본인 매장 발주)", value = "2"),
+                            @ExampleObject(name = "ORDERS_NOT_AUTHORIZED (다른 매장)", value = "100"),
+                            @ExampleObject(name = "NOT_FOUND_ORDERS (없는 발주)", value = "99999")
+                    }
+            )
+            @PathVariable Long ordersIdx,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(name = "정상 (원두 10개 추가)", value = "{\"productIdx\":1,\"count\":10}"),
+                                    @ExampleObject(name = "NOT_FOUND_PRODUCT (없는 상품)", value = "{\"productIdx\":99999,\"count\":10}")
+                            }
+                    )
+            )
             @RequestBody OrdersItemDto.OrdersItemReq req
     ) {
         if (authUserDetails == null) {
@@ -282,12 +356,28 @@ public class OrdersController {
      */
     @Operation(
             summary = "가맹점 발주 항목 수량 수정",
-            description = "가맹점이 제안 발주서 항목의 수량 변경. 인증 필요 (401)."
+            description = "가맹점이 제안 발주서 항목의 수량 변경. 자신의 발주만 수정 가능."
     )
     @PutMapping("/store/{ordersItemIdx}/items")
     public ResponseEntity updateStoreItemCount(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
-            @Parameter(description = "수정할 발주 항목 ID") @PathVariable Long ordersItemIdx,
+            @Parameter(
+                    description = "수정할 발주 항목 ID",
+                    examples = {
+                            @ExampleObject(name = "정상 (본인 매장 항목)", value = "1"),
+                            @ExampleObject(name = "ORDERS_NOT_AUTHORIZED (다른 매장 항목)", value = "500"),
+                            @ExampleObject(name = "NOT_FOUND_ORDERS_ITEM (없는 항목)", value = "99999")
+                    }
+            )
+            @PathVariable Long ordersItemIdx,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(name = "정상 (수량 20개로 변경)", value = "{\"count\":20}"),
+                                    @ExampleObject(name = "수량 0", value = "{\"count\":0}")
+                            }
+                    )
+            )
             @RequestBody OrdersItemDto.OrdersItemReq req
     ) {
         if (authUserDetails == null) {
@@ -302,12 +392,20 @@ public class OrdersController {
      */
     @Operation(
             summary = "가맹점 발주 항목 삭제",
-            description = "가맹점이 제안 발주서 항목 제거. 인증 필요 (401)."
+            description = "가맹점이 제안 발주서 항목 제거. 자신의 발주만 수정 가능."
     )
     @DeleteMapping("/store/{ordersItemIdx}/items")
     public ResponseEntity deleteStoreItem(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
-            @Parameter(description = "삭제할 발주 항목 ID") @PathVariable Long ordersItemIdx
+            @Parameter(
+                    description = "삭제할 발주 항목 ID",
+                    examples = {
+                            @ExampleObject(name = "정상 (본인 매장 항목)", value = "1"),
+                            @ExampleObject(name = "ORDERS_NOT_AUTHORIZED (다른 매장 항목)", value = "500"),
+                            @ExampleObject(name = "NOT_FOUND_ORDERS_ITEM (없는 항목)", value = "99999")
+                    }
+            )
+            @PathVariable Long ordersItemIdx
     ) {
         if (authUserDetails == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
@@ -321,12 +419,21 @@ public class OrdersController {
      */
     @Operation(
             summary = "가맹점 제안 발주서 거절",
-            description = "가맹점이 자동 발주 제안 자체를 거절. 인증 필요 (401)."
+            description = "가맹점이 자동 발주 제안 자체를 거절. WAITING 상태인 자신의 발주만 거절 가능."
     )
     @PutMapping("/store/{ordersIdx}/reject")
     public ResponseEntity rejectStoreOrder(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
-            @Parameter(description = "거절할 발주 ID") @PathVariable Long ordersIdx
+            @Parameter(
+                    description = "거절할 발주 ID (WAITING 상태인 자신의 발주만 거절 가능)",
+                    examples = {
+                            @ExampleObject(name = "정상 (WAITING + 본인 매장)", value = "2"),
+                            @ExampleObject(name = "ORDERS_NOT_AUTHORIZED (다른 매장)", value = "100"),
+                            @ExampleObject(name = "ORDERS_INVALID_STATUS (WAITING 아님)", value = "1"),
+                            @ExampleObject(name = "NOT_FOUND_ORDERS (없는 발주)", value = "99999")
+                    }
+            )
+            @PathVariable Long ordersIdx
     ) {
         if (authUserDetails == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
@@ -340,7 +447,7 @@ public class OrdersController {
      */
     @Operation(
             summary = "가맹점 발주 이력 조회",
-            description = "현재 가맹점의 발주 이력 (페이징). 인증 필요 (401)."
+            description = "현재 가맹점의 발주 이력 (페이징). 인증 필요."
     )
     @GetMapping("/store/list/paged")
     public ResponseEntity storeListPaged(
@@ -360,12 +467,21 @@ public class OrdersController {
      */
     @Operation(
             summary = "가맹점 발주 취소",
-            description = "가맹점이 본인 발주 취소. 인증 필요 (401)."
+            description = "가맹점이 본인 발주 취소. CONFIRMED 상태인 자신의 발주만 취소 가능."
     )
     @PutMapping("/store/{ordersIdx}/cancel")
     public ResponseEntity cancel(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
-            @Parameter(description = "취소할 발주 ID") @PathVariable Long ordersIdx
+            @Parameter(
+                    description = "취소할 발주 ID (CONFIRMED 상태인 자신의 발주만 취소 가능)",
+                    examples = {
+                            @ExampleObject(name = "정상 (CONFIRMED + 본인 매장)", value = "16"),
+                            @ExampleObject(name = "ORDERS_NOT_AUTHORIZED (다른 매장)", value = "100"),
+                            @ExampleObject(name = "ORDERS_INVALID_STATUS (CONFIRMED 아님)", value = "2"),
+                            @ExampleObject(name = "NOT_FOUND_ORDERS (없는 발주)", value = "99999")
+                    }
+            )
+            @PathVariable Long ordersIdx
     ) {
         if (authUserDetails == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");

--- a/backend/monolith/src/main/java/com/example/nexus/domain/orders/OrdersController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/orders/OrdersController.java
@@ -36,7 +36,7 @@ public class OrdersController {
     private final OrdersService orderService;
     private final RestTemplate restTemplate;
 
-    @Value("${batch.service.url:http://batch-service:8090}")
+    @Value("${batch.service.url:http://localhost:8090}")
     private String batchServiceUrl;
 
     /**

--- a/backend/monolith/src/main/java/com/example/nexus/domain/orders/OrdersService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/orders/OrdersService.java
@@ -140,7 +140,7 @@ public class OrdersService {
     // 발주 상세 조회 (단건)
     public OrdersDto.OrdersRes findById(Long ordersIdx) {
         Orders orders = ordersRepository.findByIdWithDetails(ordersIdx).orElseThrow(
-                () -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS));
         return OrdersDto.OrdersRes.from(orders);
     }
 
@@ -192,10 +192,10 @@ public class OrdersService {
     @Transactional
     public void approve(Long ordersIdx) {
         Orders orders = ordersRepository.findByIdWithDetailsForUpdate(ordersIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS));
 
         if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_INVALID_STATUS);
         }
 
         applyOutboundForOrder(orders, "발주 승인(이상) ordersIdx=");
@@ -208,10 +208,10 @@ public class OrdersService {
     @Transactional
     public void reject(Long ordersIdx) {
         Orders orders = ordersRepository.findByIdForUpdate(ordersIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS));
 
         if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_INVALID_STATUS);
         }
 
         orders.reject();
@@ -253,7 +253,7 @@ public class OrdersService {
         Long storeIdx = orders.getStore().getIdx();
         List<OrdersItem> items = orders.getOrdersItemList();
         if (items == null || items.isEmpty()) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_ITEMS_EMPTY);
         }
         String memo = memoPrefix + orders.getIdx();
         for (OrdersItem item : items) {
@@ -297,12 +297,12 @@ public class OrdersService {
     public void createStoreManualOrder(Long userIdx, OrdersDto.OrdersReq req) {
         // 1. 주문 아이템 리스트 검증
         if (req.getOrdersItemList() == null || req.getOrdersItemList().isEmpty()) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_ITEMS_EMPTY);
         }
 
         // 2. 인증 정보로 매장 조회
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         // 3. Product 조회 및 총 가격 계산
         long totalPrice = 0;
@@ -310,7 +310,7 @@ public class OrdersService {
 
         for (OrdersItemDto.OrdersItemReq itemReq : req.getOrdersItemList()) {
             Product product = productRepository.findById(itemReq.getProductIdx())
-                    .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                    .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_PRODUCT));
 
             totalPrice += (long) product.getUnitPrice() * itemReq.getCount();
 
@@ -365,7 +365,7 @@ public class OrdersService {
     // 점주 - 제안 발주서 목록 조회 (WAITING 상태, 현재 재고 포함)
     public List<OrdersDto.OrdersRes> findByUserIdxAndOrdersStatus(Long userIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         List<StoreInventory> inventoryList = storeInventoryRepository.findByStoreIdx(store.getIdx());
         Map<Long, Integer> stockMap = new HashMap<>();
@@ -387,17 +387,17 @@ public class OrdersService {
     @Transactional
     public void confirmStoreOrder(Long userIdx, Long ordersIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         Orders orders = ordersRepository.findByIdWithDetailsForUpdate(ordersIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS));
 
         if (!orders.getStore().getIdx().equals(store.getIdx())) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_NOT_AUTHORIZED);
         }
 
         if (orders.getOrdersStatus() != OrdersStatus.WAITING) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_INVALID_STATUS);
         }
 
         // 점주가 아이템을 수정했을 수 있으므로 확정 시점에 가격 재계산
@@ -431,17 +431,17 @@ public class OrdersService {
     @Transactional
     public void addStoreItem(Long userIdx, Long ordersIdx, OrdersItemDto.OrdersItemReq req) {
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         Orders orders = ordersRepository.findByIdForUpdate(ordersIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS));
 
         if (!orders.getStore().getIdx().equals(store.getIdx())) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_NOT_AUTHORIZED);
         }
 
         Product product = productRepository.findById(req.getProductIdx())
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_PRODUCT));
 
         ordersItemRepository.save(OrdersItem.builder()
                 .count(req.getCount())
@@ -456,17 +456,17 @@ public class OrdersService {
     @Transactional
     public void updateStoreItemCount(Long userIdx, Long ordersItemIdx, Integer count) {
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS_ITEM));
 
         if (!item.getOrders().getStore().getIdx().equals(store.getIdx())) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_NOT_AUTHORIZED);
         }
 
         Orders orders = ordersRepository.findByIdForUpdate(item.getOrders().getIdx())
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS));
         item.updateCount(count);
         recalculatePrice(orders);
     }
@@ -475,17 +475,17 @@ public class OrdersService {
     @Transactional
     public void deleteStoreItem(Long userIdx, Long ordersItemIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         OrdersItem item = ordersItemRepository.findById(ordersItemIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS_ITEM));
 
         if (!item.getOrders().getStore().getIdx().equals(store.getIdx())) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_NOT_AUTHORIZED);
         }
 
         Orders orders = ordersRepository.findByIdForUpdate(item.getOrders().getIdx())
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS));
         ordersItemRepository.delete(item);
         ordersItemRepository.flush();
         recalculatePrice(orders);
@@ -495,17 +495,17 @@ public class OrdersService {
     @Transactional
     public void rejectStoreOrder(Long userIdx, Long ordersIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         Orders orders = ordersRepository.findById(ordersIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS));
 
         if (!orders.getStore().getIdx().equals(store.getIdx())) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_NOT_AUTHORIZED);
         }
 
         if (orders.getOrdersStatus() != OrdersStatus.WAITING) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_INVALID_STATUS);
         }
 
         orders.reject();
@@ -514,7 +514,7 @@ public class OrdersService {
     // 점주 - 발주 이력 페이징 조회 (확정/승인/반려/취소)
     public Page<OrdersDto.OrdersRes> findByUserIdxPaged(Long userIdx, Pageable pageable) {
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         return ordersRepository.findAllByStore_IdxAndOrdersStatusIn(
                 store.getIdx(),
@@ -527,17 +527,17 @@ public class OrdersService {
     @Transactional
     public void cancelOrder(Long userIdx, Long ordersIdx) {
         Store store = storeRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.STORE_NOT_FOUND));
 
         Orders orders = ordersRepository.findByIdForUpdate(ordersIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_DATA));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_ORDERS));
 
         if (!orders.getStore().getIdx().equals(store.getIdx())) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_NOT_AUTHORIZED);
         }
 
         if (orders.getOrdersStatus() != OrdersStatus.CONFIRMED) {
-            throw new BaseException(BaseResponseStatus.REQUEST_ERROR);
+            throw new BaseException(BaseResponseStatus.ORDERS_INVALID_STATUS);
         }
 
         orders.cancel();

--- a/backend/monolith/src/main/resources/seed-dev.sql
+++ b/backend/monolith/src/main/resources/seed-dev.sql
@@ -1,0 +1,706 @@
+-- ============================================================
+-- Nexus Monolith 로컬 dev seed
+-- 매장 100개 + 30일치 결제 + 발주 + 알림 (store0001 집중)
+-- ============================================================
+-- 실행:
+--   docker exec -i <monolith-mariadb> mariadb -uroot -p<pw> nexus < seed-dev.sql
+--   또는 IntelliJ DB tool 에서 직접 실행
+-- 멱등성: 여러 번 실행 안전 (기존 시드 정리 후 재생성)
+-- 비밀번호: 모두 password123 (bcrypt)
+-- 로그인:
+--   본사: admin@theventi.co.kr / password123
+--   점주: store0001@theventi.co.kr ~ store0100@theventi.co.kr / password123
+-- ============================================================
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- 기존 시드 정리 (TRUNCATE: 전체 + AUTO_INCREMENT 리셋)
+TRUNCATE TABLE delivery;
+TRUNCATE TABLE store_notification;
+TRUNCATE TABLE head_notification;
+TRUNCATE TABLE pos_orders_item;
+TRUNCATE TABLE pos_pay;
+TRUNCATE TABLE orders_item;
+TRUNCATE TABLE orders;
+TRUNCATE TABLE store_inventory;
+TRUNCATE TABLE pos_store_inventory;
+TRUNCATE TABLE head_inventory;
+TRUNCATE TABLE menu_item;
+TRUNCATE TABLE menu;
+TRUNCATE TABLE menu_category;
+TRUNCATE TABLE product;
+TRUNCATE TABLE category;
+TRUNCATE TABLE store;
+TRUNCATE TABLE user;
+
+-- TRUNCATE 가 AUTO_INCREMENT 자동 리셋
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+
+-- ============================================================
+-- 1. 본사 유저 1명 (admin@theventi.co.kr, password=password123)
+-- ============================================================
+INSERT INTO user (email, password, user_name, tel, role, is_deleted) VALUES
+('admin@theventi.co.kr', '{bcrypt}$2b$10$lvGJMgshX87086lRcSRGT.NXXzXyKXIXc2PgpAgAeK10LKeWfW2MS',
+ '본사 관리자', '010-0000-0001', 'ADMIN', false);
+
+
+-- ============================================================
+-- 2. 가맹점 유저 100명 + 매장 100개 (store0001 ~ store0100)
+-- ============================================================
+DELIMITER $$
+DROP PROCEDURE IF EXISTS seed_stores$$
+CREATE PROCEDURE seed_stores()
+BEGIN
+    DECLARE i INT DEFAULT 1;
+    DECLARE user_id BIGINT;
+    DECLARE pw VARCHAR(255) DEFAULT '{bcrypt}$2b$10$lvGJMgshX87086lRcSRGT.NXXzXyKXIXc2PgpAgAeK10LKeWfW2MS';
+
+    WHILE i <= 100 DO
+        -- 가맹점 유저
+        INSERT INTO user (email, password, user_name, tel, role, is_deleted) VALUES (
+            CONCAT('store', LPAD(i, 4, '0'), '@theventi.co.kr'),
+            pw,
+            CONCAT('점주', LPAD(i, 4, '0')),
+            CONCAT('010-1', LPAD(i, 4, '0'), '-0000'),
+            'STORE',
+            false
+        );
+        SET user_id = LAST_INSERT_ID();
+
+        -- 매장 (더벤티 <지역명>점, 100개 실제 지역)
+        INSERT INTO store (
+            store_name, address, address_detail, file_path,
+            business, postcode, created_at, is_deleted, user_idx
+        ) VALUES (
+            CONCAT('더벤티 ', ELT(i,
+                '강남','강동','강서','강북','관악','광진','구로','금천','노원','도봉',
+                '동대문','동작','마포','서대문','서초','성동','성북','송파','양천','영등포',
+                '용산','은평','종로','서울중구','중랑',
+                '수원','성남','고양','용인','부천','안산','안양','평택','시흥','광명',
+                '의정부','김포','화성','남양주','군포',
+                '해운대','부산진','동래','사상','부산강서','사하','금정','기장','부산남구','부산북구',
+                '대구중구','수성','달서','달성','대구동구',
+                '인천중구','미추홀','연수','남동','부평',
+                '광주북구','광주서구','광주남구',
+                '대전유성','대전서구','대전동구',
+                '울산남구','울산동구','울산북구',
+                '세종',
+                '제주','서귀포',
+                '춘천','원주','강릉','속초','평창',
+                '청주','충주','제천',
+                '천안','아산','공주','서산',
+                '포항','경주','안동','구미',
+                '창원','김해','진주','양산',
+                '전주','군산','익산',
+                '여수','순천','목포',
+                '김포공항','시청'
+            ), '점'),
+            CONCAT('서울 강남구 테헤란로 ', i, '길'),
+            CONCAT(i, '층'),
+            'store-default.png',
+            CONCAT('100-00-', LPAD(i, 5, '0')),
+            LPAD(i, 5, '0'),
+            DATE_SUB(NOW(), INTERVAL (100 - i) DAY),
+            false,
+            user_id
+        );
+        SET i = i + 1;
+    END WHILE;
+END$$
+DELIMITER ;
+
+CALL seed_stores();
+DROP PROCEDURE seed_stores;
+
+
+-- ============================================================
+-- 3. 메뉴 카테고리 4개 + 메뉴 15개
+-- ============================================================
+INSERT INTO menu_category (menu_category_name, is_deleted) VALUES
+('음료', false),    -- idx 1
+('디저트', false),  -- idx 2
+('베이커리', false),-- idx 3
+('푸드', false);    -- idx 4
+
+INSERT INTO menu (menu_name, price, img_path, is_deleted, menu_category_idx) VALUES
+-- 음료 (5)
+('아메리카노',        3000, 'menu-default.png', false, 1),
+('카페라떼',          4000, 'menu-default.png', false, 1),
+('카푸치노',          4500, 'menu-default.png', false, 1),
+('바닐라라떼',        4500, 'menu-default.png', false, 1),
+('자몽에이드',        5500, 'menu-default.png', false, 1),
+-- 디저트 (3)
+('티라미수',          6000, 'menu-default.png', false, 2),
+('치즈케이크',        6500, 'menu-default.png', false, 2),
+('마카롱',            2500, 'menu-default.png', false, 2),
+-- 베이커리 (4)
+('크로와상',          3500, 'menu-default.png', false, 3),
+('소금빵',            3000, 'menu-default.png', false, 3),
+('초코머핀',          3500, 'menu-default.png', false, 3),
+('베이글',            4000, 'menu-default.png', false, 3),
+-- 푸드 (3)
+('샌드위치',          7000, 'menu-default.png', false, 4),
+('파니니',            8000, 'menu-default.png', false, 4),
+('샐러드',            8500, 'menu-default.png', false, 4);
+
+
+-- ============================================================
+-- 4. 본사 상품 카테고리 (재료) + 상품
+-- ============================================================
+INSERT INTO category (category_name, is_deleted) VALUES
+('원두',        false),  -- idx 1
+('유제품',      false),  -- idx 2
+('베이커리재료',false),  -- idx 3
+('과일/시럽',   false),  -- idx 4
+('식자재',      false);  -- idx 5
+
+INSERT INTO product (
+    product_name, product_unit, max_stock, min_stock, unit_price, danger_days, is_deleted, category_idx
+) VALUES
+-- 원두 (3)
+('원두 A',     'kg', 50,  10, 25000, '7',  false, 1),
+('원두 B',     'kg', 50,  10, 28000, '7',  false, 1),
+('디카페인',   'kg', 30,   5, 32000, '7',  false, 1),
+-- 유제품 (3)
+('우유',       'L',  100, 20,  3500, '3',  false, 2),
+('두유',       'L',  50,  10,  4500, '5',  false, 2),
+('생크림',     'L',  30,   5,  6500, '3',  false, 2),
+-- 베이커리재료 (4)
+('밀가루',     'kg', 100, 20,  4500, '14', false, 3),
+('버터',       'kg', 50,  10, 15000, '7',  false, 3),
+('초콜릿',     'kg', 30,   5, 18000, '14', false, 3),
+('치즈',       'kg', 30,   5, 22000, '7',  false, 3),
+-- 과일/시럽 (3)
+('자몽',       'kg', 30,   5,  8000, '5',  false, 4),
+('바닐라시럽', 'L',  30,   5, 12000, '30', false, 4),
+('초콜릿시럽', 'L',  30,   5, 11000, '30', false, 4),
+-- 식자재 (2)
+('빵',         'EA', 100, 20,  1500, '3',  false, 5),
+('샐러드믹스', 'kg', 30,   5,  9000, '3',  false, 5);
+
+
+-- ============================================================
+-- 4-1. 메뉴 레시피 (menu_item) — 메뉴 15개가 product 1~15 만 참조
+-- POS 결제 시 menu → menu_item → product 차감 (pos_store_inventory FIFO)
+-- ============================================================
+INSERT INTO menu_item (menu_idx, product_idx, quantity, menu_unit) VALUES
+-- 1. 아메리카노: 원두A 20g
+(1, 1, 20, 'g'),
+-- 2. 카페라떼: 원두A 20g, 우유 200ml
+(2, 1, 20, 'g'),
+(2, 4, 200, 'ml'),
+-- 3. 카푸치노: 원두A 20g, 우유 150ml
+(3, 1, 20, 'g'),
+(3, 4, 150, 'ml'),
+-- 4. 바닐라라떼: 원두A 20g, 우유 200ml, 바닐라시럽 20ml
+(4, 1, 20, 'g'),
+(4, 4, 200, 'ml'),
+(4, 12, 20, 'ml'),
+-- 5. 자몽에이드: 자몽 30g
+(5, 11, 30, 'g'),
+-- 6. 티라미수: 우유 50ml, 초콜릿 20g, 빵 1ea
+(6, 4, 50, 'ml'),
+(6, 9, 20, 'g'),
+(6, 14, 1, 'EA'),
+-- 7. 치즈케이크: 치즈 30g, 빵 1ea
+(7, 10, 30, 'g'),
+(7, 14, 1, 'EA'),
+-- 8. 마카롱: 초콜릿 10g
+(8, 9, 10, 'g'),
+-- 9. 크로와상: 밀가루 50g, 버터 10g
+(9, 7, 50, 'g'),
+(9, 8, 10, 'g'),
+-- 10. 소금빵: 밀가루 50g, 버터 5g
+(10, 7, 50, 'g'),
+(10, 8, 5, 'g'),
+-- 11. 초코머핀: 밀가루 30g, 초콜릿 15g, 우유 30ml
+(11, 7, 30, 'g'),
+(11, 9, 15, 'g'),
+(11, 4, 30, 'ml'),
+-- 12. 베이글: 밀가루 60g
+(12, 7, 60, 'g'),
+-- 13. 샌드위치: 빵 1ea, 치즈 20g, 샐러드믹스 20g
+(13, 14, 1, 'EA'),
+(13, 10, 20, 'g'),
+(13, 15, 20, 'g'),
+-- 14. 파니니: 빵 1ea, 치즈 30g, 샐러드믹스 15g
+(14, 14, 1, 'EA'),
+(14, 10, 30, 'g'),
+(14, 15, 15, 'g'),
+-- 15. 샐러드: 샐러드믹스 50g, 치즈 10g
+(15, 15, 50, 'g'),
+(15, 10, 10, 'g');
+
+
+-- ============================================================
+-- 5. 매장별 재고 (pos_store_inventory) — 매장당 상품 15개씩, 다양한 상태
+-- 일부 매장 일부 상품 LOW/CRITICAL 분포
+-- ============================================================
+DELIMITER $$
+DROP PROCEDURE IF EXISTS seed_inventory$$
+CREATE PROCEDURE seed_inventory()
+BEGIN
+    DECLARE s INT DEFAULT 1;
+    DECLARE p INT;
+    DECLARE qty INT;
+    DECLARE st VARCHAR(20);
+
+    WHILE s <= 100 DO
+        SET p = 1;
+        WHILE p <= 15 DO
+            -- 결정적이지만 다양한 분포 (매장 + 상품 idx 기반)
+            -- NORMAL: 충분 (1500~2000), LOW/CRITICAL 만 위험 표시용
+            SET qty = 1500 + ((s * 7 + p * 13) % 500);  -- 1500~2000 정상 (재고 풍부)
+            SET st = 'NORMAL';
+
+            -- 분포: CRITICAL ~10%, LOW ~14% (위험 표시용 — 결제는 NORMAL 매장만)
+            IF (s + p) % 10 = 0 THEN
+                SET qty = 5;
+                SET st = 'CRITICAL';
+            ELSEIF (s + p) % 7 = 0 THEN
+                SET qty = 15;
+                SET st = 'LOW';
+            END IF;
+
+            -- store0001 특별 처리: 위험 재고 표시 (LOW 3, CRITICAL 2)
+            -- 단 결제에 쓰이는 product (1,4,7,8,9,10,11,12,14,15) 는 NORMAL 충분 보장
+            -- 결제 미사용 product (2,3,5,6,13) 만 위험 표시
+            IF s = 1 THEN
+                IF p IN (2, 6) THEN
+                    SET qty = 3;
+                    SET st = 'CRITICAL';
+                ELSEIF p IN (3, 5, 13) THEN
+                    SET qty = 10;
+                    SET st = 'LOW';
+                ELSE
+                    SET qty = 2000;
+                    SET st = 'NORMAL';
+                END IF;
+            END IF;
+
+            INSERT INTO pos_store_inventory (
+                count, status, manufactured_date, store_idx, product_idx
+            ) VALUES (
+                qty,
+                st,
+                DATE_SUB(NOW(), INTERVAL ((s + p) % 5) DAY),
+                s,
+                p
+            );
+
+            SET p = p + 1;
+        END WHILE;
+        SET s = s + 1;
+    END WHILE;
+END$$
+DELIMITER ;
+
+CALL seed_inventory();
+DROP PROCEDURE seed_inventory;
+
+
+-- ============================================================
+-- 5-0. 가맹점 재고 (store_inventory) — 가맹점 대시보드 위험 재고 KPI/목록
+-- pos_store_inventory 와 별도 테이블 (pos = POS 결제 차감용, store = 위험도 추적 + 발주 관리)
+-- pos_store_inventory 데이터 그대로 복제 + avg_stock (평균 재고) 추가
+-- ============================================================
+INSERT INTO store_inventory (count, status, manufactured_date, avg_stock, store_idx, product_idx, orders_item_idx)
+SELECT
+    count,
+    status,
+    manufactured_date,
+    -- avg_stock = 정상 평균 (50, status 가 LOW/CRITICAL 이면 count 보다 큼 = 위험도 표시)
+    CASE
+        WHEN status = 'CRITICAL' THEN 50
+        WHEN status = 'LOW'      THEN 40
+        ELSE count
+    END AS avg_stock,
+    store_idx,
+    product_idx,
+    NULL  -- orders_item_idx: 시드는 발주 추적 X
+FROM pos_store_inventory;
+
+
+-- ============================================================
+-- 5-1. 본사 재고 (head_inventory) — 본사 대시보드 KPI + 목록 데이터
+-- product 15개 각각 1~3건 (NORMAL/LOW/CRITICAL 분포)
+-- ============================================================
+-- product 당 head_inventory 1건만 (findByProductIdxForUpdate 가 unique 1건 기대)
+-- count 는 모두 2000 (출고 가능 충분) + status 만 다양 (위험도 표시용)
+INSERT INTO head_inventory (count, status, manufactured_date, product_idx) VALUES
+(2000, 'NORMAL',   DATE_SUB(NOW(), INTERVAL 2 DAY),  1),
+(2000, 'NORMAL',   DATE_SUB(NOW(), INTERVAL 3 DAY),  2),
+(2000, 'LOW',      DATE_SUB(NOW(), INTERVAL 8 DAY),  3),   -- LOW 표시
+(2000, 'NORMAL',   DATE_SUB(NOW(), INTERVAL 4 DAY),  4),
+(2000, 'NORMAL',   DATE_SUB(NOW(), INTERVAL 5 DAY),  5),
+(2000, 'LOW',      DATE_SUB(NOW(), INTERVAL 9 DAY),  6),   -- LOW 표시
+(2000, 'CRITICAL', DATE_SUB(NOW(), INTERVAL 15 DAY), 7),   -- CRITICAL 표시
+(2000, 'LOW',      DATE_SUB(NOW(), INTERVAL 10 DAY), 8),   -- LOW 표시
+(2000, 'CRITICAL', DATE_SUB(NOW(), INTERVAL 16 DAY), 9),   -- CRITICAL 표시
+(2000, 'CRITICAL', DATE_SUB(NOW(), INTERVAL 13 DAY), 10),  -- CRITICAL 표시
+(2000, 'LOW',      DATE_SUB(NOW(), INTERVAL 11 DAY), 11),  -- LOW 표시
+(2000, 'CRITICAL', DATE_SUB(NOW(), INTERVAL 18 DAY), 12),  -- CRITICAL 표시
+(2000, 'LOW',      DATE_SUB(NOW(), INTERVAL 12 DAY), 13),  -- LOW 표시
+(2000, 'CRITICAL', DATE_SUB(NOW(), INTERVAL 14 DAY), 14),  -- CRITICAL 표시
+(2000, 'NORMAL',   DATE_SUB(NOW(), INTERVAL 6 DAY),  15);
+
+
+-- ============================================================
+-- 6. 결제 (pos_pay + pos_orders_item) — 30일치, 매장당 일 5건
+-- 시간대 분산: 09, 12, 15, 18, 21시
+-- 금액 결정적 (매장 + 일자 + 건 번호 기반) → 통계 MSA daily_*_sales 와 일치 위해
+-- ============================================================
+DELIMITER $$
+DROP PROCEDURE IF EXISTS seed_payments$$
+CREATE PROCEDURE seed_payments()
+BEGIN
+    DECLARE d INT DEFAULT 0;       -- 0 = 오늘, 1~30 = 어제부터
+    DECLARE s INT;                 -- store idx
+    DECLARE i INT;                 -- pay idx (1~5)
+    DECLARE hr INT;                -- 시간대
+    DECLARE amount BIGINT;
+    DECLARE method VARCHAR(10);
+    DECLARE pay_id BIGINT;
+    DECLARE menu_id INT;
+    DECLARE qty INT;
+
+    WHILE d <= 30 DO
+        SET s = 1;
+        WHILE s <= 100 DO
+            SET i = 1;
+            WHILE i <= 7 DO
+                -- 시간대: 09, 11, 13, 15, 17, 19, 21 (2시간 간격)
+                SET hr = CASE i WHEN 1 THEN 9 WHEN 2 THEN 11 WHEN 3 THEN 13 WHEN 4 THEN 15 WHEN 5 THEN 17 WHEN 6 THEN 19 ELSE 21 END;
+                -- 금액 결정적 (매장 idx, 일자, 건 번호 기반) — d 포함하여 일별 변동성
+                SET amount = 1000 + ((s * 100 + i * 1500 + d * 700) % 9001);  -- 1000 ~ 10000
+                -- 결제 수단 ~71% CARD, ~29% CASH
+                SET method = IF (i <= 5, 'CARD', 'CASH');
+
+                INSERT INTO pos_pay (method, paid_at, pay_amount, store_idx) VALUES (
+                    method,
+                    DATE_ADD(DATE_SUB(CURDATE(), INTERVAL d DAY), INTERVAL hr HOUR),
+                    amount,
+                    s
+                );
+                SET pay_id = LAST_INSERT_ID();
+
+                -- 결제마다 1~2개 메뉴 항목 (결정적)
+                SET menu_id = 1 + ((s + d + i) % 15);   -- 1~15
+                SET qty = 1 + (i % 2);                  -- 1 or 2
+                INSERT INTO pos_orders_item (quantity, menu_idx, pos_pay_idx) VALUES (qty, menu_id, pay_id);
+
+                -- 50% 결제는 메뉴 2개 (다양성)
+                IF i % 2 = 0 THEN
+                    SET menu_id = 1 + ((s + d + i + 7) % 15);
+                    INSERT INTO pos_orders_item (quantity, menu_idx, pos_pay_idx) VALUES (1, menu_id, pay_id);
+                END IF;
+
+                SET i = i + 1;
+            END WHILE;
+            SET s = s + 1;
+        END WHILE;
+        SET d = d + 1;
+    END WHILE;
+END$$
+DELIMITER ;
+
+CALL seed_payments();
+DROP PROCEDURE seed_payments;
+
+
+-- ============================================================
+-- 7. 발주 (orders + orders_item)
+-- store0001 집중 (50건) + 나머지 99 매장 각 2~3건 = 총 ~300건
+-- ============================================================
+DELIMITER $$
+DROP PROCEDURE IF EXISTS seed_orders$$
+CREATE PROCEDURE seed_orders()
+BEGIN
+    DECLARE i INT;
+    DECLARE s INT;
+    DECLARE d INT;
+    DECLARE order_type VARCHAR(20);
+    DECLARE order_status VARCHAR(20);
+    DECLARE total_price BIGINT;
+    DECLARE order_id BIGINT;
+    DECLARE p INT;
+    DECLARE cnt INT;
+    DECLARE is_danger BOOLEAN;
+    DECLARE reason_val VARCHAR(500);
+    DECLARE day_offset INT;
+
+    -- ========================================================
+    -- store0001 (store_idx=1) 50건 집중
+    -- status 분포 (10건씩): WAITING / APPROVE / REJECT / CONFIRMED / CANCELLED
+    -- is_danger 별도 분포: i%4=0 → 12건 (status 와 무관)
+    -- reason: AUTO + AI 추천 사유 / is_danger + 이상 발주 사유
+    -- created_at: i<=7 → 오늘 (대시보드 KPI 의미)
+    -- ========================================================
+    SET i = 1;
+    WHILE i <= 50 DO
+        -- 5건 묶음별 status (각 10건)
+        -- 단, 오늘 created_at 인 AUTO 는 모두 WAITING 으로 강제 (KPI = 목록 일치)
+        SET day_offset = IF (i <= 7, 0, i - 7);
+        IF i % 5 = 1 THEN
+            SET order_type = 'MANUAL'; SET order_status = 'CONFIRMED';
+        ELSEIF i % 5 = 2 THEN
+            SET order_type = 'AUTO';   SET order_status = 'WAITING';
+        ELSEIF i % 5 = 3 THEN
+            SET order_type = 'AUTO';
+            SET order_status = IF (day_offset = 0, 'WAITING', 'APPROVE');
+        ELSEIF i % 5 = 4 THEN
+            SET order_type = 'AUTO';
+            SET order_status = IF (day_offset = 0, 'WAITING', 'REJECT');
+        ELSE
+            SET order_type = 'MANUAL'; SET order_status = 'CANCELLED';
+        END IF;
+
+        -- is_danger 별도 (status 와 분리, ~24% 이상 발주)
+        SET is_danger = IF (i % 4 = 0, true, false);
+
+        -- reason: is_danger 또는 AUTO 면 사유 명시
+        IF is_danger THEN
+            SET reason_val = ELT(1 + (i % 3),
+                '평균 대비 200% 초과 - 이상 발주 감지',
+                '발주 패턴 이상 - 검토 필요',
+                '재고 급증 감지 - 확인 필요'
+            );
+        ELSEIF order_type = 'AUTO' THEN
+            SET reason_val = ELT(1 + (i % 5),
+                'AI 추천: 안전 재고 미달 감지',
+                'AI 추천: 발주 주기 도래',
+                'AI 추천: 재고 부족 예측',
+                'AI 추천: 평균 소비량 분석 기반',
+                'AI 추천: 계절성 수요 증가 예측'
+            );
+        ELSE
+            SET reason_val = NULL;
+        END IF;
+
+        -- 일부 발주 오늘 (i<=7), 나머지 i-7 일 전
+        SET day_offset = IF (i <= 7, 0, i - 7);
+        SET total_price = 50000 + (i * 1000);
+
+        INSERT INTO orders (
+            price, order_type, order_status, is_danger, reason, created_at, store_idx
+        ) VALUES (
+            total_price, order_type, order_status, is_danger, reason_val,
+            DATE_SUB(NOW(), INTERVAL day_offset DAY),
+            1
+        );
+        SET order_id = LAST_INSERT_ID();
+
+        -- 발주 항목 5개 (다양성)
+        SET p = 1;
+        WHILE p <= 5 DO
+            SET cnt = 5 + ((i + p) % 10);
+            -- processed: APPROVE 만 true (이미 처리 완료). CONFIRMED 는 false (batch 가 처리할 대상)
+            INSERT INTO orders_item (count, processed, orders_idx, product_idx) VALUES (
+                cnt,
+                IF (order_status = 'APPROVE', true, false),
+                order_id,
+                1 + ((i + p * 3) % 15)
+            );
+            SET p = p + 1;
+        END WHILE;
+        SET i = i + 1;
+    END WHILE;
+
+    -- ========================================================
+    -- 나머지 99 매장 각 3건 (s=2~100)
+    -- status 분포 다양화 (대시보드 그래프 의미)
+    -- 매장 % 7 = 0 → is_danger=true (14매장)
+    -- 매장 % 5 = 0 → created_at 오늘 (KPI 의미, 20매장)
+    -- ========================================================
+    SET s = 2;
+    WHILE s <= 100 DO
+        SET d = 1;
+        WHILE d <= 3 DO
+            -- order_type
+            SET order_type = IF (d <= 2, 'AUTO', 'MANUAL');
+
+            -- day_offset 먼저 계산 (매장 %5=0 인 20매장 → 오늘)
+            SET day_offset = IF (s % 5 = 0, 0, (s + d) % 30);
+
+            -- status 다양화 (오늘 created_at + AUTO 는 모두 WAITING — KPI = 목록 일치)
+            IF d = 1 THEN
+                IF day_offset = 0 THEN
+                    SET order_status = 'WAITING';
+                ELSE
+                    SET order_status = ELT(1 + (s % 5),
+                        'APPROVE', 'WAITING', 'REJECT', 'CONFIRMED', 'CANCELLED');
+                END IF;
+            ELSEIF d = 2 THEN
+                IF day_offset = 0 THEN
+                    SET order_status = 'WAITING';
+                ELSE
+                    SET order_status = ELT(1 + ((s + 1) % 4),
+                        'APPROVE', 'WAITING', 'CONFIRMED', 'REJECT');
+                END IF;
+            ELSE
+                -- d=3 는 MANUAL 이라 자동 발주 제안 KPI 와 무관
+                SET order_status = ELT(1 + ((s + 2) % 3),
+                    'CONFIRMED', 'APPROVE', 'CANCELLED');
+            END IF;
+
+            -- is_danger: 매장 idx % 7 = 0 (14매장) 의 d=1 발주
+            SET is_danger = IF (s % 7 = 0 AND d = 1, true, false);
+
+            -- reason
+            IF is_danger THEN
+                SET reason_val = '재고 급증 이상 감지';
+            ELSEIF order_type = 'AUTO' THEN
+                SET reason_val = ELT(1 + (s % 5),
+                    'AI 추천: 안전 재고 미달 감지',
+                    'AI 추천: 발주 주기 도래',
+                    'AI 추천: 재고 부족 예측',
+                    'AI 추천: 평균 소비량 분석',
+                    'AI 추천: 계절성 수요 증가'
+                );
+            ELSE
+                SET reason_val = NULL;
+            END IF;
+
+            -- created_at: 매장 % 5 = 0 인 20매장 → 오늘 (대시보드 KPI)
+            SET day_offset = IF (s % 5 = 0, 0, (s + d) % 30);
+
+            SET total_price = 30000 + (s * 100 + d * 1000);
+
+            INSERT INTO orders (price, order_type, order_status, is_danger, reason, created_at, store_idx) VALUES (
+                total_price, order_type, order_status, is_danger, reason_val,
+                DATE_SUB(NOW(), INTERVAL day_offset DAY),
+                s
+            );
+            SET order_id = LAST_INSERT_ID();
+
+            -- 항목 3개 (processed: APPROVE 만 true. CONFIRMED 는 false → batch 처리 대상)
+            INSERT INTO orders_item (count, processed, orders_idx, product_idx) VALUES
+              (5 + (s % 5),       IF (order_status = 'APPROVE', true, false), order_id, 1 + (s % 15)),
+              (3 + ((s + 1) % 7), IF (order_status = 'APPROVE', true, false), order_id, 1 + ((s + 5) % 15)),
+              (4 + ((s + 2) % 6), IF (order_status = 'APPROVE', true, false), order_id, 1 + ((s + 10) % 15));
+            SET d = d + 1;
+        END WHILE;
+        SET s = s + 1;
+    END WHILE;
+END$$
+DELIMITER ;
+
+CALL seed_orders();
+DROP PROCEDURE seed_orders;
+
+
+-- ============================================================
+-- 7-1. 배송 (delivery) — 진행 중인 발주 (APPROVE/CONFIRMED) 에 1:1 매핑
+-- DeliveryStatus 분포: READY 25% / DELIVERYING 25% / DELIVERED 35% / DELAY 15%
+-- ============================================================
+INSERT INTO delivery (delivery_status, delay_reason, dep_date, est_des_date, delivered_date, orders_idx)
+SELECT
+    CASE
+        WHEN o.orders_idx % 20 < 3 THEN 'READY'
+        WHEN o.orders_idx % 20 < 8 THEN 'DELIVERYING'
+        WHEN o.orders_idx % 20 < 15 THEN 'DELIVERED'
+        WHEN o.orders_idx % 20 < 17 THEN 'START'
+        ELSE 'DELAY'
+    END,
+    -- delay_reason
+    CASE
+        WHEN o.orders_idx % 20 >= 17 THEN
+            ELT(1 + (o.orders_idx % 4),
+                '교통 체증으로 지연', '기상 악화로 지연',
+                '차량 점검으로 지연', '배송 인력 부족')
+        ELSE NULL
+    END,
+    -- 출발일
+    DATE_SUB(o.created_at, INTERVAL -1 DAY),
+    -- 예상 도착일
+    DATE_ADD(o.created_at, INTERVAL 2 DAY),
+    -- 실제 도착일 (DELIVERED 만)
+    CASE WHEN o.orders_idx % 20 >= 8 AND o.orders_idx % 20 < 15
+         THEN DATE_ADD(o.created_at, INTERVAL 2 DAY)
+         ELSE NULL END,
+    o.orders_idx
+FROM orders o
+WHERE o.order_status IN ('APPROVE', 'CONFIRMED');
+
+
+-- ============================================================
+-- 8. 알림 (head_notification + store_notification)
+-- store_notification 은 store0001 (store_idx=1) 에 집중
+-- ============================================================
+
+-- 본사 알림 (10건)
+INSERT INTO head_notification (type, title, content, is_read, created_at) VALUES
+('LOW_STOCK',      '재고 부족 알림',   '원두 A 재고가 부족합니다.',     false, DATE_SUB(NOW(), INTERVAL 1 HOUR)),
+('LOW_STOCK',      '재고 부족 알림',   '우유 재고가 부족합니다.',       false, DATE_SUB(NOW(), INTERVAL 3 HOUR)),
+('EXPIRY',         '유통기한 임박',    '버터 3일 후 유통기한 만료.',    false, DATE_SUB(NOW(), INTERVAL 5 HOUR)),
+('ABNORMAL_ORDER', '이상 발주 감지',   '스토어0010 의 발주량 급증.',    false, DATE_SUB(NOW(), INTERVAL 8 HOUR)),
+('DELIVERY_DELAY', '배송 지연',        '스토어0023 배송이 지연됩니다.', true,  DATE_SUB(NOW(), INTERVAL 1 DAY)),
+('DELIVERY_START', '배송 시작',        '스토어0045 배송이 시작됨.',     true,  DATE_SUB(NOW(), INTERVAL 1 DAY)),
+('DELIVERED',      '배송 완료',        '스토어0067 배송이 완료됨.',     true,  DATE_SUB(NOW(), INTERVAL 2 DAY)),
+('LOW_STOCK',      '재고 부족 알림',   '치즈 재고가 부족합니다.',       true,  DATE_SUB(NOW(), INTERVAL 2 DAY)),
+('EXPIRY',         '유통기한 임박',    '생크림 1일 후 유통기한 만료.',  true,  DATE_SUB(NOW(), INTERVAL 3 DAY)),
+('ABNORMAL_ORDER', '이상 발주 감지',   '스토어0089 의 발주량 급증.',    true,  DATE_SUB(NOW(), INTERVAL 4 DAY));
+
+-- 가맹점 알림 — store0001 (store_idx=1) 집중 (15건)
+INSERT INTO store_notification (type, title, content, is_read, created_at, store_idx) VALUES
+('LOW_STOCK',      '재고 부족',        '원두 A 재고가 부족합니다.',     false, DATE_SUB(NOW(), INTERVAL 30 MINUTE), 1),
+('LOW_STOCK',      '재고 부족',        '우유 재고가 부족합니다.',       false, DATE_SUB(NOW(), INTERVAL 2 HOUR),  1),
+('EXPIRY',         '유통기한 임박',    '버터 3일 후 만료.',             false, DATE_SUB(NOW(), INTERVAL 4 HOUR),  1),
+('EXPIRY',         '유통기한 임박',    '생크림 1일 후 만료.',           false, DATE_SUB(NOW(), INTERVAL 6 HOUR),  1),
+('DELIVERY_START', '배송 시작',        '자동 발주 배송이 시작됨.',      false, DATE_SUB(NOW(), INTERVAL 8 HOUR),  1),
+('DELIVERY_DELAY', '배송 지연',        '배송이 지연됩니다.',            false, DATE_SUB(NOW(), INTERVAL 1 DAY),   1),
+('DELIVERED',      '배송 완료',        '발주 #1 배송 완료됨.',          true,  DATE_SUB(NOW(), INTERVAL 1 DAY),   1),
+('ABNORMAL_ORDER', '이상 발주',        '발주량 급증 감지됨.',           true,  DATE_SUB(NOW(), INTERVAL 2 DAY),   1),
+('LOW_STOCK',      '재고 부족',        '치즈 재고가 부족합니다.',       true,  DATE_SUB(NOW(), INTERVAL 2 DAY),   1),
+('EXPIRY',         '유통기한 임박',    '빵 2일 후 만료.',               true,  DATE_SUB(NOW(), INTERVAL 3 DAY),   1),
+('DELIVERY_START', '배송 시작',        '발주 #5 배송 시작.',            true,  DATE_SUB(NOW(), INTERVAL 4 DAY),   1),
+('DELIVERED',      '배송 완료',        '발주 #5 배송 완료.',            true,  DATE_SUB(NOW(), INTERVAL 4 DAY),   1),
+('LOW_STOCK',      '재고 부족',        '바닐라시럽 재고 부족.',         true,  DATE_SUB(NOW(), INTERVAL 5 DAY),   1),
+('DELIVERED',      '배송 완료',        '발주 #10 배송 완료.',           true,  DATE_SUB(NOW(), INTERVAL 6 DAY),   1),
+('LOW_STOCK',      '재고 부족',        '초콜릿 재고 부족.',             true,  DATE_SUB(NOW(), INTERVAL 7 DAY),   1);
+
+-- 다른 매장에도 가벼운 알림 (랜덤 분포)
+DELIMITER $$
+DROP PROCEDURE IF EXISTS seed_other_store_notifications$$
+CREATE PROCEDURE seed_other_store_notifications()
+BEGIN
+    DECLARE s INT DEFAULT 2;
+
+    WHILE s <= 100 DO
+        -- 매장당 2~3건
+        INSERT INTO store_notification (type, title, content, is_read, created_at, store_idx) VALUES
+        ('LOW_STOCK', '재고 부족', '재고 부족 알림입니다.', false, DATE_SUB(NOW(), INTERVAL (s % 12) HOUR), s),
+        ('DELIVERY_START', '배송 시작', '배송이 시작됐습니다.', true,  DATE_SUB(NOW(), INTERVAL (s % 5)  DAY), s);
+
+        IF s % 3 = 0 THEN
+            INSERT INTO store_notification (type, title, content, is_read, created_at, store_idx) VALUES
+            ('EXPIRY', '유통기한 임박', '유통기한이 임박했습니다.', false, DATE_SUB(NOW(), INTERVAL (s % 24) HOUR), s);
+        END IF;
+
+        SET s = s + 1;
+    END WHILE;
+END$$
+DELIMITER ;
+
+CALL seed_other_store_notifications();
+DROP PROCEDURE seed_other_store_notifications;
+
+
+-- ============================================================
+-- 완료 확인 (SELECT 결과 보고 정상인지 확인)
+-- ============================================================
+SELECT 'user',                COUNT(*) AS cnt FROM user
+UNION ALL SELECT 'store',     COUNT(*) FROM store
+UNION ALL SELECT 'menu_category', COUNT(*) FROM menu_category
+UNION ALL SELECT 'menu',      COUNT(*) FROM menu
+UNION ALL SELECT 'category',  COUNT(*) FROM category
+UNION ALL SELECT 'product',   COUNT(*) FROM product
+UNION ALL SELECT 'pos_store_inventory', COUNT(*) FROM pos_store_inventory
+UNION ALL SELECT 'pos_pay',   COUNT(*) FROM pos_pay
+UNION ALL SELECT 'pos_orders_item', COUNT(*) FROM pos_orders_item
+UNION ALL SELECT 'orders',    COUNT(*) FROM orders
+UNION ALL SELECT 'orders_item', COUNT(*) FROM orders_item
+UNION ALL SELECT 'head_notification', COUNT(*) FROM head_notification
+UNION ALL SELECT 'store_notification', COUNT(*) FROM store_notification;

--- a/backend/statistics/src/main/java/com/example/statistics/InternalStatisticsController.java
+++ b/backend/statistics/src/main/java/com/example/statistics/InternalStatisticsController.java
@@ -4,6 +4,7 @@ import com.example.statistics.domain.daily.DailyDumpService;
 import com.example.statistics.domain.daily.dto.DumpResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -50,8 +51,13 @@ public class InternalStatisticsController {
     @PostMapping("/dailyDump")
     public ResponseEntity<DumpResult> manualDailyDump(
             @Parameter(
-                    description = "처리할 날짜 (yyyy-MM-dd 형식, 생략 시 어제). 예: 2026-05-25",
-                    example = "2026-05-25"
+                    description = "처리할 날짜 (yyyy-MM-dd 형식, 생략 시 어제)",
+                    examples = {
+                            @ExampleObject(name = "어제 (기본값)", value = "2026-05-26"),
+                            @ExampleObject(name = "30일 전 (catch-up)", value = "2026-04-27"),
+                            @ExampleObject(name = "오늘 (당일 - 보통 미사용)", value = "2026-05-27"),
+                            @ExampleObject(name = "미래 (데이터 없음)", value = "2099-01-01")
+                    }
             )
             @RequestParam(required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date

--- a/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsController.java
+++ b/backend/statistics/src/main/java/com/example/statistics/LongTermStatisticsController.java
@@ -3,6 +3,7 @@ package com.example.statistics;
 import com.example.statistics.common.model.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -52,7 +53,14 @@ public class LongTermStatisticsController {
     )
     @GetMapping("/monthly")
     public ResponseEntity<BaseResponse> getMonthly(
-            @Parameter(description = "조회할 연도 (예: 2026)", example = "2026")
+            @Parameter(
+                    description = "조회할 연도",
+                    examples = {
+                            @ExampleObject(name = "현재 연도", value = "2026"),
+                            @ExampleObject(name = "작년", value = "2025"),
+                            @ExampleObject(name = "데이터 없는 연도 (빈 결과)", value = "2099")
+                    }
+            )
             @RequestParam int year
     ) {
         return ResponseEntity.ok(BaseResponse.success(longTermStatisticsService.getMonthlySales(year)));
@@ -71,7 +79,14 @@ public class LongTermStatisticsController {
     )
     @GetMapping("/quarterly")
     public ResponseEntity<BaseResponse> getQuarterly(
-            @Parameter(description = "조회할 연도 (예: 2026)", example = "2026")
+            @Parameter(
+                    description = "조회할 연도",
+                    examples = {
+                            @ExampleObject(name = "현재 연도", value = "2026"),
+                            @ExampleObject(name = "작년", value = "2025"),
+                            @ExampleObject(name = "데이터 없는 연도 (빈 결과)", value = "2099")
+                    }
+            )
             @RequestParam int year
     ) {
         return ResponseEntity.ok(BaseResponse.success(longTermStatisticsService.getQuarterlySales(year)));
@@ -92,9 +107,23 @@ public class LongTermStatisticsController {
     )
     @GetMapping("/stores")
     public ResponseEntity<BaseResponse> getStores(
-            @Parameter(description = "조회할 연도 (예: 2026)", example = "2026")
+            @Parameter(
+                    description = "조회할 연도",
+                    examples = {
+                            @ExampleObject(name = "현재 연도", value = "2026"),
+                            @ExampleObject(name = "작년", value = "2025"),
+                            @ExampleObject(name = "데이터 없는 연도 (빈 결과)", value = "2099")
+                    }
+            )
             @RequestParam int year,
-            @Parameter(description = "조회할 월 (1~12, 선택). 없으면 연 단위 합계", example = "5")
+            @Parameter(
+                    description = "조회할 월 (1~12, 선택). 없으면 연 단위 합계",
+                    examples = {
+                            @ExampleObject(name = "5월", value = "5"),
+                            @ExampleObject(name = "12월 (연말)", value = "12"),
+                            @ExampleObject(name = "1월 (연초)", value = "1")
+                    }
+            )
             @RequestParam(required = false) Integer month
     ) {
         return ResponseEntity.ok(BaseResponse.success(
@@ -117,9 +146,23 @@ public class LongTermStatisticsController {
     )
     @GetMapping("/categories")
     public ResponseEntity<BaseResponse> getCategories(
-            @Parameter(description = "조회할 연도 (예: 2026)", example = "2026")
+            @Parameter(
+                    description = "조회할 연도",
+                    examples = {
+                            @ExampleObject(name = "현재 연도", value = "2026"),
+                            @ExampleObject(name = "작년", value = "2025"),
+                            @ExampleObject(name = "데이터 없는 연도 (빈 결과)", value = "2099")
+                    }
+            )
             @RequestParam int year,
-            @Parameter(description = "조회할 월 (1~12, 선택). 없으면 연 단위 합계", example = "5")
+            @Parameter(
+                    description = "조회할 월 (1~12, 선택). 없으면 연 단위 합계",
+                    examples = {
+                            @ExampleObject(name = "5월", value = "5"),
+                            @ExampleObject(name = "12월 (연말)", value = "12"),
+                            @ExampleObject(name = "1월 (연초)", value = "1")
+                    }
+            )
             @RequestParam(required = false) Integer month
     ) {
         return ResponseEntity.ok(BaseResponse.success(
@@ -142,9 +185,23 @@ public class LongTermStatisticsController {
     )
     @GetMapping("/menus")
     public ResponseEntity<BaseResponse> getMenus(
-            @Parameter(description = "조회할 연도 (예: 2026)", example = "2026")
+            @Parameter(
+                    description = "조회할 연도",
+                    examples = {
+                            @ExampleObject(name = "현재 연도", value = "2026"),
+                            @ExampleObject(name = "작년", value = "2025"),
+                            @ExampleObject(name = "데이터 없는 연도 (빈 결과)", value = "2099")
+                    }
+            )
             @RequestParam int year,
-            @Parameter(description = "조회할 월 (1~12, 선택). 없으면 연 단위 합계", example = "5")
+            @Parameter(
+                    description = "조회할 월 (1~12, 선택). 없으면 연 단위 합계",
+                    examples = {
+                            @ExampleObject(name = "5월", value = "5"),
+                            @ExampleObject(name = "12월 (연말)", value = "12"),
+                            @ExampleObject(name = "1월 (연초)", value = "1")
+                    }
+            )
             @RequestParam(required = false) Integer month
     ) {
         return ResponseEntity.ok(BaseResponse.success(

--- a/backend/statistics/src/main/resources/seed-dev.sql
+++ b/backend/statistics/src/main/resources/seed-dev.sql
@@ -1,0 +1,401 @@
+-- ============================================================
+-- Nexus Statistics MSA 로컬 dev seed
+-- daily_*_sales 7개 테이블 (어제 ~ 30일 전, 영구 보존 통계)
+-- ============================================================
+-- 일치 조건 (모놀리식 seed-dev.sql 의 결제 식과 동일):
+--   매장 s 의 매일 결제 5건:
+--     i=1: 시간 9,  amount=1000+((s*100+1*1500)%9001), method=CARD
+--     i=2: 시간 12, amount=1000+((s*100+2*1500)%9001), method=CARD
+--     i=3: 시간 15, amount=1000+((s*100+3*1500)%9001), method=CARD
+--     i=4: 시간 18, amount=1000+((s*100+4*1500)%9001), method=CASH
+--     i=5: 시간 21, amount=1000+((s*100+5*1500)%9001), method=CASH
+--   pos_orders_item:
+--     항목 1: menu = 1 + ((s + d + i) % 15), qty = 1 + (i % 2)
+--     항목 2 (i % 2 = 0): menu = 1 + ((s + d + i + 7) % 15), qty = 1
+--
+-- 범위: aggregate_date = 어제 (CURDATE - 1) ~ 30일 전 (CURDATE - 30)
+--   (오늘은 Redis 에서, 모놀리식 pos_pay 의 오늘 데이터)
+-- ============================================================
+
+SET FOREIGN_KEY_CHECKS = 0;
+-- TRUNCATE: 이전 데이터 + UNIQUE constraint 누적 모두 정리 (dev 환경)
+TRUNCATE TABLE daily_total_sales;
+TRUNCATE TABLE daily_store_sales;
+TRUNCATE TABLE daily_menu_sales;
+TRUNCATE TABLE daily_category_sales;
+TRUNCATE TABLE daily_hourly_sales;
+TRUNCATE TABLE daily_payment_sales;
+TRUNCATE TABLE daily_dump_log;
+SET FOREIGN_KEY_CHECKS = 1;
+
+
+-- ============================================================
+-- 메뉴 / 카테고리 매핑 (모놀리식 seed-dev.sql 과 동일)
+-- ============================================================
+-- menu_idx 1~5  → 음료
+-- menu_idx 6~8  → 디저트
+-- menu_idx 9~12 → 베이커리
+-- menu_idx 13~15→ 푸드
+--
+-- 메뉴명 / 가격 (모놀리식과 동일):
+-- 1=아메리카노(3000), 2=카페라떼(4000), 3=카푸치노(4500), 4=바닐라라떼(4500), 5=자몽에이드(5500)
+-- 6=티라미수(6000), 7=치즈케이크(6500), 8=마카롱(2500)
+-- 9=크로와상(3500), 10=소금빵(3000), 11=초코머핀(3500), 12=베이글(4000)
+-- 13=샌드위치(7000), 14=파니니(8000), 15=샐러드(8500)
+
+
+-- ============================================================
+-- 1. 메인 PROCEDURE — 30일치 daily_*_sales 채움
+-- ============================================================
+DELIMITER $$
+DROP PROCEDURE IF EXISTS seed_daily_stats$$
+CREATE PROCEDURE seed_daily_stats()
+BEGIN
+    DECLARE d INT;        -- 1~30 (어제부터)
+    DECLARE s INT;        -- 1~100 (매장)
+    DECLARE i INT;        -- 1~5 (결제 건)
+    DECLARE target_date DATE;
+    DECLARE amount BIGINT;
+    DECLARE menu1 INT;
+    DECLARE qty1 INT;
+    DECLARE menu2 INT;
+    DECLARE store_sum BIGINT;
+    DECLARE day_total BIGINT;
+
+    -- 임시 테이블 (일자별/매장별/메뉴별/시간별/결제수단별/카테고리별 누적)
+    DROP TEMPORARY TABLE IF EXISTS tmp_daily;
+    CREATE TEMPORARY TABLE tmp_daily (
+        agg_date DATE,
+        store_idx INT,
+        store_name VARCHAR(100),
+        amount BIGINT
+    );
+
+    DROP TEMPORARY TABLE IF EXISTS tmp_menu;
+    CREATE TEMPORARY TABLE tmp_menu (
+        agg_date DATE,
+        menu_idx INT,
+        qty BIGINT
+    );
+
+    DROP TEMPORARY TABLE IF EXISTS tmp_hourly;
+    CREATE TEMPORARY TABLE tmp_hourly (
+        agg_date DATE,
+        hour INT,
+        amount BIGINT
+    );
+
+    DROP TEMPORARY TABLE IF EXISTS tmp_payment;
+    CREATE TEMPORARY TABLE tmp_payment (
+        agg_date DATE,
+        method VARCHAR(20),
+        amount BIGINT
+    );
+
+    -- ====================================================
+    -- 결정적 식으로 30일 × 100매장 × 5건 누적 계산
+    -- ====================================================
+    SET d = 1;
+    WHILE d <= 30 DO
+        SET target_date = DATE_SUB(CURDATE(), INTERVAL d DAY);
+        SET s = 1;
+        WHILE s <= 100 DO
+            SET store_sum = 0;
+            SET i = 1;
+            WHILE i <= 7 DO
+                -- 모놀리식과 동일한 결정적 식 (d 포함 — 일별 변동성)
+                SET amount = 1000 + ((s * 100 + i * 1500 + d * 700) MOD 9001);
+                SET store_sum = store_sum + amount;
+
+                -- 시간대 누적 (i=1→9, 2→11, 3→13, 4→15, 5→17, 6→19, 7→21)
+                INSERT INTO tmp_hourly (agg_date, hour, amount) VALUES (
+                    target_date,
+                    CASE i WHEN 1 THEN 9 WHEN 2 THEN 11 WHEN 3 THEN 13 WHEN 4 THEN 15 WHEN 5 THEN 17 WHEN 6 THEN 19 ELSE 21 END,
+                    amount
+                );
+
+                -- 결제 수단 누적 (i<=5 CARD, i>=6 CASH)
+                INSERT INTO tmp_payment (agg_date, method, amount) VALUES (
+                    target_date,
+                    IF (i <= 5, 'CARD', 'CASH'),
+                    amount
+                );
+
+                -- 메뉴 항목 1 (모놀리식 식)
+                SET menu1 = 1 + ((s + d + i) MOD 15);
+                SET qty1 = 1 + (i MOD 2);
+                INSERT INTO tmp_menu (agg_date, menu_idx, qty) VALUES (target_date, menu1, qty1);
+
+                -- 메뉴 항목 2 (i % 2 = 0)
+                IF i MOD 2 = 0 THEN
+                    SET menu2 = 1 + ((s + d + i + 7) MOD 15);
+                    INSERT INTO tmp_menu (agg_date, menu_idx, qty) VALUES (target_date, menu2, 1);
+                END IF;
+
+                SET i = i + 1;
+            END WHILE;
+
+            -- 매장별 sum 누적 (매장 이름은 모놀리식과 동일 — 더벤티 <지역>점)
+            INSERT INTO tmp_daily (agg_date, store_idx, store_name, amount) VALUES (
+                target_date, s,
+                CONCAT('더벤티 ', ELT(s,
+                    '강남','강동','강서','강북','관악','광진','구로','금천','노원','도봉',
+                    '동대문','동작','마포','서대문','서초','성동','성북','송파','양천','영등포',
+                    '용산','은평','종로','서울중구','중랑',
+                    '수원','성남','고양','용인','부천','안산','안양','평택','시흥','광명',
+                    '의정부','김포','화성','남양주','군포',
+                    '해운대','부산진','동래','사상','부산강서','사하','금정','기장','부산남구','부산북구',
+                    '대구중구','수성','달서','달성','대구동구',
+                    '인천중구','미추홀','연수','남동','부평',
+                    '광주북구','광주서구','광주남구',
+                    '대전유성','대전서구','대전동구',
+                    '울산남구','울산동구','울산북구',
+                    '세종',
+                    '제주','서귀포',
+                    '춘천','원주','강릉','속초','평창',
+                    '청주','충주','제천',
+                    '천안','아산','공주','서산',
+                    '포항','경주','안동','구미',
+                    '창원','김해','진주','양산',
+                    '전주','군산','익산',
+                    '여수','순천','목포',
+                    '김포공항','시청'
+                ), '점'),
+                store_sum
+            );
+
+            SET s = s + 1;
+        END WHILE;
+        SET d = d + 1;
+    END WHILE;
+
+    -- ====================================================
+    -- daily_store_sales (일자 × 매장)
+    -- ====================================================
+    INSERT INTO daily_store_sales (aggregate_date, store_idx, store_name, amount, created_at)
+    SELECT agg_date, store_idx, store_name, amount, NOW() FROM tmp_daily;
+
+    -- ====================================================
+    -- daily_total_sales (일자별 총)
+    -- ====================================================
+    INSERT INTO daily_total_sales (aggregate_date, total_amount, created_at)
+    SELECT agg_date, SUM(amount), NOW() FROM tmp_daily GROUP BY agg_date;
+
+    -- ====================================================
+    -- daily_hourly_sales (일자 × 시간)
+    -- ====================================================
+    INSERT INTO daily_hourly_sales (aggregate_date, hour, amount, created_at)
+    SELECT agg_date, hour, SUM(amount), NOW() FROM tmp_hourly GROUP BY agg_date, hour;
+
+    -- ====================================================
+    -- daily_payment_sales (일자 × 결제수단)
+    -- ====================================================
+    INSERT INTO daily_payment_sales (aggregate_date, payment_method, amount, created_at)
+    SELECT agg_date, method, SUM(amount), NOW() FROM tmp_payment GROUP BY agg_date, method;
+
+    -- ====================================================
+    -- daily_menu_sales (일자 × 메뉴)
+    -- ====================================================
+    INSERT INTO daily_menu_sales (aggregate_date, menu_idx, menu_name, quantity, created_at)
+    SELECT
+        agg_date,
+        menu_idx,
+        CASE menu_idx
+            WHEN 1 THEN '아메리카노' WHEN 2 THEN '카페라떼' WHEN 3 THEN '카푸치노' WHEN 4 THEN '바닐라라떼' WHEN 5 THEN '자몽에이드'
+            WHEN 6 THEN '티라미수' WHEN 7 THEN '치즈케이크' WHEN 8 THEN '마카롱'
+            WHEN 9 THEN '크로와상' WHEN 10 THEN '소금빵' WHEN 11 THEN '초코머핀' WHEN 12 THEN '베이글'
+            WHEN 13 THEN '샌드위치' WHEN 14 THEN '파니니' ELSE '샐러드' END,
+        SUM(qty),
+        NOW()
+    FROM tmp_menu
+    GROUP BY agg_date, menu_idx;
+
+    -- ====================================================
+    -- daily_category_sales (일자 × 카테고리)
+    -- menu_idx 1~5 = 음료, 6~8 = 디저트, 9~12 = 베이커리, 13~15 = 푸드
+    -- 카테고리별 매출 = SUM(menu_price * quantity)
+    -- ====================================================
+    INSERT INTO daily_category_sales (aggregate_date, category_name, amount, created_at)
+    SELECT
+        agg_date,
+        CASE
+            WHEN menu_idx BETWEEN 1 AND 5  THEN '음료'
+            WHEN menu_idx BETWEEN 6 AND 8  THEN '디저트'
+            WHEN menu_idx BETWEEN 9 AND 12 THEN '베이커리'
+            ELSE '푸드'
+        END AS cat,
+        SUM(qty *
+            CASE menu_idx
+                WHEN 1 THEN 3000 WHEN 2 THEN 4000 WHEN 3 THEN 4500 WHEN 4 THEN 4500 WHEN 5 THEN 5500
+                WHEN 6 THEN 6000 WHEN 7 THEN 6500 WHEN 8 THEN 2500
+                WHEN 9 THEN 3500 WHEN 10 THEN 3000 WHEN 11 THEN 3500 WHEN 12 THEN 4000
+                WHEN 13 THEN 7000 WHEN 14 THEN 8000 ELSE 8500 END
+        ),
+        NOW()
+    FROM tmp_menu
+    GROUP BY agg_date, cat;
+
+    -- ====================================================
+    -- daily_dump_log (일자별 SUCCESS 로그)
+    -- ====================================================
+    SET d = 1;
+    WHILE d <= 30 DO
+        SET target_date = DATE_SUB(CURDATE(), INTERVAL d DAY);
+        INSERT INTO daily_dump_log (aggregate_date, dump_status, record_count, error_message, dumped_at)
+        VALUES (target_date, 'SUCCESS', 500, NULL, NOW());   -- 일별 500건 (매장 100 × 일 5건)
+        SET d = d + 1;
+    END WHILE;
+
+    -- 정리
+    DROP TEMPORARY TABLE tmp_daily;
+    DROP TEMPORARY TABLE tmp_menu;
+    DROP TEMPORARY TABLE tmp_hourly;
+    DROP TEMPORARY TABLE tmp_payment;
+END$$
+DELIMITER ;
+
+CALL seed_daily_stats();
+DROP PROCEDURE seed_daily_stats;
+
+
+-- ============================================================
+-- 2. 장기 통계 (작년 ~ 1.5년 전 매월 1일 데이터)
+-- LongTermStatisticsService 의 월별/분기별/연도별 차트용
+-- 매월 1일에 1건 INSERT (그 달 합계)
+-- 운영 패턴: 30일 이전 raw 데이터는 폐기, daily_*_sales 만 영구 보존
+-- ============================================================
+DELIMITER $$
+DROP PROCEDURE IF EXISTS seed_long_term$$
+CREATE PROCEDURE seed_long_term()
+BEGIN
+    DECLARE m INT;
+    DECLARE s INT;
+    DECLARE i INT;
+    DECLARE p INT;
+    DECLARE target_date DATE;
+    DECLARE store_daily_sum BIGINT;
+    DECLARE store_monthly BIGINT;
+    DECLARE total_monthly BIGINT;
+    DECLARE month_days INT;
+
+    -- 매월 1일 데이터 (m=2..18, 2개월 전 ~ 18개월 전 = 작년 + 그 이전 일부)
+    -- m=1 (지난달) 은 seed_daily_stats 의 일별 데이터로 커버됨
+    SET m = 2;
+    WHILE m <= 18 DO
+        SET target_date = DATE_FORMAT(DATE_SUB(CURDATE(), INTERVAL m MONTH), '%Y-%m-01');
+        SET total_monthly = 0;
+        -- 한 달 일수 변동 (25~30일)
+        SET month_days = 25 + (m % 6);
+
+        -- 매장별 매월 매출
+        SET s = 1;
+        WHILE s <= 100 DO
+            SET store_daily_sum = 0;
+            SET i = 1;
+            WHILE i <= 7 DO
+                SET store_daily_sum = store_daily_sum + (1000 + ((s * 100 + i * 1500) MOD 9001));
+                SET i = i + 1;
+            END WHILE;
+            SET store_monthly = store_daily_sum * month_days;
+            SET total_monthly = total_monthly + store_monthly;
+
+            INSERT INTO daily_store_sales (aggregate_date, store_idx, store_name, amount, created_at)
+            VALUES (target_date, s,
+                CONCAT('더벤티 ', ELT(s,
+                    '강남','강동','강서','강북','관악','광진','구로','금천','노원','도봉',
+                    '동대문','동작','마포','서대문','서초','성동','성북','송파','양천','영등포',
+                    '용산','은평','종로','서울중구','중랑',
+                    '수원','성남','고양','용인','부천','안산','안양','평택','시흥','광명',
+                    '의정부','김포','화성','남양주','군포',
+                    '해운대','부산진','동래','사상','부산강서','사하','금정','기장','부산남구','부산북구',
+                    '대구중구','수성','달서','달성','대구동구',
+                    '인천중구','미추홀','연수','남동','부평',
+                    '광주북구','광주서구','광주남구',
+                    '대전유성','대전서구','대전동구',
+                    '울산남구','울산동구','울산북구',
+                    '세종',
+                    '제주','서귀포',
+                    '춘천','원주','강릉','속초','평창',
+                    '청주','충주','제천',
+                    '천안','아산','공주','서산',
+                    '포항','경주','안동','구미',
+                    '창원','김해','진주','양산',
+                    '전주','군산','익산',
+                    '여수','순천','목포',
+                    '김포공항','시청'
+                ), '점'),
+                store_monthly, NOW());
+
+            SET s = s + 1;
+        END WHILE;
+
+        -- 그 달 총 매출
+        INSERT INTO daily_total_sales (aggregate_date, total_amount, created_at)
+        VALUES (target_date, total_monthly, NOW());
+
+        -- 메뉴별 판매량 (15개)
+        SET p = 1;
+        WHILE p <= 15 DO
+            INSERT INTO daily_menu_sales (aggregate_date, menu_idx, menu_name, quantity, created_at)
+            VALUES (target_date, p,
+                CASE p
+                    WHEN 1 THEN '아메리카노' WHEN 2 THEN '카페라떼' WHEN 3 THEN '카푸치노' WHEN 4 THEN '바닐라라떼' WHEN 5 THEN '자몽에이드'
+                    WHEN 6 THEN '티라미수' WHEN 7 THEN '치즈케이크' WHEN 8 THEN '마카롱'
+                    WHEN 9 THEN '크로와상' WHEN 10 THEN '소금빵' WHEN 11 THEN '초코머핀' WHEN 12 THEN '베이글'
+                    WHEN 13 THEN '샌드위치' WHEN 14 THEN '파니니' ELSE '샐러드' END,
+                30000 + (p * 1500) + ((m * 200) MOD 5000),  -- 메뉴 idx + 월별 변동
+                NOW());
+            SET p = p + 1;
+        END WHILE;
+
+        -- 카테고리별 (총 매출 분배)
+        INSERT INTO daily_category_sales (aggregate_date, category_name, amount, created_at) VALUES
+        (target_date, '음료',     total_monthly * 40 DIV 100, NOW()),
+        (target_date, '디저트',   total_monthly * 20 DIV 100, NOW()),
+        (target_date, '베이커리', total_monthly * 25 DIV 100, NOW()),
+        (target_date, '푸드',     total_monthly * 15 DIV 100, NOW());
+
+        -- 시간대별 (7개, 1일 평균 분배)
+        INSERT INTO daily_hourly_sales (aggregate_date, hour, amount, created_at) VALUES
+        (target_date, 9,  total_monthly DIV (month_days * 7), NOW()),
+        (target_date, 11, total_monthly DIV (month_days * 7), NOW()),
+        (target_date, 13, total_monthly DIV (month_days * 5), NOW()),
+        (target_date, 15, total_monthly DIV (month_days * 6), NOW()),
+        (target_date, 17, total_monthly DIV (month_days * 6), NOW()),
+        (target_date, 19, total_monthly DIV (month_days * 7), NOW()),
+        (target_date, 21, total_monthly DIV (month_days * 7), NOW());
+
+        -- 결제 수단별 (CARD 71%, CASH 29%)
+        INSERT INTO daily_payment_sales (aggregate_date, payment_method, amount, created_at) VALUES
+        (target_date, 'CARD', total_monthly * 71 DIV 100, NOW()),
+        (target_date, 'CASH', total_monthly * 29 DIV 100, NOW());
+
+        -- dump log
+        INSERT INTO daily_dump_log (aggregate_date, dump_status, record_count, error_message, dumped_at)
+        VALUES (target_date, 'SUCCESS', 700 * month_days, NULL, NOW());
+
+        SET m = m + 1;
+    END WHILE;
+END$$
+DELIMITER ;
+
+CALL seed_long_term();
+DROP PROCEDURE seed_long_term;
+
+
+-- ============================================================
+-- 완료 확인
+-- ============================================================
+SELECT 'daily_total_sales',  COUNT(*) AS cnt FROM daily_total_sales
+UNION ALL SELECT 'daily_store_sales', COUNT(*) FROM daily_store_sales
+UNION ALL SELECT 'daily_menu_sales',  COUNT(*) FROM daily_menu_sales
+UNION ALL SELECT 'daily_category_sales', COUNT(*) FROM daily_category_sales
+UNION ALL SELECT 'daily_hourly_sales', COUNT(*) FROM daily_hourly_sales
+UNION ALL SELECT 'daily_payment_sales', COUNT(*) FROM daily_payment_sales
+UNION ALL SELECT 'daily_dump_log', COUNT(*) FROM daily_dump_log;
+
+-- 검증: 매장 1 의 일일 매출 (모놀리식 SUM 과 동일해야 함)
+SELECT aggregate_date, amount FROM daily_store_sales WHERE store_idx = 1 ORDER BY aggregate_date DESC LIMIT 5;
+
+-- 검증: daily_total (매일 동일 sum)
+SELECT aggregate_date, total_amount FROM daily_total_sales ORDER BY aggregate_date DESC LIMIT 5;

--- a/backend/statistics/src/main/resources/seed-redis-dev.sh
+++ b/backend/statistics/src/main/resources/seed-redis-dev.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# ============================================================
+# Nexus Statistics Redis 로컬 dev seed
+# 오늘 (CURDATE) 의 실시간 사전 집계 데이터
+# ============================================================
+# 일치 조건 (모놀리식 seed-dev.sql 의 d=0 결제와 동일):
+#   매장 s 의 오늘 결제 5건:
+#     i=1: 09시, amount=1000+((s*100+1500)%9001),  CARD, menu=1+((s+0+1)%15), qty=2
+#     i=2: 12시, amount=1000+((s*100+3000)%9001),  CARD, menu=1+((s+0+2)%15), qty=1, +menu=1+((s+9)%15)*1
+#     i=3: 15시, amount=1000+((s*100+4500)%9001),  CARD, menu=1+((s+0+3)%15), qty=2
+#     i=4: 18시, amount=1000+((s*100+6000)%9001),  CASH, menu=1+((s+0+4)%15), qty=1, +menu=1+((s+11)%15)*1
+#     i=5: 21시, amount=1000+((s*100+7500)%9001),  CASH, menu=1+((s+0+5)%15), qty=2
+#
+# 실행:
+#   chmod +x seed-redis-dev.sh
+#   ./seed-redis-dev.sh
+#
+# 환경변수 (선택):
+#   REDIS_HOST (default: localhost)
+#   REDIS_PORT (default: 6379)
+# ============================================================
+
+REDIS_HOST="${REDIS_HOST:-localhost}"
+REDIS_PORT="${REDIS_PORT:-6379}"
+# REDIS_CLI: redis-cli 명령 (호스트 설치 시) 또는 "docker exec -i <container> redis-cli" (docker 사용 시)
+# 예: REDIS_CLI="docker exec -i nexus-redis redis-cli" ./seed-redis-dev.sh
+REDIS_CLI="${REDIS_CLI:-redis-cli}"
+DATE=$(date +%Y-%m-%d)
+TTL=604800   # 7일
+
+# 매장명 매핑 (모놀리식 seed-dev.sql 의 ELT 와 동일, 100개)
+# 인덱스 1~100 사용 (인덱스 0 은 빈 문자열)
+STORE_NAMES=("" \
+    "강남" "강동" "강서" "강북" "관악" "광진" "구로" "금천" "노원" "도봉" \
+    "동대문" "동작" "마포" "서대문" "서초" "성동" "성북" "송파" "양천" "영등포" \
+    "용산" "은평" "종로" "서울중구" "중랑" \
+    "수원" "성남" "고양" "용인" "부천" "안산" "안양" "평택" "시흥" "광명" \
+    "의정부" "김포" "화성" "남양주" "군포" \
+    "해운대" "부산진" "동래" "사상" "부산강서" "사하" "금정" "기장" "부산남구" "부산북구" \
+    "대구중구" "수성" "달서" "달성" "대구동구" \
+    "인천중구" "미추홀" "연수" "남동" "부평" \
+    "광주북구" "광주서구" "광주남구" \
+    "대전유성" "대전서구" "대전동구" \
+    "울산남구" "울산동구" "울산북구" \
+    "세종" \
+    "제주" "서귀포" \
+    "춘천" "원주" "강릉" "속초" "평창" \
+    "청주" "충주" "제천" \
+    "천안" "아산" "공주" "서산" \
+    "포항" "경주" "안동" "구미" \
+    "창원" "김해" "진주" "양산" \
+    "전주" "군산" "익산" \
+    "여수" "순천" "목포" \
+    "김포공항" "시청")
+
+# 메뉴명 매핑 (모놀리식 seed-dev.sql 과 동일)
+MENU_NAMES=("" "아메리카노" "카페라떼" "카푸치노" "바닐라라떼" "자몽에이드" \
+            "티라미수" "치즈케이크" "마카롱" \
+            "크로와상" "소금빵" "초코머핀" "베이글" \
+            "샌드위치" "파니니" "샐러드")
+
+# 메뉴 가격 (카테고리별 매출 계산용)
+MENU_PRICES=(0 3000 4000 4500 4500 5500 \
+             6000 6500 2500 \
+             3500 3000 3500 4000 \
+             7000 8000 8500)
+
+# 메뉴 → 카테고리 매핑
+menu_to_category() {
+    local m=$1
+    if   [ $m -le 5 ];  then echo "음료"
+    elif [ $m -le 8 ];  then echo "디저트"
+    elif [ $m -le 12 ]; then echo "베이커리"
+    else                     echo "푸드"
+    fi
+}
+
+echo "=== Redis seed 시작 ($REDIS_HOST:$REDIS_PORT, $DATE) ==="
+
+# 기존 오늘 키 정리
+$REDIS_CLI -h "$REDIS_HOST" -p "$REDIS_PORT" DEL \
+    "sales:today:$DATE" \
+    "sales:store:ranking:$DATE" \
+    "sales:menu:ranking:$DATE" \
+    "sales:hourly:$DATE" \
+    "sales:category:$DATE" \
+    "sales:payment:$DATE" > /dev/null
+
+# 결정적 식으로 100매장 × 5건 누적 → redis-cli pipe
+{
+    pos_pay_idx=1
+    for s in $(seq 1 100); do
+        # 매장명 = "<idx>|더벤티 <지역>점" 형식 (모놀리식 + 통계 MSA 와 동일)
+        store_name="${s}|더벤티 ${STORE_NAMES[$s]}점"
+
+        for i in 1 2 3 4 5 6 7; do
+            amount=$(( 1000 + (s * 100 + i * 1500) % 9001 ))
+            hour=$(case $i in 1) echo 9;; 2) echo 11;; 3) echo 13;; 4) echo 15;; 5) echo 17;; 6) echo 19;; 7) echo 21;; esac)
+            method=$([ $i -le 5 ] && echo "CARD" || echo "CASH")
+
+            # 항목 1: menu = 1 + ((s + 0 + i) % 15), qty = 1 + (i % 2)
+            menu1=$(( 1 + (s + i) % 15 ))
+            qty1=$(( 1 + i % 2 ))
+            menu1_member="${menu1}|${MENU_NAMES[$menu1]}"
+            cat1=$(menu_to_category $menu1)
+            line_amount1=$(( MENU_PRICES[$menu1] * qty1 ))
+
+            # 1. sales:today (총 매출)
+            echo "INCRBY sales:today:$DATE $amount"
+
+            # 2. sales:store:ranking (매장 매출)
+            echo "ZINCRBY sales:store:ranking:$DATE $amount \"$store_name\""
+
+            # 3. sales:hourly (시간대 매출)
+            echo "HINCRBY sales:hourly:$DATE $hour $amount"
+
+            # 4. sales:payment (결제수단)
+            echo "HINCRBY sales:payment:$DATE $method $amount"
+
+            # 5. sales:menu:ranking (메뉴 수량)
+            echo "ZINCRBY sales:menu:ranking:$DATE $qty1 \"$menu1_member\""
+
+            # 6. sales:category (카테고리 매출 = 메뉴가격 × 수량)
+            echo "HINCRBY sales:category:$DATE \"$cat1\" $line_amount1"
+
+            # 항목 2 (i % 2 == 0): 추가 메뉴
+            if [ $((i % 2)) -eq 0 ]; then
+                menu2=$(( 1 + (s + i + 7) % 15 ))
+                menu2_member="${menu2}|${MENU_NAMES[$menu2]}"
+                cat2=$(menu_to_category $menu2)
+                line_amount2=${MENU_PRICES[$menu2]}
+
+                echo "ZINCRBY sales:menu:ranking:$DATE 1 \"$menu2_member\""
+                echo "HINCRBY sales:category:$DATE \"$cat2\" $line_amount2"
+            fi
+
+            # 7. 멱등성 SETNX (PaymentEventConsumer 의 processed: 패턴)
+            echo "SET processed:posPayIdx:$pos_pay_idx 1 EX $TTL"
+            pos_pay_idx=$((pos_pay_idx + 1))
+        done
+    done
+
+    # 6개 통계 키 TTL 7일
+    echo "EXPIRE sales:today:$DATE $TTL"
+    echo "EXPIRE sales:store:ranking:$DATE $TTL"
+    echo "EXPIRE sales:menu:ranking:$DATE $TTL"
+    echo "EXPIRE sales:hourly:$DATE $TTL"
+    echo "EXPIRE sales:category:$DATE $TTL"
+    echo "EXPIRE sales:payment:$DATE $TTL"
+
+} | $REDIS_CLI -h "$REDIS_HOST" -p "$REDIS_PORT" > /dev/null
+
+echo ""
+echo "=== 검증 ==="
+echo -n "오늘 총 매출 (sales:today:$DATE): "
+$REDIS_CLI -h "$REDIS_HOST" -p "$REDIS_PORT" GET "sales:today:$DATE"
+
+echo ""
+echo "매장 TOP 5 (sales:store:ranking:$DATE):"
+$REDIS_CLI -h "$REDIS_HOST" -p "$REDIS_PORT" ZREVRANGE "sales:store:ranking:$DATE" 0 4 WITHSCORES
+
+echo ""
+echo "메뉴 TOP 5 (sales:menu:ranking:$DATE):"
+$REDIS_CLI -h "$REDIS_HOST" -p "$REDIS_PORT" ZREVRANGE "sales:menu:ranking:$DATE" 0 4 WITHSCORES
+
+echo ""
+echo "시간대별 (sales:hourly:$DATE):"
+$REDIS_CLI -h "$REDIS_HOST" -p "$REDIS_PORT" HGETALL "sales:hourly:$DATE"
+
+echo ""
+echo "카테고리별 (sales:category:$DATE):"
+$REDIS_CLI -h "$REDIS_HOST" -p "$REDIS_PORT" HGETALL "sales:category:$DATE"
+
+echo ""
+echo "결제 수단별 (sales:payment:$DATE):"
+$REDIS_CLI -h "$REDIS_HOST" -p "$REDIS_PORT" HGETALL "sales:payment:$DATE"
+
+echo ""
+echo "=== 완료 ==="


### PR DESCRIPTION
## Summary
- 발주/알림/대시보드 도메인의 에러 응답을 일반 코드 (NOT_FOUND_DATA / REQUEST_ERROR) 에서 구체 BaseResponseStatus 코드로 세분화
- Swagger UI 의 Try it out 에서 정상/에러 유발 케이스를 examples 드롭다운으로 테스트 가능하게 정비
- 로컬 dev 환경 seed 데이터 정합성 보정 (POS 결제 / 발주 batch 승인 동작 보장)

## 변경 파일
### 모놀리식
- `common/model/BaseResponseStatus.java`
- `domain/orders/OrdersController.java`, `OrdersService.java`
- `domain/notification/HeadNotificationController.java`, `HeadNotificationService.java`
- `domain/notification/StoreNotificationController.java`, `StoreNotificationService.java`
- `domain/dashboard/StoreDashboardService.java`
- `resources/seed-dev.sql`

### 통계 MSA
- `LongTermStatisticsController.java`
- `InternalStatisticsController.java`
- `resources/seed-dev.sql`, `resources/seed-redis-dev.sh`

## 주요 변경 사항

### BaseResponseStatus 에러 코드 7개 추가
- 4202 `NOT_FOUND_ORDERS` — 발주를 찾을 수 없습니다
- 4203 `NOT_FOUND_ORDERS_ITEM` — 발주 항목을 찾을 수 없습니다
- 4204 `ORDERS_NOT_AUTHORIZED` — 해당 발주에 대한 권한이 없습니다
- 4205 `ORDERS_INVALID_STATUS` — 현재 발주 상태에서 처리할 수 없습니다
- 4209 `ORDERS_ITEMS_EMPTY` — 발주 항목이 비어 있습니다
- 4210 `BATCH_SERVICE_UNAVAILABLE` — 배치 서비스 호출에 실패했습니다
- 4301 `NOT_FOUND_NOTIFICATION` — 알림을 찾을 수 없습니다

### Service throw 구체화
- OrdersService 의 NOT_FOUND_DATA / REQUEST_ERROR 를 NOT_FOUND_ORDERS / NOT_FOUND_ORDERS_ITEM / STORE_NOT_FOUND / NOT_FOUND_PRODUCT / ORDERS_NOT_AUTHORIZED / ORDERS_INVALID_STATUS / ORDERS_ITEMS_EMPTY 로 분리
- HeadNotificationService.markAsRead 의 IllegalArgumentException → BaseException(NOT_FOUND_NOTIFICATION)
- StoreNotificationService 의 NOT_FOUND_DATA 6곳 → STORE_NOT_FOUND / NOT_FOUND_NOTIFICATION 분리
- StoreDashboardService 의 NOT_FOUND_DATA 8곳 → STORE_NOT_FOUND
- approveAll 의 batch RestTemplate 호출에 try-catch + BATCH_SERVICE_UNAVAILABLE throw 추가

### Swagger Try it out examples 추가
- OrdersController PathVariable 9곳 + RequestBody 4곳에 정상/에러 유발 케이스 examples
- HeadNotificationController / StoreNotificationController 의 notificationIdx 에 examples
- LongTermStatisticsController 의 year / month examples (현재/작년/데이터 없는 연도, 5월/12월/1월)
- InternalStatisticsController 의 date examples (어제/30일 전/오늘/미래)

## Test Plan
- [ ] Swagger UI (/swagger-ui/index.html) 에서 OrdersController 의 PUT /orders/{idx}/approve 등 Try it out 시 examples 드롭다운으로 정상 / NOT_FOUND_ORDERS / ORDERS_INVALID_STATUS 케이스 응답 확인
- [ ] HeadNotificationController.markAsRead 에서 정상 idx (1) 와 NOT_FOUND_NOTIFICATION idx (99999) 응답 확인
- [ ] 통계 MSA Swagger UI 에서 LongTerm 의 year=2099 등 데이터 없는 케이스 응답 확인
- [ ] seed-dev.sql 재실행 후 store0001 로 POS 결제 / 발주 batch 승인 정상 동작 확인

## Issue
- Closes #926