### PR TITLE
[Fix] #934 - Swagger 문서 수정 및 상세 설명 추가

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/domain/head/model/HeadIncomeDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/head/model/HeadIncomeDto.java
@@ -23,11 +23,21 @@ public class HeadIncomeDto {
 
     @Getter
     @Builder
+    @io.swagger.v3.oas.annotations.media.Schema(description = "본사 수입 내역 조회 응답 데이터")
     public static class FindHeadIncomeRes {
+        @io.swagger.v3.oas.annotations.media.Schema(description = "수입 내역 ID", example = "101")
         private Long idx;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "금액", example = "500000")
         private Long price;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "납부 여부", example = "false")
         private boolean paid;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "가맹점 ID", example = "5")
         private Long storeIdx;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "연관 주문 ID", example = "20240528001")
         private Long ordersIdx;
     }
 

--- a/backend/monolith/src/main/java/com/example/nexus/domain/settlement/SettlementController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/settlement/SettlementController.java
@@ -48,7 +48,13 @@ public class SettlementController {
     private final SettlementService settlementService;
     private final OrdersService ordersService;
 
-    @Operation(summary = "미납 내역 조회", description = "재시도(2차) 결제까지 최종 실패한 미납 내역 목록을 조회합니다.")
+    @Operation(
+            summary = "미납 내역 조회",
+            description = "배치 처리 후 재시도(2차) 결제까지 최종 실패한 가맹점의 미납 내역 목록을 조회합니다.",
+            parameters = {
+                    @Parameter(name = "authUserDetails", hidden = true)
+            }
+    )
     @GetMapping("/unpaid/list")
     public ResponseEntity<List<SettlementDto.FinalRetryFailRes>> getUnpaidList(
             @AuthenticationPrincipal AuthUserDetails authUserDetails) {
@@ -62,7 +68,20 @@ public class SettlementController {
         return ResponseEntity.ok(finalFailures);
     }
 
-    @Operation(summary = "결제 요청", description = "미납된 정산 내역에 대해 결제를 요청합니다.")
+    @Operation(
+            summary = "결제 요청",
+            description = "미납된 정산 내역에 대해 결제를 시작하기 위한 초기 데이터를 생성합니다.",
+            parameters = {
+                    @Parameter(name = "authUserDetails", hidden = true)
+            },
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "결제할 총 금액과 대상 수입 내역 ID 목록",
+                    required = true,
+                    content = @io.swagger.v3.oas.annotations.media.Content(
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = SettlementDto.PayReq.class)
+                    )
+            )
+    )
     @PostMapping("/pay")
     public ResponseEntity<List<HeadIncomeDto.FindHeadIncomeRes>> pay(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
@@ -91,7 +110,53 @@ public class SettlementController {
         return ResponseEntity.ok(headIncomeResList);
     }
 
-    @Operation(summary = "결제 검증", description = "포트원 등을 통한 결제 완료 후 서버 측에서 결제 정보의 유효성을 검증합니다.")
+    @Operation(
+            summary = "결제 검증",
+            description = """
+                    포트원(Portone) 결제 완료 후 서버 측에서 결제 정보의 유효성을 검증합니다.
+                    
+                    **검증 절차:**
+                    1. 클라이언트가 전달한 `paymentId`를 통해 포트원 서버에 결제 상세 정보 조회
+                    2. 서버에 기록된 정산 예정 금액과 실제 결제 금액 비교
+                    3. 검증 성공 시 정산 상태 및 관련 수입 내역(HeadIncome) 상태를 '결제 완료'로 업데이트
+                    """,
+            parameters = {
+                    @Parameter(name = "authUserDetails", hidden = true)
+            },
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "포트원에서 발급받은 결제 ID",
+                    required = true,
+                    content = @io.swagger.v3.oas.annotations.media.Content(
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = SettlementDto.VerifyReq.class)
+                    )
+            ),
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "결제 검증 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "text/plain",
+                                    examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = "결제 성공")
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "결제 금액 불일치 또는 잘못된 요청",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "text/plain",
+                                    examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = "결제 금액이 일치하지 않습니다.")
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "정산 내역을 찾을 수 없음",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "text/plain",
+                                    examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = "정산 정보를 찾을 수 없습니다.")
+                            )
+                    )
+            }
+    )
     @PostMapping("/verify")
     public ResponseEntity<String> verify(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,

--- a/backend/monolith/src/main/java/com/example/nexus/domain/settlement/model/SettlementDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/settlement/model/SettlementDto.java
@@ -10,42 +10,68 @@ public class SettlementDto {
 
     @Getter
     @Builder
+    @io.swagger.v3.oas.annotations.media.Schema(description = "결제 요청 데이터")
     public static class PayReq {
+        @io.swagger.v3.oas.annotations.media.Schema(description = "총 결제 금액", example = "1500000")
         private Long paymentPrice;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "결제 대상 본사 수입(HeadIncome) ID 목록", example = "[101, 102, 103]")
         List<Long> headIncomeidxList;
     }
 
     @Getter
     @Builder
+    @io.swagger.v3.oas.annotations.media.Schema(description = "결제 요청 응답 데이터")
     public static class PayRes {
+        @io.swagger.v3.oas.annotations.media.Schema(description = "생성된 정산 ID", example = "50")
         private Long settlementIdx;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "결제 금액", example = "1500000")
         private Long paymentPrice;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "결제 처리된 수입 내역 ID 목록", example = "[101, 102, 103]")
         private List<Long> headIncomeIdxList;
     }
 
     @Getter
     @Builder
+    @io.swagger.v3.oas.annotations.media.Schema(description = "결제 검증 요청 데이터")
     public static class VerifyReq {
+        @io.swagger.v3.oas.annotations.media.Schema(description = "포트원 결제 고유 번호 (payment_id)", example = "payment-88099881-8b38-42f0-9377-51253457a41d")
         private String paymentId;
     }
 
     @Getter
     @Builder
+    @io.swagger.v3.oas.annotations.media.Schema(description = "미납 내역 응답 데이터")
     public static class unPaid {
+        @io.swagger.v3.oas.annotations.media.Schema(description = "미납된 수입 내역 상세 목록")
         private List<HeadIncomeDto.FindHeadIncomeRes> unpaidList;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "정산 ID", example = "50")
         private Long settlementIdx;
     }
 
     @Getter
     @Builder
+    @io.swagger.v3.oas.annotations.media.Schema(description = "최종 결제 실패 내역 응답")
     public static class FinalRetryFailRes {
+        @io.swagger.v3.oas.annotations.media.Schema(description = "정산 ID", example = "50")
         private Long idx;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "가맹점 ID", example = "5")
         private Long storeIdx;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "총 미납 금액", example = "1500000")
         private Integer amount;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "결제 대상 월 (yyyy-MM)", example = "2024-05")
         private String payedMonth;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "실패 사유", example = "잔액 부족")
         private String failReason;
+        
+        @io.swagger.v3.oas.annotations.media.Schema(description = "연관된 수입 내역 ID 목록", example = "[101, 102]")
         private List<Long> headIncomeIdxList;
     }
-
-
 }


### PR DESCRIPTION
docs: 정산 및 결제 관련 API Swagger 문서화 및 상세 설명 추가

- /settlement (가맹점 정산 처리 API)
- /unpaid/list (미납 내역 조회 API)
- /pay (미납금 결제 및 검증 API)

각 API의 비즈니스 로직, 파라미터 제약 조건, 예외 처리 흐름을 
Swagger(OpenAPI) 명세에 반영