### PR TITLE
[Feat] #927 - 백엔드 스웨거(Swagger) 예시 데이터 및 에러 응답 명세 추가

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuController.java
@@ -5,6 +5,10 @@ import com.example.nexus.domain.menu.model.MenuDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +27,7 @@ public class MenuController {
     // 메뉴 리스트 조회
     @Operation(summary = "메뉴 목록 전체 조회 및 검색", description = "본사 메뉴 관리 페이지에서 메뉴 목록을 페이징하여 조회합니다.")
     @GetMapping("/list")
-    public ResponseEntity list(
+    public ResponseEntity<BaseResponse<MenuDto.MenuPageRes>> list(
             MenuDto.MenuSearchPagingReq searchReq,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size)
@@ -36,16 +40,20 @@ public class MenuController {
     // 메뉴 재료 조회
     @Operation(summary = "메뉴 구성 재료(레시피) 조회", description = "특정 메뉴(menuIdx)에 포함된 원자재 목록과 각각의 소모량을 조회합니다.")
     @GetMapping("/item/list/{menuIdx}")
-    public ResponseEntity menuItemList(@Parameter(description = "메뉴 식별자(ID)") @PathVariable Long menuIdx){
+    public ResponseEntity<BaseResponse<MenuDto.MenuItemListRes>> menuItemList(@Parameter(description = "메뉴 식별자(ID)") @PathVariable Long menuIdx){
         MenuDto.MenuItemListRes result = menuService.menuItemList(menuIdx);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
     // S3 Pre-signed URL 요청
     @Operation(summary = "S3 업로드용 Pre-signed URL 발급", description = "메뉴 이미지 파일 첨부를 위해 AWS S3에 직접 업로드할 수 있는 임시 권한 URL을 발급받습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "파일 용량 초과", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":400, \"message\":\"이미지 파일 용량을 초과했습니다.\"}")))
+    })
     @GetMapping("/presignedUrl/{fileName}")
-    public ResponseEntity presignedUrl(
-            @Parameter(description = "업로드할 파일명 (확장자 포함)") @PathVariable(name = "fileName") String fileName,
+    public ResponseEntity<BaseResponse<Map<String, String>>> presignedUrl(
+            @Parameter(description = "업로드할 파일명 (확장자 포함)", example = "americano.jpg") @PathVariable(name = "fileName") String fileName,
             @Parameter(description = "파일 크기 (Byte 단위)", example = "1024") @RequestParam(name = "fileSize") long fileSize){
         // 1. 서비스를 호출하여 URL과 고유 파일명을 받아옵니다.
         Map<String, String> result = menuService.getPresignedUrl(fileName, fileSize);
@@ -56,8 +64,13 @@ public class MenuController {
 
     // 메뉴 등록
     @Operation(summary = "신규 메뉴 등록", description = "새로운 메뉴와 해당 메뉴의 레시피(원자재 구성 정보)를 본사 시스템에 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404", description = "원자재를 찾을 수 없음", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":404, \"message\":\"원자재를 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "중복되거나 삭제된 메뉴명", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":409, \"message\":\"이미 존재하는 메뉴명입니다.\"}")))
+    })
     @PostMapping("/new/register")
-    public ResponseEntity menuRegister(@Valid @RequestBody MenuDto.MenuRegReq dto){
+    public ResponseEntity<BaseResponse<String>> menuRegister(@Valid @RequestBody MenuDto.MenuRegReq dto){
         menuService.menuRegister(dto);
 
         return ResponseEntity.ok(BaseResponse.success("성공"));
@@ -65,8 +78,13 @@ public class MenuController {
 
     // 메뉴 수정
     @Operation(summary = "메뉴 정보 수정", description = "기존 메뉴의 정보(이름, 가격, 카테고리, 이미지 등) 및 레시피 구성을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404", description = "원자재를 찾을 수 없음", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":404, \"message\":\"원자재를 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "중복되거나 삭제된 메뉴명", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":409, \"message\":\"이미 존재하는 메뉴명입니다.\"}")))
+    })
     @PutMapping("/update/{menuIdx}")
-    public ResponseEntity menuUpdate(@Parameter(description = "메뉴 식별자(ID)") @PathVariable(name = "menuIdx") Long menuIdx, @Valid  @RequestBody MenuDto.MenuRegReq dto){
+    public ResponseEntity<BaseResponse<String>> menuUpdate(@Parameter(description = "메뉴 식별자(ID)") @PathVariable(name = "menuIdx") Long menuIdx, @Valid  @RequestBody MenuDto.MenuRegReq dto){
         menuService.menuUpdate(menuIdx, dto);
         return ResponseEntity.ok(BaseResponse.success("성공"));
     }
@@ -74,7 +92,7 @@ public class MenuController {
     // 메뉴 삭제
     @Operation(summary = "메뉴 삭제 (논리 삭제)", description = "특정 메뉴를 비활성화(삭제 처리) 상태로 변경합니다.")
     @PutMapping("/delete/{menuIdx}")
-    public ResponseEntity menuDelete(@Parameter(description = "메뉴 식별자(ID)") @PathVariable(name = "menuIdx") Long menuIdx){
+    public ResponseEntity<BaseResponse<String>> menuDelete(@Parameter(description = "메뉴 식별자(ID)") @PathVariable(name = "menuIdx") Long menuIdx){
         menuService.menuDelete(menuIdx);
         return ResponseEntity.ok(BaseResponse.success("성공"));
     }
@@ -82,23 +100,31 @@ public class MenuController {
     // 메뉴 카테고리 조회
     @Operation(summary = "메뉴 카테고리 목록 조회", description = "등록된 전체 메뉴 카테고리(예: 커피류, 디저트류 등) 목록을 조회합니다.")
     @GetMapping("/category/list")
-    public ResponseEntity menuCategory(){
+    public ResponseEntity<BaseResponse<List<MenuDto.MenuCategoryRes>>> menuCategory(){
         List<MenuDto.MenuCategoryRes> result =  menuService.menucategory();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
     // 메뉴 카테고리 등록
     @Operation(summary = "신규 메뉴 카테고리 등록", description = "새로운 메뉴 카테고리를 시스템에 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "409", description = "중복된 카테고리명", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":409, \"message\":\"중복된 카테고리명입니다.\"}")))
+    })
     @PostMapping("/category/register")
-    public ResponseEntity<BaseResponse> menuCategoryReg(@Valid @RequestBody MenuDto.MenuCategoryRegReq dto){
+    public ResponseEntity<BaseResponse<String>> menuCategoryReg(@Valid @RequestBody MenuDto.MenuCategoryRegReq dto){
         menuService.menucategoryReg(dto);
         return ResponseEntity.ok(BaseResponse.success("성공"));
     }
 
     // 메뉴 카테고리 삭제
     @Operation(summary = "메뉴 카테고리 삭제", description = "특정 메뉴 카테고리를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "삭제 불가 (사용 중인 카테고리)", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":400, \"message\":\"사용 중인 카테고리라 삭제할 수 없습니다.\"}")))
+    })
     @DeleteMapping("/category/delete/{categoryIdx}")
-    public ResponseEntity menuCategoryDelete(@Parameter(description = "카테고리 식별자(ID)") @PathVariable Long categoryIdx ){
+    public ResponseEntity<BaseResponse<String>> menuCategoryDelete(@Parameter(description = "카테고리 식별자(ID)") @PathVariable Long categoryIdx ){
         menuService.menuCategoryDelete(categoryIdx);
         return ResponseEntity.ok(BaseResponse.success("성공"));
     }

--- a/backend/monolith/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
@@ -4,6 +4,7 @@ import com.example.nexus.common.exception.BaseException;
 import com.example.nexus.domain.product.model.Product;
 import jakarta.persistence.*;
 import lombok.*;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.data.domain.Page;
 import java.util.List;
 import java.util.Map;
@@ -104,8 +105,11 @@ public class MenuDto {
 
     @Getter
     public static class MenuItemReq{
+        @Schema(description = "소모량", example = "1")
         private Integer quantity;
+        @Schema(description = "단위", example = "개")
         private String menuUnit;
+        @Schema(description = "원자재 식별자(ID)", example = "105")
         private Long productIdx;
 
         public MenuItem toEntity(Menu menu, Product product) {
@@ -124,10 +128,15 @@ public class MenuDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MenuRegReq{
+        @Schema(description = "메뉴 이름", example = "아이스 아메리카노")
         private String menuName;
+        @Schema(description = "가격", example = "4500")
         private Integer price;
+        @Schema(description = "메뉴 이미지 S3 URL", example = "https://s3.amazonaws.com/venti/ice_americano.jpg")
         private String imgPath;
+        @Schema(description = "카테고리 식별자(ID)", example = "1")
         private Long menuCategoryIdx;
+        @Schema(description = "레시피 (원자재 구성)")
         private List<MenuItemReq> menuItemList;
 
         public Menu toEntity(MenuCategory category, List<Product> products) {
@@ -187,6 +196,7 @@ public class MenuDto {
     // 카테고리 등록 Req
     @Getter
     public static class MenuCategoryRegReq{
+        @Schema(description = "신규 카테고리 이름", example = "프라페")
         private String menuCategoryName;
     }
 

--- a/backend/monolith/src/main/java/com/example/nexus/domain/report/ReportController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/report/ReportController.java
@@ -15,7 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-@Tag(name = "AI 보고서 (Report)", description = "AI 챗봇(클로드) 기반 데이터 분석 및 보고서 자동 생성/조회 API")
+@Tag(name = "AI 보고서", description = "AI 챗봇(클로드) 기반 데이터 분석 및 보고서 자동 생성/조회 API")
 @RequestMapping("/report")
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +25,7 @@ public class ReportController {
     // 사용자 메세지 통신
     @Operation(summary = "AI 챗봇 대화 및 보고서 생성", description = "AI 챗봇에게 데이터 분석 및 요약을 요청하고, 그 결과로 생성된 보고서를 저장합니다.")
     @PostMapping("/generate")
-    public ResponseEntity<BaseResponse> requestReport(
+    public ResponseEntity<BaseResponse<String>> requestReport(
             @Parameter(hidden = true) @AuthenticationPrincipal AuthUserDetails userDetails,
             @Valid @RequestBody ReportDto.ChatRequest request) {
         if (userDetails == null) {

--- a/backend/monolith/src/main/java/com/example/nexus/domain/report/model/ReportDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/report/model/ReportDto.java
@@ -3,6 +3,7 @@ package com.example.nexus.domain.report.model;
 import com.example.nexus.domain.store.model.StoreDto;
 import com.example.nexus.domain.user.model.User;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
@@ -16,8 +17,10 @@ public class ReportDto {
 
     // 사용자 요청 DTO
     public record ChatRequest(
+            @Schema(description = "보고서 생성을 위한 AI 요청 메시지", example = "지난주 대비 이번주 매출 변화와 원자재 소모량에 대해 분석해줘")
             @NotBlank(message = "메시지는 비어있을 수 없습니다.")
             String message,
+            @Schema(description = "대화 세션 식별자 (선택값, 미입력시 사용자 기준 기본 세션 사용)", example = "session-123")
             String sessionId   // 대화 세션 식별자 (선택값, 없으면 서버에서 userIdx 기반 기본값 사용)
     ) {}
 

--- a/backend/monolith/src/main/java/com/example/nexus/domain/store/StoreController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/store/StoreController.java
@@ -9,6 +9,10 @@ import com.example.nexus.domain.user.model.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -50,7 +54,7 @@ public class StoreController {
     // [본사] keyword로 가맹점 검색
     @Operation(summary = "가맹점 이름 검색", description = "가맹점 명칭(키워드)으로 가맹점을 검색합니다.")
     @GetMapping("/search")
-    public ResponseEntity searchStore(
+    public ResponseEntity<BaseResponse<List<StoreDto.StoreSearchRes>>> searchStore(
             @AuthenticationPrincipal UserDetails userDetails,
             @Parameter(description = "검색 키워드") @RequestParam(value = "keyword", required = false, defaultValue = "") String keyword) {
         if (userDetails == null) {
@@ -67,7 +71,7 @@ public class StoreController {
     // 가맹점 목록 조회 및 검색 조건
     @Operation(summary = "가맹점 목록 조회", description = "전체 가맹점 목록을 페이징하여 조회합니다. 상태 및 키워드 필터를 지원합니다.")
     @GetMapping("/list")
-    public ResponseEntity storeList(
+    public ResponseEntity<BaseResponse<StoreDto.StorePageRes>> storeList(
             StoreDto.StoreSearchPagingReq searchReq,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size
@@ -78,7 +82,7 @@ public class StoreController {
 
     @Operation(summary = "가맹점 전체 상태 집계", description = "현재 운영 중이거나 폐점된 가맹점의 전체 숫자를 집계하여 조회합니다.")
     @GetMapping("/totalCount/list")
-    public ResponseEntity storeTotalList(){
+    public ResponseEntity<BaseResponse<StoreDto.StoreTotalRes>> storeTotalList(){
         StoreDto.StoreTotalRes result = storeService.storeTotalList();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
@@ -96,24 +100,33 @@ public class StoreController {
     // 가맹점 목록 상세 조회
     @Operation(summary = "가맹점 상세 정보 조회", description = "특정 가맹점의 상세 정보(점주 명, 연락처, 주소 등)를 조회합니다.")
     @GetMapping("/detail/list/{storeIdx}")
-    public ResponseEntity storeDetailList(@Parameter(description = "가맹점 번호") @PathVariable Long storeIdx){
+    public ResponseEntity<BaseResponse<StoreDto.StoreDetailListRes>> storeDetailList(@Parameter(description = "가맹점 번호") @PathVariable Long storeIdx){
         StoreDto.StoreDetailListRes result = storeService.storeDetailList(storeIdx);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
     // 신규 가맹점 등록
     @Operation(summary = "신규 가맹점 등록", description = "새로운 가맹점 정보를 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404", description = "점주를 찾을 수 없음", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":404, \"message\":\"존재하지 않는 유저입니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "중복 데이터 발생 (가맹점 보유, 가맹점명 중복, 사업자번호 중복)", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":409, \"message\":\"이미 가맹점을 보유한 점주입니다.\"}")))
+    })
     @PostMapping("/new/register")
-    public ResponseEntity storeReg(@RequestBody StoreDto.StoreRegReq dto ){
+    public ResponseEntity<BaseResponse<String>> storeReg(@RequestBody StoreDto.StoreRegReq dto ){
         storeService.storeReg(dto);
         return ResponseEntity.ok(BaseResponse.success("성공"));
     }
 
     // S3 Pre-signed URL 요청
     @Operation(summary = "S3 업로드용 Pre-signed URL 생성", description = "가맹점 이미지 등을 S3에 직접 업로드하기 위한 Pre-signed URL을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "파일 용량 초과", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":400, \"message\":\"PDF 파일 용량을 초과했습니다.\"}")))
+    })
     @GetMapping("/presignedUrl/{fileName}")
-    public ResponseEntity presignedUrl(
-            @Parameter(description = "업로드할 파일명 (확장자 포함)") @PathVariable(name = "fileName") String fileName,
+    public ResponseEntity<BaseResponse<Map<String, String>>> presignedUrl(
+            @Parameter(description = "업로드할 파일명 (확장자 포함)", example = "business_license.pdf") @PathVariable(name = "fileName") String fileName,
             @Parameter(description = "파일 크기 (Byte 단위)", example = "1024") @RequestParam(name = "fileSize") long fileSize){
         // 1. 서비스를 호출하여 URL과 고유 파일명을 받아옵니다.
         Map<String, String> result = storeService.getPresignedUrl(fileName, fileSize);
@@ -124,8 +137,13 @@ public class StoreController {
 
     // 가맹점 수정
     @Operation(summary = "가맹점 정보 수정", description = "기존 가맹점의 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "이미 폐점 처리된 가맹점", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":400, \"message\":\"이미 폐점 처리된 가맹점입니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "가맹점명 중복", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":409, \"message\":\"이미 존재하는 가맹점명입니다.\"}")))
+    })
     @PutMapping("/update/{storeIdx}")
-    public ResponseEntity storeUpdate(
+    public ResponseEntity<BaseResponse<String>> storeUpdate(
             @Parameter(description = "가맹점 번호") @PathVariable(name = "storeIdx") Long storeIdx,
             @RequestBody StoreDto.StoreUpdateReq dto){
         storeService.storeUpdate(storeIdx, dto);

--- a/backend/monolith/src/main/java/com/example/nexus/domain/store/model/StoreDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/store/model/StoreDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.domain.Page;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -160,12 +161,19 @@ public class StoreDto {
     // 신규 가맹점 등록 req
     @Getter
     public static class StoreRegReq{
+        @Schema(description = "가맹점 이름", example = "더벤티 강남역점")
         private String storeName;
+        @Schema(description = "가맹점주 이메일 (회원가입된 유저의 이메일)", example = "gangnam@theventi.co.kr")
         private String ownerEmail;
+        @Schema(description = "우편번호", example = "06236")
         private String postcode;
+        @Schema(description = "기본 주소", example = "서울 강남구 테헤란로 152")
         private String address;
+        @Schema(description = "상세 주소", example = "1층 더벤티")
         private String addressDetail;
+        @Schema(description = "사업자 등록번호", example = "123-45-67890")
         private String business;
+        @Schema(description = "첨부파일(사업자 등록증 등) S3 URL", example = "https://s3.amazonaws.com/venti/document.jpg")
         private String filePath;
 
         public Store toEntity(){
@@ -184,13 +192,21 @@ public class StoreDto {
     @Getter
     @Builder
     public static class StoreUpdateReq{
+        @Schema(description = "가맹점 이름", example = "더벤티 강남역점 (수정)")
         private String storeName;
+        @Schema(description = "점주 이름", example = "홍길동")
         private String ownerName;
+        @Schema(description = "가맹점주 이메일", example = "gangnam@theventi.co.kr")
         private String ownerEmail;
+        @Schema(description = "우편번호", example = "06236")
         private String postcode;
+        @Schema(description = "기본 주소", example = "서울 강남구 테헤란로 152")
         private String address;
+        @Schema(description = "상세 주소", example = "2층 201호")
         private String addressDetail;
+        @Schema(description = "폐점 일시 (운영중일 경우 null)", example = "2026-05-27T07:08:38.615Z")
         private LocalDateTime closedAt;
+        @Schema(description = "첨부파일(사업자 등록증 등) S3 URL", example = "https://s3.amazonaws.com/venti/image.jpg")
         private String filePath;
 
     }

--- a/frontend/src/components/store/StoreTrendChart.vue
+++ b/frontend/src/components/store/StoreTrendChart.vue
@@ -47,14 +47,14 @@ async function loadAndRender() {
         {
           label: '입점',
           data: openedCounts,
-          backgroundColor: '#F37321',
+          backgroundColor: '#22c55e', // Green
           borderRadius: 4,
           maxBarThickness: 18,
         },
         {
           label: '폐점',
           data: closedCounts,
-          backgroundColor: '#ef4444',
+          backgroundColor: '#ef4444', // Red
           borderRadius: 4,
           maxBarThickness: 18,
         },
@@ -120,7 +120,7 @@ onUnmounted(() => {
           <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}년</option>
         </select>
         <div class="flex items-center gap-4 text-xs text-gray-500">
-          <span class="flex items-center gap-1.5"><span class="w-3 h-3 bg-[#F37321] inline-block rounded"></span>입점</span>
+          <span class="flex items-center gap-1.5"><span class="w-3 h-3 bg-[#22c55e] inline-block rounded"></span>입점</span>
           <span class="flex items-center gap-1.5"><span class="w-3 h-3 bg-[#ef4444] inline-block rounded"></span>폐점</span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- 프론트엔드 연동 편의성을 위해 모놀리스 서버의 스웨거(Swagger) 명세를 고도화했습니다.
- 가맹점, 메뉴, 보고서 API의 제네릭 반환 타입을 명확히 하고, Request Body 및 Exception 응답 예시를 추가했습니다.

## 변경 파일
- `backend/monolith/src/main/java/com/example/nexus/common/model/BaseResponse.java`
- `backend/monolith/src/main/java/com/example/nexus/domain/store/StoreController.java`
- `backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuController.java`
- `backend/monolith/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java`
- `backend/monolith/src/main/java/com/example/nexus/domain/report/ReportController.java`
- `backend/monolith/src/main/java/com/example/nexus/domain/report/model/ReportDto.java`

## 주요 변경 사항
- [x] `BaseResponse` 및 컨트롤러의 반환 타입을 제네릭(`BaseResponse<T>`)으로 구체화하여 정상적인 응답 스키마 노출
- [x] `MenuDto`, `ReportDto` 내 Request Body 필드에 `@Schema(example="...")` 데이터 추가
- [x] S3 URL 발급 API(`StoreController`, `MenuController`)의 `fileName` 파라미터에 예시 문자열 추가
- [x] 가맹점 및 메뉴 로직의 비즈니스 예외(400, 404, 409 에러) 상황을 `@ApiResponses`로 스웨거 하단에 문서화


## Test Plan
- [x] 서버 실행 시 스웨거(Swagger UI) 정상 렌더링 확인
- [x] 각 API 엔드포인트의 Request Body 예시가 정상적으로 노출되는지 확인
- [x] Responses 탭 하단에 400, 404, 409 에러 코드 및 응답 메시지가 표기되는지 확인

## Issue
- Closes #927 