### PR TITLE
[Feat] #927 - 스웨거 무한 로딩 버그 수정 및 파라미터 예시 고도화

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springdoc.core.annotations.ParameterObject;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +29,7 @@ public class MenuController {
     @Operation(summary = "메뉴 목록 전체 조회 및 검색", description = "본사 메뉴 관리 페이지에서 메뉴 목록을 페이징하여 조회합니다.")
     @GetMapping("/list")
     public ResponseEntity<BaseResponse<MenuDto.MenuPageRes>> list(
-            MenuDto.MenuSearchPagingReq searchReq,
+            @ParameterObject MenuDto.MenuSearchPagingReq searchReq,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size)
     {
@@ -80,6 +81,7 @@ public class MenuController {
     @Operation(summary = "메뉴 정보 수정", description = "기존 메뉴의 정보(이름, 가격, 카테고리, 이미지 등) 및 레시피 구성을 수정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 메뉴", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":3204, \"message\":\"존재하지 않는 메뉴입니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "원자재를 찾을 수 없음", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":404, \"message\":\"원자재를 찾을 수 없습니다.\"}"))),
             @ApiResponse(responseCode = "409", description = "중복되거나 삭제된 메뉴명", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":409, \"message\":\"이미 존재하는 메뉴명입니다.\"}")))
     })
@@ -91,6 +93,10 @@ public class MenuController {
 
     // 메뉴 삭제
     @Operation(summary = "메뉴 삭제 (논리 삭제)", description = "특정 메뉴를 비활성화(삭제 처리) 상태로 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 메뉴", content = @Content(schema = @Schema(example = "{\"success\":false, \"code\":3204, \"message\":\"존재하지 않는 메뉴입니다.\"}")))
+    })
     @PutMapping("/delete/{menuIdx}")
     public ResponseEntity<BaseResponse<String>> menuDelete(@Parameter(description = "메뉴 식별자(ID)") @PathVariable(name = "menuIdx") Long menuIdx){
         menuService.menuDelete(menuIdx);

--- a/backend/monolith/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java
@@ -109,7 +109,7 @@ public class MenuDto {
         private Integer quantity;
         @Schema(description = "단위", example = "개")
         private String menuUnit;
-        @Schema(description = "원자재 식별자(ID)", example = "105")
+        @Schema(description = "원자재 식별자(ID)", example = "1")
         private Long productIdx;
 
         public MenuItem toEntity(Menu menu, Product product) {
@@ -174,7 +174,9 @@ public class MenuDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MenuSearchPagingReq {
+        @Schema(description = "메뉴 이름 검색 키워드입니다. 아무것도 적지 않거나 비워둘 경우, 키워드 필터링 없이 전체 메뉴를 조회합니다.", example = "")
         private String keyword;
+        @Schema(description = "조회할 카테고리의 고유 식별자(ID)입니다. 전체 카테고리를 대상으로 검색하려면 이 값을 지우고 비워주세요.", example = "1")
         private Long categoryIdx;
     }
 

--- a/backend/monolith/src/main/java/com/example/nexus/domain/store/StoreController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/store/StoreController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springdoc.core.annotations.ParameterObject;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -56,7 +57,7 @@ public class StoreController {
     @GetMapping("/search")
     public ResponseEntity<BaseResponse<List<StoreDto.StoreSearchRes>>> searchStore(
             @AuthenticationPrincipal UserDetails userDetails,
-            @Parameter(description = "검색 키워드") @RequestParam(value = "keyword", required = false, defaultValue = "") String keyword) {
+            @Parameter(description = "검색할 가맹점 이름의 일부 또는 전체를 입력하세요. (예: 서울, 강남 등). 아무것도 입력하지 않으면 전체 가맹점이 조회될 수 있습니다.", example = "서울") @RequestParam(value = "keyword", required = false, defaultValue = "") String keyword) {
         if (userDetails == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
         }
@@ -72,7 +73,7 @@ public class StoreController {
     @Operation(summary = "가맹점 목록 조회", description = "전체 가맹점 목록을 페이징하여 조회합니다. 상태 및 키워드 필터를 지원합니다.")
     @GetMapping("/list")
     public ResponseEntity<BaseResponse<StoreDto.StorePageRes>> storeList(
-            StoreDto.StoreSearchPagingReq searchReq,
+            @ParameterObject StoreDto.StoreSearchPagingReq searchReq,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size
     ){

--- a/backend/monolith/src/main/java/com/example/nexus/domain/store/model/StoreDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/store/model/StoreDto.java
@@ -138,7 +138,9 @@ public class StoreDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class StoreSearchPagingReq {
+        @Schema(description = "가맹점 이름 검색 키워드입니다. 아무것도 적지 않거나 비워둘 경우, 키워드 필터링 없이 전체 가맹점을 조회합니다.", example = "")
         private String keyword;
+        @Schema(description = "가맹점 운영 상태 필터입니다 (예: 영업중, 폐업 등). 특정 상태만 조회하고 싶지 않다면 이 칸을 비워주세요 (기본 전체 조회).", example = "")
         private String status;
     }
 


### PR DESCRIPTION
## Summary
- 스웨거(Swagger)에서 `GET` 방식의 페이징/검색 API 호출 시 발생하던 무한 로딩(파라미터 매칭 오류) 버그를 해결했습니다.
- 프론트엔드 연동을 위해 검색 파라미터(`searchReq`) 내부 필드들의 Description(설명)을 더욱 친절하게 개선하고, 불필요한 예시 값들을 비워두었습니다(기본값 처리).

## 변경 파일
- `backend/monolith/src/main/java/com/example/nexus/domain/store/StoreController.java`
- `backend/monolith/src/main/java/com/example/nexus/domain/store/model/StoreDto.java`
- `backend/monolith/src/main/java/com/example/nexus/domain/menu/MenuController.java`
- `backend/monolith/src/main/java/com/example/nexus/domain/menu/model/MenuDto.java`

## 주요 변경 사항
- [x] **스웨거 파라미터 매칭 버그 수정 (`@ParameterObject`)**
  - `StoreController`와 `MenuController`의 `list` 조회 API에 `@ParameterObject`를 적용하여, 스웨거가 단일 JSON 객체가 아닌 개별 쿼리 파라미터(필드 단위)로 올바르게 전송하도록 수정해 무한 로딩 타임아웃 문제를 해결했습니다.
- [x] **DTO 파라미터 예시 및 친절한 설명 추가**
  - `MenuSearchPagingReq`: 키워드 없이 카테고리만 검색할 수 있도록 친절한 안내 문구를 넣고, `keyword` 예시는 빈칸(`""`), `categoryIdx`는 `1`로 세팅.
  - `StoreSearchPagingReq`: 상태 필터 등 사용법 안내 문구를 구체화하고 `keyword`, `status` 기본 예시를 빈칸(`""`)으로 세팅.
  - 메뉴 원자재 등록 DTO(`MenuItemReq`)의 `productIdx` 기본 예시 값을 `105`에서 `1`로 변경.
- [x] **단일 파라미터 예시 추가**
  - `StoreController` 가맹점 이름 검색(`/search`) API의 키워드에 예시 값(`"서울"`) 및 상세 설명 추가.


## Test Plan
- [x] 가맹점 및 메뉴 전체 조회 API에서 파라미터 입력창이 쪼개져 나오는지 확인
- [x] 스웨거에서 검색 API `Execute` 클릭 시 무한 로딩 없이 `200 OK`가 잘 반환되는지 확인
- [x] 텍스트 입력창 바로 옆에 덧붙인 안내용 Description이 제대로 읽히는지 확인

## Issue
- Closes #927 