### PR TITLE
[Fix] - headincome 에서 settlementview.vue 총액 매장명으로 검색시 해당 매장 총액으로 바뀌게 수정

### DIFF
--- a/backend/monolith/src/main/java/com/example/nexus/domain/head/HeadController.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/head/HeadController.java
@@ -131,13 +131,14 @@ public class HeadController {
     @GetMapping("/settlement/summary")
     public ResponseEntity<BaseResponse<HeadIncomeDto.HeadSettlementSummaryRes>> getSettlementSummary(
             @AuthenticationPrincipal AuthUserDetails userDetails,
+            @Parameter(description = "가맹점명 검색어") @RequestParam(required = false) String storeName,
             @Parameter(description = "조회 연도", example = "2026") @RequestParam int year,
             @Parameter(description = "조회 월", example = "4") @RequestParam int month) {
         if (userDetails == null) {
             throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
         }
 
-        HeadIncomeDto.HeadSettlementSummaryRes result = headIncomeService.getSettlementSummary(year, month);
+        HeadIncomeDto.HeadSettlementSummaryRes result = headIncomeService.getSettlementSummary(storeName, year, month);
 
         return ResponseEntity.ok(BaseResponse.success(result));
     }

--- a/backend/monolith/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java
@@ -52,10 +52,12 @@ public interface HeadIncomeRepository extends JpaRepository<HeadIncome, Long> {
             SELECT COALESCE(SUM(hi.price), 0)
             FROM HeadIncome hi
             JOIN hi.orders o
-            WHERE o.createdAt >= :start
+            WHERE (:storeName IS NULL OR :storeName = '' OR hi.store.storeName LIKE %:storeName%)
+              AND o.createdAt >= :start
               AND o.createdAt < :end
             """)
     Long sumTotalBillingByMonth(
+            @Param("storeName") String storeName,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );

--- a/backend/monolith/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java
@@ -132,11 +132,11 @@ public class HeadIncomeService {
 
     // 본사 정산 관리 - 상단 카드 요약 조회
     @Transactional(readOnly = true)
-    public HeadIncomeDto.HeadSettlementSummaryRes getSettlementSummary(int year, int month) {
+    public HeadIncomeDto.HeadSettlementSummaryRes getSettlementSummary(String storeName, int year, int month) {
         LocalDateTime start = LocalDateTime.of(LocalDate.of(year, month, 1), LocalTime.MIN);
         LocalDateTime end = start.plusMonths(1);
 
-        Long totalBillingAmount = headIncomeRepository.sumTotalBillingByMonth(start, end);
+        Long totalBillingAmount = headIncomeRepository.sumTotalBillingByMonth(storeName, start, end);
 
         return HeadIncomeDto.HeadSettlementSummaryRes.builder()
                 .totalBillingAmount(totalBillingAmount != null ? totalBillingAmount : 0L)

--- a/backend/monolith/src/main/java/com/example/nexus/domain/report/tools/AiFinanceTools.java
+++ b/backend/monolith/src/main/java/com/example/nexus/domain/report/tools/AiFinanceTools.java
@@ -28,7 +28,7 @@ public class AiFinanceTools {
             @ToolParam(description = "월 1~12") int month) {
         LocalDateTime start = LocalDate.of(year, month, 1).atStartOfDay();
         LocalDateTime end = start.plusMonths(1); // 쿼리가 반개방(< end)이라 다음 달 1일 0시
-        Long sum = headIncomeRepository.sumTotalBillingByMonth(start, end);
+        Long sum = headIncomeRepository.sumTotalBillingByMonth(null, start, end);
         return sum != null ? sum : 0L;
     }
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -177,8 +177,9 @@ https://github.com/user-attachments/assets/de76e3eb-00f5-4306-baac-593f19009722
 
 <details>
 <summary><b>🏪 가맹점 관리</b></summary>
-<br>
-<p align="center"><img width="80%" src="../docs/img/gif/login.gif"/></p>
+
+https://github.com/user-attachments/assets/929b48dc-0b6a-4a65-bbc6-cabf44bfa1ff
+
 </details>
 
 <details>

--- a/frontend/src/api/headincome/index.js
+++ b/frontend/src/api/headincome/index.js
@@ -1,8 +1,8 @@
 import api from '@/plugins/axiosinterceptor'
 
 // 본사 정산 관리 - 상단 카드 요약 조회
-export const getHeadSettlementSummary = (year, month) =>
-  api.get('/head/settlement/summary', { params: { year, month } })
+export const getHeadSettlementSummary = (year, month, storeName = '') =>
+  api.get('/head/settlement/summary', { params: { year, month, storeName } })
 
 // 본사 정산 관리 - 가맹점별 정산 리스트 페이징 조회
 export const getHeadSettlementList = (year, month, storeName = '', page = 0, size = 10) =>

--- a/frontend/src/views/hq/SettlementView.vue
+++ b/frontend/src/views/hq/SettlementView.vue
@@ -167,7 +167,7 @@ const parsedDate = () => {
 const fetchSummary = async () => {
   try {
     const { year, month } = parsedDate()
-    const res = await getHeadSettlementSummary(year, month)
+    const res = await getHeadSettlementSummary(year, month, settlementSearch.value)
     totalBillingAmount.value = res.data.result?.totalBillingAmount ?? 0
   } catch (error) {
     console.error('청구 합계 조회 실패:', error)
@@ -196,12 +196,13 @@ const onMonthChange = () => {
   fetchList(0)
 }
 
-// 검색어 입력 시 0페이지부터 다시 조회
+// 검색어 입력 시 0페이지부터 다시 조회 및 요약 데이터 갱신
 let searchTimer = null
 const onSearchInput = () => {
   clearTimeout(searchTimer)
   searchTimer = setTimeout(() => {
     currentPage.value = 0
+    fetchSummary()
     fetchList(0)
   }, 300) // 타이핑 멈추고 300ms 후 조회 (debounce)
 }


### PR DESCRIPTION
## 📋 Summary
- headincome 에서 settlementview.vue 총액 매장명으로 검색 시 해당 매장 총액으로 바뀌게 수정

## 📂 변경 파일
- 'backend/monolith/src/main/java/com/example/nexus/domain/head/HeadController.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/head/HeadIncomeRepository.java'
- 'backend/monolith/src/main/java/com/example/nexus/domain/head/HeadIncomeService.java'

- 'backend/monolith/src/main/java/com/example/nexus/domain/report/tools/AiFinanceTools.java'

- 'frontend/src/api/headincome/index.js'
- 'frontend/src/views/hq/SettlementView.vue'

## ✨ 주요 변경 사항
- headincome 에서 settlementview.vue 총액 매장명으로 검색 시 해당 매장 총액으로 바뀌게 수정
- settlementview.vue 에 반영

- AI headincome 매개변수 오류 수정