### PR TITLE
[Docs] #940 - DTO 내 Swagger 어노테이션 추가 및 클래스 명칭 충돌 해결

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/domain/billing/model/BillingDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/billing/model/BillingDto.java
@@ -1,5 +1,6 @@
 package com.example.nexus.domain.billing.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.util.List;
@@ -9,8 +10,12 @@ public class BillingDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "빌링키 발급 요청")
     public static class IssueBillingKeyRequestDto {
+        @Schema(description = "카드 인증 증명서")
         private String authKey;
+
+        @Schema(description = "각 가맹점 구분 키", example = "STORE_1")
         private String customerKey;
     }
 

--- a/backend/monolith/src/main/java/com/example/nexus/domain/category/model/CategoryDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/category/model/CategoryDto.java
@@ -1,5 +1,6 @@
 package com.example.nexus.domain.category.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,8 +10,11 @@ public class CategoryDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "CategoryRegReq", description = "카테고리 등록/수정 요청")
     public static class RegReq {
+        @Schema(description = "카테고리 번호", example = "1")
         private Long idx;
+        @Schema(description = "카테고리 이름", example = "원두/커피")
         private String categoryName;
 
         public Category toEntity() {
@@ -22,6 +26,7 @@ public class CategoryDto {
 
     @Builder
     @Getter
+    @Schema(name = "CategoryRegRes", description = "카테고리 등록 결과")
     public static class RegRes {
         private Long idx;
         private String categoryName;

--- a/backend/monolith/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java
@@ -1,6 +1,7 @@
 package com.example.nexus.domain.delivery.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.springframework.data.domain.Page;
 
@@ -90,9 +91,13 @@ public class DeliveryDto {
     // 배송 지연 사유 요청 DTO
     @Getter
     @NoArgsConstructor
+    @Schema(description = "배송 지연 사유 등록 요청")
     public static class DelayReasonRequest {
 
+        @Schema(description = "배송 번호(IDX)", example = "1")
         private Long deliveryIdx;
+
+        @Schema(description = "지연 사유", example = "기상 악화로 인한 배송 지연")
         private String delayReason;
     }
 }

--- a/backend/monolith/src/main/java/com/example/nexus/domain/product/model/ProductDto.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/product/model/ProductDto.java
@@ -1,6 +1,7 @@
 package com.example.nexus.domain.product.model;
 
 import com.example.nexus.domain.category.model.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,14 +13,30 @@ import java.util.List;
 
 public class ProductDto {
     @Getter
+    @Schema(name = "ProductRegReq", description = "제품 등록 및 수정 요청")
     public static class RegReq {
+        @Schema(description = "제품 번호 (수정 시 필수)", example = "1")
         private Long idx;
+
+        @Schema(description = "제품명", example = "우유")
         private String productName;
+
+        @Schema(description = "카테고리 번호", example = "2")
         private Long categoryIdx;
+
+        @Schema(description = "제품 단위", example = "L")
         private String productUnit;
+
+        @Schema(description = "최대 재고량", example = "100")
         private Integer maxStock;
+
+        @Schema(description = "최소 재고량", example = "20")
         private Integer minStock;
+
+        @Schema(description = "단가", example = "10000")
         private Integer unitPrice;
+
+        @Schema(description = "위험 재고 판단 기준 일수", example = "3")
         private String dangerDays;
 
         public Product toEntity(Category category) {
@@ -41,8 +58,12 @@ public class ProductDto {
 
     @Getter
     @Builder
+    @Schema(name = "ProductRegRes", description = "제품 등록 결과")
     public static class RegRes {
+        @Schema(description = "생성된 제품 번호", example = "10")
         private Long idx;
+
+        @Schema(description = "등록된 제품명", example = "감자 10kg")
         private String productName;
 
         public static RegRes from(Product entity) {
@@ -55,14 +76,30 @@ public class ProductDto {
 
     @Getter
     @Builder
+    @Schema(description = "제품 상세 정보")
     public static class ListRes {
+        @Schema(description = "제품 번호", example = "1")
         private Long idx;
+
+        @Schema(description = "제품명", example = "감자 10kg")
         private String productName;
+
+        @Schema(description = "카테고리명", example = "채소류")
         private String categoryName;
+
+        @Schema(description = "단위", example = "박스")
         private String productUnit;
+
+        @Schema(description = "최대 재고량", example = "100")
         private Integer maxStock;
+
+        @Schema(description = "최소 재고량", example = "20")
         private Integer minStock;
+
+        @Schema(description = "단가", example = "25000")
         private Integer unitPrice;
+
+        @Schema(description = "위험 재고 판단 기준 일수", example = "3")
         private String dangerDays;
 
 


### PR DESCRIPTION
 ## 📋 Summary
- DTO 내 Swagger 어노테이션 추가 및 클래스 명칭 충돌 해결

## 📂 변경 파일
- 'backend/monolith/src/main/java/com/example/nexus/domain/billing/model/BillingDto.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/category/model/CategoryDto.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/product/model/ProductDto.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/delivery/model/DeliveryDto.java'

- ## ✨ 주요 변경 사항
- 각 도메인 DTO(Billing, Category, Product, Delivery)에 @Schema 추가
- Swagger UI 내 Request Body 예시 데이터(example) 보강
- @Schema(name) 속성을 사용하여 도메인 간 동일 클래스명(RegReq 등) 충돌 문제 해결
- API 문서의 가시성 및 정확도 향상

Closes #940 