### PR TITLE
[Docs] #938 - README 헤더를 GIF 에서 PNG 로 되돌림 (화질 이슈)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/Nexus_animation.gif" alt="Nexus — 더벤티 프랜차이즈 통합 관리 시스템" width="100%"/>
+  <img src="docs/nexus%20%EB%8C%80%ED%91%9C%20%EC%9D%B4%EB%AF%B8%EC%A7%80.png" alt="Nexus — 더벤티 프랜차이즈 통합 관리 시스템" width="100%"/>
 </p>
 
 ---

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../docs/Nexus_animation.gif" alt="Nexus — 더벤티 프랜차이즈 통합 관리 시스템" width="100%"/>
+  <img src="../docs/nexus%20%EB%8C%80%ED%91%9C%20%EC%9D%B4%EB%AF%B8%EC%A7%80.png" alt="Nexus — 더벤티 프랜차이즈 통합 관리 시스템" width="100%"/>
 </p>
 
 <h3 align="center">⚙️ Backend — Spring Boot 3.4 MSA + 배치 구조</h3>

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../docs/Nexus_animation.gif" alt="Nexus — 더벤티 프랜차이즈 통합 관리 시스템" width="100%"/>
+  <img src="../docs/nexus%20%EB%8C%80%ED%91%9C%20%EC%9D%B4%EB%AF%B8%EC%A7%80.png" alt="Nexus — 더벤티 프랜차이즈 통합 관리 시스템" width="100%"/>
 </p>
 
 <h3 align="center">🎨 Frontend — Vue 3 + Vite 기반 통합 웹 클라이언트</h3>


### PR DESCRIPTION
## Summary
- GIF 의 256색 팔레트 한계로 화질이 떨어지는 문제
- 3개 README 의 img src 를 Nexus_animation.gif → nexus 대표 이미지.png 로 되돌림
- docs/Nexus_animation.gif 제거 (사용 안 함)