### PR TITLE
[Docs] #940 - Swagger(OpenAPI) 문서화 및 상세 설명 추가 example 데이터 일치하게 수정

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/domain/billing/BillingController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/billing/BillingController.java
@@ -6,6 +6,11 @@ import com.example.nexus.domain.store.StoreService;
 import com.example.nexus.domain.user.model.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +29,26 @@ public class BillingController {
     private final StoreService storeService;
 
     @Operation(summary = "빌링키 발급 및 등록", description = "포트원 인증키를 통해 가맹점 자동 결제를 위한 빌링키를 발급받고 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "빌링키 발급 및 등록 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "빌링키 발급 및 등록 성공",
+                                          "result": "빌링키 발급 및 등록 성공"
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @PostMapping("/issue")
     public ResponseEntity issueBillingKey(@AuthenticationPrincipal AuthUserDetails authUserDetails, @RequestBody BillingDto.IssueBillingKeyRequestDto request) {
         Long storeIdx = storeService.findStoreIdx(authUserDetails.getIdx());
@@ -35,6 +60,37 @@ public class BillingController {
     }
 
     @Operation(summary = "등록된 빌링 정보 조회", description = "로그인한 가맹점에 등록된 빌링(카드) 정보 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "등록된 빌링 정보 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": [
+                                            {
+                                              "id": 1,
+                                              "mId": "tvivarepublica2",
+                                              "customerKey": "STORE_1",
+                                              "authenticatedAt": "2026-05-28T10:00:00",
+                                              "method": "카드",
+                                              "storeIdx": 1,
+                                              "cardCompany": "신한카드",
+                                              "cardNumber": "4518********1234"
+                                            }
+                                          ]
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/list")
     public ResponseEntity getBillingList(@AuthenticationPrincipal AuthUserDetails authUserDetails) {
         Long storeIdx = storeService.findStoreIdx(authUserDetails.getIdx());
@@ -45,6 +101,26 @@ public class BillingController {
     }
 
     @Operation(summary = "빌링 정보 삭제", description = "가맹점에 등록된 빌링 정보를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "빌링 정보 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "빌링 정보 삭제 성공",
+                                          "result": "빌링 정보 삭제 성공"
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @DeleteMapping("/delete/{storeIdx}")
     public ResponseEntity deleteBillingInfo(@Parameter(description = "가맹점 번호") @PathVariable Long storeIdx) {
         billingService.deleteBillingInfo(storeIdx);

--- a/backend/monolith/src/main/java/com/example/nexus/domain/category/CategoryController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/category/CategoryController.java
@@ -3,6 +3,11 @@ package com.example.nexus.domain.category;
 import com.example.nexus.common.model.BaseResponse;
 import com.example.nexus.domain.category.model.CategoryDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +25,29 @@ public class CategoryController {
 
     // 카테고리 등록
     @Operation(summary = "카테고리 등록", description = "새로운 원자재 카테고리를 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "카테고리 등록 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": {
+                                            "idx": 1,
+                                            "categoryName": "원두/커피"
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @PostMapping("/reg")
     public ResponseEntity<BaseResponse<CategoryDto.RegRes>> createCategory(@Valid @RequestBody CategoryDto.RegReq dto) {
         CategoryDto.RegRes result = categoryService.addCategory(dto);
@@ -28,6 +56,35 @@ public class CategoryController {
 
     // 카테고리 목록 조회
     @Operation(summary = "카테고리 목록 조회", description = "등록된 모든 카테고리 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "카테고리 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": [
+                                            {
+                                              "idx": 1,
+                                              "categoryName": "원두/커피"
+                                            },
+                                            {
+                                              "idx": 2,
+                                              "categoryName": "유제품"
+                                            }
+                                          ]
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/list")
     public ResponseEntity readCategoryList() {
         List<CategoryDto.ListRes> dto = categoryService.findAllCategories();
@@ -36,6 +93,26 @@ public class CategoryController {
 
     // 카테고리 소프트 삭제
     @Operation(summary = "카테고리 삭제", description = "특정 카테고리를 소프트 삭제 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "카테고리 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "success delete category",
+                                          "result": "success delete category"
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @DeleteMapping("/delete")
     public ResponseEntity<BaseResponse<String>> deleteCategory(@RequestBody CategoryDto.RegReq dto) {
         categoryService.deleteCategory(dto.getIdx());

--- a/backend/monolith/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java
@@ -6,6 +6,11 @@ import com.example.nexus.domain.delivery.model.DeliveryDto;
 import com.example.nexus.domain.user.model.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +31,45 @@ public class DeliveryController {
     // 본사 배송 관리 페이지 전체 배송현황 리스트 조회
     // 검색 및 필터 포함
     @Operation(summary = "본사 전체 배송 현황 조회", description = "본사 관리자가 모든 가맹점의 배송 현황을 조회합니다. 가맹점명, 배송 상태, 날짜 필터를 지원합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "본사 전체 배송 현황 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": {
+                                            "deliveryList": [
+                                              {
+                                                "deliveryIdx": 101,
+                                                "orderIdx": 501,
+                                                "storeName": "강남점",
+                                                "deliveryStatus": "DELIVERYING",
+                                                "delayReason": null,
+                                                "departureDate": "2026-05-27T10:00:00",
+                                                "estimatedArrivalAt": "2026-05-28T14:00:00",
+                                                "deliveredDate": null,
+                                                "orderPrice": 1200000,
+                                                "itemCount": 5
+                                              }
+                                            ],
+                                            "totalPage": 1,
+                                            "totalCount": 1,
+                                            "currentPage": 0,
+                                            "currentSize": 10
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/head")
     public ResponseEntity<BaseResponse<DeliveryDto.DeliveryPageRes>> getAllDeliveries(
             @Parameter(description = "가맹점명 검색어") @RequestParam(required = false) String storeName,
@@ -51,6 +95,45 @@ public class DeliveryController {
 
     // 본인 가맹점 배송 현황 조회
     @Operation(summary = "가맹점 본인 배송 현황 조회", description = "로그인한 가맹점주가 자신의 가맹점에 대한 배송 현황을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "가맹점 본인 배송 현황 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": {
+                                            "deliveryList": [
+                                              {
+                                                "deliveryIdx": 102,
+                                                "orderIdx": 502,
+                                                "storeName": "강남점",
+                                                "deliveryStatus": "DELAY",
+                                                "delayReason": "기상 악화로 인한 배송 지연",
+                                                "departureDate": "2026-05-26T09:00:00",
+                                                "estimatedArrivalAt": "2026-05-27T18:00:00",
+                                                "deliveredDate": null,
+                                                "orderPrice": 850000,
+                                                "itemCount": 3
+                                              }
+                                            ],
+                                            "totalPage": 1,
+                                            "totalCount": 1,
+                                            "currentPage": 0,
+                                            "currentSize": 10
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/store")
     public ResponseEntity<BaseResponse<DeliveryDto.DeliveryPageRes>> getMyStoreDeliveries(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
@@ -84,6 +167,26 @@ public class DeliveryController {
 
     // 본사 배송 지연 사유 입력
     @Operation(summary = "배송 지연 사유 등록", description = "본사 관리자가 배송 지연된 건에 대해 사유를 입력합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "배송 지연 사유 등록 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "배송 지연 사유가 성공적으로 등록되었습니다.",
+                                          "result": "배송 지연 사유가 성공적으로 등록되었습니다."
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @PatchMapping("/head/delayreason")
     public ResponseEntity<BaseResponse<String>> updateDelayReason(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,

--- a/backend/monolith/src/main/java/com/example/nexus/domain/head/HeadController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/head/HeadController.java
@@ -7,6 +7,11 @@ import com.example.nexus.domain.head.model.HeadInventoryDto;
 import com.example.nexus.domain.user.model.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -49,6 +54,41 @@ public class HeadController {
 
     // 본사 정산 내역 조회
     @Operation(summary = "본사 수익 내역 조회", description = "발주별 본사 수익 내역을 조회합니다. 가맹점명, 정산 상태, 날짜 범위 필터를 지원합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "본사 수익 내역 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": [
+                                            {
+                                              "incomeIdx": 1,
+                                              "storeName": "강남점",
+                                              "billingAmount": 1500000,
+                                              "settlementStatus": true,
+                                              "settlementDate": "2026-05-20"
+                                            },
+                                            {
+                                              "incomeIdx": 2,
+                                              "storeName": "홍대점",
+                                              "billingAmount": 1200000,
+                                              "settlementStatus": false,
+                                              "settlementDate": null
+                                            }
+                                          ]
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/income")
     public ResponseEntity<BaseResponse<List<HeadIncomeDto.ListRes>>> getIncomeList(
             @Parameter(description = "가맹점명 검색어") @RequestParam(required = false) String storeName,
@@ -65,6 +105,29 @@ public class HeadController {
 
     // 본사 정산 관리 - 상단 요약 카드 조회
     @Operation(summary = "본사 정산 요약 조회", description = "특정 월의 전체 가맹점 청구 합계 등 요약 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "본사 정산 요약 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": {
+                                            "totalBillingAmount": 25450000,
+                                            "totalStoreCount": 12
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/settlement/summary")
     public ResponseEntity<BaseResponse<HeadIncomeDto.HeadSettlementSummaryRes>> getSettlementSummary(
             @AuthenticationPrincipal AuthUserDetails userDetails,
@@ -81,6 +144,49 @@ public class HeadController {
 
     // 본사 정산 관리 - 가맹점별 정산 리스트 페이징 조회
     @Operation(summary = "가맹점별 월 정산 리스트 조회", description = "특정 월의 가맹점별 정산 현황(발주 건수, 총 금액, 상태)을 페이징하여 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "가맹점별 월 정산 리스트 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": {
+                                            "content": [
+                                              {
+                                                "storeIdx": 1,
+                                                "storeName": "강남점",
+                                                "orderCount": 15,
+                                                "totalBillingAmount": 4500000,
+                                                "settlementStatus": true
+                                              },
+                                              {
+                                                "storeIdx": 2,
+                                                "storeName": "홍대점",
+                                                "orderCount": 12,
+                                                "totalBillingAmount": 3800000,
+                                                "settlementStatus": false
+                                              }
+                                            ],
+                                            "page": {
+                                              "size": 10,
+                                              "number": 0,
+                                              "totalElements": 2,
+                                              "totalPages": 1
+                                            }
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/settlement/list")
     public ResponseEntity<BaseResponse<PageResponse<HeadIncomeDto.StoreSettlementRes>>> getStoreSettlementList(
             @AuthenticationPrincipal AuthUserDetails userDetails,

--- a/backend/monolith/src/main/java/com/example/nexus/domain/product/ProductController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/product/ProductController.java
@@ -5,6 +5,11 @@ import com.example.nexus.domain.product.model.ProductDto;
 import com.example.nexus.domain.user.model.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +33,29 @@ public class ProductController {
 
     // 신규 제품 등록
     @Operation(summary = "신규 제품 등록", description = "새로운 원자재 제품을 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "제품 등록 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": {
+                                            "idx": 1,
+                                            "productName": "우유"
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @PostMapping("/reg")
     public ResponseEntity<BaseResponse<ProductDto.RegRes>> addNewProduct(@Valid @RequestBody ProductDto.RegReq dto) {
         ProductDto.RegRes result = productService.addProduct(dto);
@@ -36,6 +64,43 @@ public class ProductController {
 
     // 제품 목록으로 조회
     @Operation(summary = "제품 목록 조회", description = "전체 제품 목록을 페이징하여 조회합니다. 카테고리 필터를 지원합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "제품 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": {
+                                            "productList": [
+                                              {
+                                                "idx": 2,
+                                                "productName": "디카페인 원두",
+                                                "categoryName": "원두/커피",
+                                                "productUnit": "kg",
+                                                "maxStock": 30,
+                                                "minStock": 5,
+                                                "unitPrice": 18000,
+                                                "dangerDays": "30"
+                                              }
+                                            ],
+                                            "totalPage": 1,
+                                            "totalCount": 1,
+                                            "currentPage": 0,
+                                            "currentSize": 10
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/list")
     public ResponseEntity<BaseResponse<ProductDto.ProductPageRes>> readProductList(
             @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,
@@ -49,6 +114,26 @@ public class ProductController {
 
     // 기존 제품 수정
     @Operation(summary = "제품 정보 수정", description = "기존 제품의 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "제품 수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "success modify product",
+                                          "result": "success modify product"
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @PutMapping("/update")
     public ResponseEntity<BaseResponse<String>> updateProduct(@Valid @RequestBody ProductDto.RegReq dto) {
         boolean isModified = productService.updateProduct(dto.getIdx(), dto);
@@ -63,6 +148,26 @@ public class ProductController {
 
     // 기존 제품 삭제
     @Operation(summary = "제품 삭제", description = "기존 제품을 삭제(소프트 삭제) 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "제품 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "success delete product",
+                                          "result": "success delete product"
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @DeleteMapping("/delete")
     public ResponseEntity<BaseResponse<String>> deleteProduct(@RequestBody ProductDto.RegReq dto) {
 
@@ -78,6 +183,37 @@ public class ProductController {
 
     // 본사 제품 검색
     @Operation(summary = "본사 제품 검색", description = "제품명으로 제품을 검색합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "제품 검색 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": [
+                                            {
+                                                "idx": 2,
+                                                "productName": "디카페인 원두",
+                                                "categoryName": "원두/커피",
+                                                "productUnit": "kg",
+                                                "maxStock": 30,
+                                                "minStock": 5,
+                                                "unitPrice": 18000,
+                                                "dangerDays": "30"
+                                            }
+                                          ]
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/search")
     public ResponseEntity<BaseResponse<List<ProductDto.ListRes>>> searchProduct(@Parameter(description = "제품명 검색어") @RequestParam String productName) {
         List<ProductDto.ListRes> result = productService.searchProduct(productName);
@@ -86,6 +222,42 @@ public class ProductController {
 
     // 가맹점 별 제품 조회
     @Operation(summary = "가맹점 제품 조회", description = "로그인한 가맹점주가 발주 가능한 제품 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "가맹점 제품 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": {
+                                            "content": [
+                                              {
+                                                "idx": 2,
+                                                "productName": "디카페인 원두",
+                                                "categoryName": "원두/커피",
+                                                "productUnit": "kg",
+                                                "maxStock": 30,
+                                                "minStock": 5,
+                                                "unitPrice": 18000,
+                                                "dangerDays": "30"
+                                              }
+                                            ],
+                                            "pageable": { "pageNumber": 0, "pageSize": 10 },
+                                            "totalPages": 1,
+                                            "totalElements": 1
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/store")
     public ResponseEntity<BaseResponse<Page<ProductDto.ListRes>>> getMyStoreProducts(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,
@@ -104,6 +276,37 @@ public class ProductController {
 
     // 가맹점 별 제품 검색
     @Operation(summary = "가맹점 제품 검색", description = "로그인한 가맹점주가 발주 가능한 제품을 검색합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "가맹점 제품 검색 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": [
+                                            {
+                                                "idx": 2,
+                                                "productName": "디카페인 원두",
+                                                "categoryName": "원두/커피",
+                                                "productUnit": "kg",
+                                                "maxStock": 30,
+                                                "minStock": 5,
+                                                "unitPrice": 18000,
+                                                "dangerDays": "30"
+                                            }
+                                          ]
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/store/search")
     public ResponseEntity<BaseResponse<List<ProductDto.ListRes>>> searchInMyStore(
             @AuthenticationPrincipal AuthUserDetails authUserDetails,

--- a/backend/monolith/src/main/java/com/example/nexus/domain/store/StoreController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/store/StoreController.java
@@ -8,6 +8,11 @@ import com.example.nexus.domain.store.model.StoreInventoryDto;
 import com.example.nexus.domain.user.model.AuthUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -152,6 +157,45 @@ public class StoreController {
 
     // 가맹점별 매출 정산 조회
     @Operation(summary = "가맹점 매출 정산 조회", description = "로그인한 가맹점주가 특정 월의 매출 및 POS 정산 내역을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "가맹점 매출 정산 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "success": true,
+                                          "code": 1000,
+                                          "message": "요청에 성공하였습니다.",
+                                          "result": {
+                                            "monthlyTotalAmount": 8500000,
+                                            "payHistory": {
+                                              "content": [
+                                                {
+                                                  "posPayIdx": 1,
+                                                  "menuNames": "아메리카노 외 2건",
+                                                  "payCount": 3,
+                                                  "paidDate": "2026-05-20",
+                                                  "payAmount": 25000
+                                                }
+                                              ],
+                                              "page": {
+                                                "size": 10,
+                                                "number": 0,
+                                                "totalElements": 1,
+                                                "totalPages": 1
+                                              }
+                                            }
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
     @GetMapping("/income/settlement")
     public ResponseEntity<BaseResponse<StoreIncomeDto.TotalSettlementRes>> getSettlement(
             @Parameter(hidden = true) @AuthenticationPrincipal AuthUserDetails userDetails,


### PR DESCRIPTION
## 📋 Summary
- Swagger(OpenAPI) 문서화 및 상세 설명 추가 example 데이터 일치하게 수정

## 📂 변경 파일
- 'backend/monolith/src/main/java/com/example/nexus/domain/category/CategoryController.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/delivery/DeliveryController.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/product/ProductController.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/billing/BillingController.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/head/HeadController.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/store/StoreController.java'

## ✨ 주요 변경 사항
- Swagger(OpenAPI) 문서화 및 상세 설명 추가 example 수정
- Head, Delivery, Category, Product, Store, Billing 컨트롤러의 Swagger 어노테이션 수정
- 실제 데이터와 일치하는 @ExampleObject 추가로 API 문서 정확도 향상
- 프론트엔드 개발 및 API 테스트 편의성 개선

Closes #940