### PR TITLE
[Feat] #927 - POS 모듈 Swagger 전역 인증(X-User-Idx) 기능 적용

### DIFF
--- a/backend/pos/src/main/java/com/example/pos/PosController.java
+++ b/backend/pos/src/main/java/com/example/pos/PosController.java
@@ -52,7 +52,7 @@ public class PosController {
     })
     @GetMapping("/inventory/list")
     public ResponseEntity<BaseResponse<PageResponse<PosStoreInventoryDto.ListRes>>> list(
-            @RequestHeader("X-User-Idx") Long userIdx,
+            @Parameter(hidden = true) @RequestHeader("X-User-Idx") Long userIdx,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size) {
         if (userIdx == null) {
@@ -89,7 +89,7 @@ public class PosController {
     })
     @PatchMapping("/inventory/{posStoreInventoryIdx}")
     public ResponseEntity<BaseResponse<PosStoreInventoryDto.SyncCountRes>> changeInventoryCount(
-            @RequestHeader("X-User-Idx") Long userIdx,
+            @Parameter(hidden = true) @RequestHeader("X-User-Idx") Long userIdx,
             @Parameter(description = "수정할 POS 재고 lot ID", example = "1") @PathVariable Long posStoreInventoryIdx,
             @RequestBody PosStoreInventoryDto.CountReq req) {
         if (userIdx == null) {
@@ -131,7 +131,7 @@ public class PosController {
     })
     @PostMapping("/pay")
     public ResponseEntity<BaseResponse<PosPayDto.PayRes>> pay(
-            @RequestHeader("X-User-Idx") Long userIdx,
+            @Parameter(hidden = true) @RequestHeader("X-User-Idx") Long userIdx,
             @Valid @RequestBody PosPayDto.PayReq req) {
         if (userIdx == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
@@ -164,7 +164,7 @@ public class PosController {
     })
     @GetMapping("/pay/today")
     public ResponseEntity<BaseResponse<List<PosPayDto.TodayPayRes>>> todayPays(
-            @RequestHeader("X-User-Idx") Long userIdx) {
+            @Parameter(hidden = true) @RequestHeader("X-User-Idx") Long userIdx) {
         if (userIdx == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
         }
@@ -202,7 +202,7 @@ public class PosController {
     })
     @PostMapping("/close")
     public ResponseEntity<BaseResponse<PosCloseDto.CloseRes>> close(
-            @RequestHeader("X-User-Idx") Long userIdx) {
+            @Parameter(hidden = true) @RequestHeader("X-User-Idx") Long userIdx) {
         if (userIdx == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
         }

--- a/backend/pos/src/main/java/com/example/pos/config/SwaggerConfig.java
+++ b/backend/pos/src/main/java/com/example/pos/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.example.pos.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -31,6 +34,13 @@ public class SwaggerConfig {
                                 1. **결제 발생**: POS 결제 완료 시 Kafka `pos.payment.created` 토픽 발행 (통계 서버 연동)
                                 2. **마감 발생**: POS 마감 시 Kafka `pos.close.completed` 토픽 발행 (본사 서버 연동)
                                 3. **데이터 동기화(Consumer)**: 본사 서버의 원자재, 메뉴 변경 시 Kafka를 통해 POS DB 자동 동기화
-                                """));
+                                """))
+                .addSecurityItem(new SecurityRequirement().addList("X-User-Idx"))
+                .components(new Components()
+                        .addSecuritySchemes("X-User-Idx", new SecurityScheme()
+                                .name("X-User-Idx")
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .description("가맹점주 식별자(user_idx)를 입력하세요.")));
     }
 }


### PR DESCRIPTION
## Summary
- POS 모듈 스웨거(Swagger)에서 API 테스트 시 개별적으로 `X-User-Idx` 헤더를 매번 입력해야 하는 번거로움을 해소하고자 전역 인증(Authorize) 기능을 도입했습니다.

## 변경 파일
- `backend/pos/src/main/java/com/example/pos/config/SwaggerConfig.java`
- `backend/pos/src/main/java/com/example/pos/PosController.java`

## 주요 변경 사항
- [x] **SwaggerConfig**: 전역 `SecurityScheme`(APIKEY 방식, Header) 추가 및 `X-User-Idx` 인증 등록
- [x] **PosController**: 전역 인증 적용에 따라, 각 API 파라미터에서 중복 노출되던 `@RequestHeader("X-User-Idx")` 항목을 스웨거 UI에서 숨김 처리(`@Parameter(hidden = true)`)

## Test Plan
- [x] POS 서버 기동 후 스웨거 UI 접속 확인
- [x] 우측 상단 `Authorize` 🔒 버튼 클릭 후 가맹점 번호 입력 시, 자물쇠 잠금 상태(인증 유지) 확인
- [x] 각 API 테스트(Execute) 시 헤더 입력란 없이 정상적으로 파라미터(인증 정보)가 넘어가는지 확인

## Issue
- Resolved: #927 